### PR TITLE
feat:공고 탐색 필터 기능 추가

### DIFF
--- a/src/assets/icons/button/leftButton.tsx
+++ b/src/assets/icons/button/leftButton.tsx
@@ -1,13 +1,12 @@
 import { SVGProps } from "react";
 
-export const LeftButton = (props: SVGProps<SVGSVGElement>) => {
+export const LeftButton = ({ className, ...props }: SVGProps<SVGSVGElement>) => {
   return (
     <svg
-      width="20"
-      height="21"
-      viewBox="0 0 20 21"
+      viewBox="0 0 20 20"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
+      className={className}
       {...props}
     >
       <g clipPath="url(#clip0_8454_736)">

--- a/src/entities/listings/api/listingsApi.ts
+++ b/src/entities/listings/api/listingsApi.ts
@@ -1,25 +1,21 @@
 import { LISTING_LIST_NOTICES } from "@/src/shared/api";
 import { http } from "../../../shared/api/http";
-import {
-  ListingListApiResponse,
-  ListingListFilterBody,
-  ListingListPage,
-  ListingListParams,
-} from "../model/type";
+import { ListingListFilterBody, ListingListPage, ListingListParams } from "../model/type";
 import { IResponse } from "@/src/shared/types";
 
-export const requestListingList = async (
-  params: ListingListParams,
-  reqbody: ListingListFilterBody
-) => {
-  const body = {
-    page: params.page ?? 1,
-    offSet: params.offSet ?? 10,
-  };
-
-  const res = await http.post<IResponse, ListingListFilterBody>(LISTING_LIST_NOTICES, reqbody, {
-    params: body,
+export const requestListingList = async <
+  TData extends IResponse,
+  TReqBody extends object,
+  TParams extends object,
+  TReturn,
+>(
+  url: string,
+  params: TParams,
+  reqBody: TReqBody
+): Promise<TReturn> => {
+  const res = await http.post<TData, TReqBody>(url, reqBody, {
+    params,
   });
 
-  return res.data as ListingListPage;
+  return res.data as TReturn;
 };

--- a/src/entities/listings/model/type.ts
+++ b/src/entities/listings/model/type.ts
@@ -46,7 +46,7 @@ export interface ListingContentsListProps {
 }
 
 export interface ListingsContentHeaderProps {
-  totalCount: number;
+  totalCount: number | null;
 }
 
 export interface FilterSheetState {
@@ -71,4 +71,26 @@ export interface FilterOption {
   label: string;
   component: string;
   type?: "select" | "radio" | "checkbox" | "sort" | "panel";
+}
+
+export interface ListingsFilterState {
+  regionType: string[];
+  rentalTypes: string[];
+  supplyTypes: string[];
+  houseTypes: string[];
+  status: string;
+  sortType: string;
+
+  toggleRegionType: (item: string) => void;
+  toggleRentalType: (item: string) => void;
+  toggleSupplyType: (item: string) => void;
+  toggleHouseType: (item: string) => void;
+
+  setStatus: (status: string) => void;
+  setSortType: (sort: string) => void;
+
+  resetRegionType: () => void;
+  resetRentalTypes: () => void;
+  resetSupplyTypes: () => void;
+  resetHouseTypes: () => void;
 }

--- a/src/features/listings/model/filterPanelModel.tsx
+++ b/src/features/listings/model/filterPanelModel.tsx
@@ -16,3 +16,12 @@ export const AllFitler_OPTIONS: AllFilterOption = {
   type: "panel",
   icon: <OnOffTrue />,
 };
+
+export type City = { code: string; name: string };
+export type SectionMap = Record<string, ReadonlyArray<City>>;
+export type SectionLabelMap = Record<string, string>;
+
+export interface SearchResultsProps {
+  center?: boolean;
+  handleSearch: (keyword: string) => void;
+}

--- a/src/features/listings/model/index.ts
+++ b/src/features/listings/model/index.ts
@@ -1,2 +1,3 @@
 export * from "./listingsModel";
 export * from "./filterPanelModel";
+export * from "./listingsStore";

--- a/src/features/listings/model/listingsModel.ts
+++ b/src/features/listings/model/listingsModel.ts
@@ -1,5 +1,6 @@
 import { FilterOption } from "@/src/entities/listings/model/type";
 import { PinPoint, PinPointMap } from "@/src/shared/ui/dropDown/deafult/type";
+import { SectionLabelMap, SectionMap } from "./filterPanelModel";
 
 export const listingsHistory = ["행복주택", "청년", "등등"];
 export const listingsResults = ["행복주택", "청년", "등등"];
@@ -230,10 +231,6 @@ export const FILTER_TABS = [
   { key: "housing", label: "주택유형" },
 ] as const;
 
-type City = { code: string; name: string };
-type SectionMap = Record<string, ReadonlyArray<City>>;
-type SectionLabelMap = Record<string, string>;
-
 export const TAB_CONFIG: Record<FilterTabKey, { sections: SectionMap; labels: SectionLabelMap }> = {
   region: {
     sections: LISTING_PARTIAL_SHEET,
@@ -254,8 +251,3 @@ export const TAB_CONFIG: Record<FilterTabKey, { sections: SectionMap; labels: Se
 };
 
 export type FilterTabKey = (typeof FILTER_TABS)[number]["key"];
-
-export interface SearchResultsProps {
-  center?: boolean;
-  handleSearch: (keyword: string) => void;
-}

--- a/src/features/listings/model/listingsStore.ts
+++ b/src/features/listings/model/listingsStore.ts
@@ -1,9 +1,12 @@
-import { AddressState } from "@/src/entities/address/model/address.type";
 import { create } from "zustand";
-import { FilterSheetState, ListingState } from "@/src/entities/listings/model/type";
+import {
+  FilterSheetState,
+  ListingsFilterState,
+  ListingState,
+} from "@/src/entities/listings/model/type";
 
 export const useListingState = create<ListingState>(set => ({
-  status: "",
+  status: "전체",
   setStatus: value => set({ status: value }),
   reset: () => set({ status: "" }),
 }));
@@ -12,4 +15,73 @@ export const useFilterSheetStore = create<FilterSheetState>(set => ({
   open: false,
   openSheet: () => set({ open: true }),
   closeSheet: () => set({ open: false }),
+}));
+
+export const useListingsFilterStore = create<ListingsFilterState>(set => ({
+  regionType: [],
+  rentalTypes: [],
+  supplyTypes: [],
+  houseTypes: [],
+  status: "",
+  sortType: "최신공고순",
+
+  toggleRegionType: region =>
+    set(state => {
+      const exists = state.regionType.includes(region);
+      return {
+        regionType: exists
+          ? state.regionType.filter(i => i !== region)
+          : [...state.regionType, region],
+      };
+    }),
+
+  toggleRentalType: rental =>
+    set(state => {
+      const exists = state.rentalTypes.includes(rental);
+      return {
+        rentalTypes: exists
+          ? state.rentalTypes.filter(i => i !== rental)
+          : [...state.rentalTypes, rental],
+      };
+    }),
+
+  toggleSupplyType: supply =>
+    set(state => {
+      const exists = state.supplyTypes.includes(supply);
+      return {
+        supplyTypes: exists
+          ? state.supplyTypes.filter(i => i !== supply)
+          : [...state.supplyTypes, supply],
+      };
+    }),
+
+  toggleHouseType: house =>
+    set(state => {
+      const exists = state.houseTypes.includes(house);
+      return {
+        houseTypes: exists
+          ? state.houseTypes.filter(i => i !== house)
+          : [...state.houseTypes, house],
+      };
+    }),
+
+  setStatus: status => set({ status }),
+  setSortType: sort => set({ sortType: sort }),
+
+  resetRegionType: () =>
+    set({
+      regionType: [],
+    }),
+  resetRentalTypes: () =>
+    set({
+      rentalTypes: [],
+    }),
+  resetSupplyTypes: () =>
+    set({
+      supplyTypes: [],
+    }),
+  resetHouseTypes: () =>
+    set({
+      houseTypes: [],
+    }),
 }));

--- a/src/features/listings/ui/listingsContents/listingsContents.tsx
+++ b/src/features/listings/ui/listingsContents/listingsContents.tsx
@@ -1,23 +1,61 @@
+"use client";
+
 import { useListingListInfiniteQuery } from "@/src/entities/listings/hooks/useListingHooks";
 import { ListingsContentHeader } from "./listingsContentsHeader";
 import { ListingContentsList } from "./listingsContentsList";
+import { useEffect, useRef } from "react";
+import { queryClient } from "@/src/app/providers";
+import { useFilterSheetStore, useListingsFilterStore, useListingState } from "../../model";
+import { ListingNoSearchResult } from "../listingsNoSearchResult/listingNoSearchResult";
+import { Spinner } from "@/src/shared/ui/spinner/default";
 
 export const ListingsContent = () => {
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isError } =
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isError, isLoading, isSuccess } =
     useListingListInfiniteQuery();
-  const totalCount = data?.pages[0]?.totalCount ?? 0;
-  return (
-    <div className="flex h-full flex-col">
-      <ListingsContentHeader totalCount={totalCount} />
-      <div className="min-h-0 flex-1">
-        <ListingContentsList
-          data={data}
-          fetchNextPage={fetchNextPage}
-          hasNextPage={hasNextPage}
-          isFetchingNextPage={isFetchingNextPage}
-          isError={isError}
-        />
+  const open = useFilterSheetStore(state => state.open);
+  const prevOpenRef = useRef(open);
+
+  useEffect(() => {
+    if (prevOpenRef.current === true && open === false) {
+      queryClient.invalidateQueries({
+        queryKey: ["listingListInfinite"],
+      });
+    }
+    prevOpenRef.current = open;
+  }, [open]);
+
+  const totalCount = isLoading || !isSuccess ? null : (data?.pages[0]?.totalCount ?? 0);
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center pb-[88px]">
+        <Spinner title="공고 탐색중..." description="잠시만 기다려주세요" />
       </div>
-    </div>
+    );
+  }
+
+  return (
+    <>
+      {totalCount === 0 ? (
+        <div className="flex h-full items-center justify-center pb-[88px]">
+          <ListingNoSearchResult
+            text={"조건에 맞는 공고를 찾지 못했어요. <br />탐색 범위를 넓혀서 다시 탐색해 보세요"}
+          />
+        </div>
+      ) : (
+        <div className="flex h-full flex-col">
+          <ListingsContentHeader totalCount={totalCount} />
+          <div className="min-h-0 flex-1">
+            <ListingContentsList
+              data={data}
+              fetchNextPage={fetchNextPage}
+              hasNextPage={hasNextPage}
+              isFetchingNextPage={isFetchingNextPage}
+              isError={isError}
+            />
+          </div>
+        </div>
+      )}
+    </>
   );
 };

--- a/src/features/listings/ui/listingsContents/listingsContentsHeader.tsx
+++ b/src/features/listings/ui/listingsContents/listingsContentsHeader.tsx
@@ -1,12 +1,19 @@
+"use client";
 import { ArrowUpArrowDown } from "@/src/assets/icons/button/arrowUpArrowDown";
-import { listingPoint } from "../../model";
+import { listingPoint, useListingsFilterStore } from "../../model";
 import { CaretDropDown } from "@/src/shared/ui/dropDown/CaretDropDown";
-import { useListingState } from "../../model/listingsStore";
 import { ListingsContentHeaderProps } from "@/src/entities/listings/model/type";
+import { MouseEvent } from "react";
 
 export const ListingsContentHeader = ({ totalCount }: ListingsContentHeaderProps) => {
-  const { status, setStatus } = useListingState();
+  const sortType = useListingsFilterStore(state => state.sortType);
+  const setSortType = useListingsFilterStore(state => state.setSortType);
 
+  const onChange = (e: MouseEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const nextSortType = sortType === "최신공고순" ? "마감임박순" : "최신공고순";
+    setSortType(nextSortType);
+  };
   return (
     <div className="flex items-center justify-between">
       <div className="flex items-center gap-1 text-xl font-bold">
@@ -16,17 +23,11 @@ export const ListingsContentHeader = ({ totalCount }: ListingsContentHeaderProps
 
       <div className="flex items-center">
         <div className="flex items-center gap-1">
-          <CaretDropDown
-            variant="ghost"
-            types="drop"
-            data={listingPoint}
-            setSelect={setStatus}
-            selected={status}
-          />
+          <CaretDropDown variant="ghost" types="drop" data={listingPoint} />
         </div>
 
-        <div className="flex items-center gap-1">
-          <div className="text-xs font-bold">최신순</div>
+        <div className="flex items-center gap-1" onClick={e => onChange(e)}>
+          <div className="text-xs font-bold">{sortType}</div>
           <ArrowUpArrowDown />
         </div>
       </div>

--- a/src/features/listings/ui/listingsContents/listingsContentsList.tsx
+++ b/src/features/listings/ui/listingsContents/listingsContentsList.tsx
@@ -1,9 +1,9 @@
 "use client";
-import { useListingListInfiniteQuery } from "@/src/entities/listings/hooks/useListingHooks";
 import { ListingContentsCards } from "./listingsContentsCards";
 import { useEffect, useRef } from "react";
 import { Button } from "@/src/shared/ui/button/deafult";
 import { ListingContentsListProps } from "@/src/entities/listings/model/type";
+import { ListingNoSearchResult } from "../listingsNoSearchResult/listingNoSearchResult";
 
 export const ListingContentsList = ({
   data,
@@ -38,7 +38,7 @@ export const ListingContentsList = ({
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   return (
-    <div className="flex h-full flex-col overflow-y-auto pb-[88px]">
+    <div className="flex h-full flex-col overflow-y-auto pb-[88px] scrollbar-hide">
       <ListingContentsCards data={items} />
 
       {!isError && hasNextPage && <div ref={observerRef} className="h-10" />}
@@ -48,18 +48,21 @@ export const ListingContentsList = ({
       )}
 
       {isError && (
-        <div className="justify-centerpy-5 flex gap-2 py-2 text-center text-sm text-red-500">
-          <p>데이터를 불러오는 중 오류가 발생했습니다.</p>
-          <Button
-            variant={"outline"}
-            onClick={() => fetchNextPage()}
-            size={"sm"}
-            radius={"sm"}
-            text={"sm"}
-            className="h-6 border-0 bg-gray-900 px-3 py-1 text-xs text-text-greyscale-grey-50"
-          >
-            재시도
-          </Button>
+        <div className="flex h-full flex-col items-center justify-center gap-5 pb-[88px]">
+          <div>
+            <ListingNoSearchResult text="정보를 가져오지 못했어요 <br /> 네트워크 상태를 확인하거나 잠시 후 다시 시도해주세요." />
+          </div>
+          <div>
+            <Button
+              variant={"solid"}
+              onClick={() => fetchNextPage()}
+              size={"sm"}
+              radius={"sm"}
+              text={"sm"}
+            >
+              재시도
+            </Button>
+          </div>
         </div>
       )}
 

--- a/src/features/listings/ui/listingsHeaders/listingSearchResultList.tsx
+++ b/src/features/listings/ui/listingsHeaders/listingSearchResultList.tsx
@@ -22,7 +22,7 @@ export const SearchResults = ({ center = false, handleSearch }: SearchResultsPro
               handleSearch(word);
             }}
             className={cn(
-              "text-text-greyscale-grey-85 rounded-full border px-3 py-1 font-suit text-sm transition-all"
+              "rounded-full border px-3 py-1 font-suit text-sm text-text-greyscale-grey-85 transition-all"
             )}
           >
             {word}

--- a/src/features/listings/ui/listingsHeaders/listingsHeaders.tsx
+++ b/src/features/listings/ui/listingsHeaders/listingsHeaders.tsx
@@ -6,19 +6,20 @@ export const ListingsHeaders = () => {
   const router = useRouter();
   return (
     <div className="flex items-center justify-between">
-      <div className="font-pretendard text-md flex-1 font-bold leading-tight tracking-[0]">
+      <div className="text-md flex-1 font-pretendard font-bold leading-tight tracking-[0]">
         공고 탐색
       </div>
-      <div
+      {/* <div
         className="flex flex-[2] items-center rounded-2xl border border-gray-200 bg-white p-1.5 pl-3"
         onClick={() => router.push("/listings/search")}
       >
         <input
-          className="font-pretendard w-full text-xs font-bold leading-tight tracking-[0] outline-none placeholder:text-gray-400"
+          className="w-full font-pretendard text-xs font-bold leading-tight tracking-[0] outline-none placeholder:text-gray-400"
           placeholder="공고명을 검색해보세요"
         />
         <Search className="ml-2 text-gray-600" />
-      </div>
+      </div> */}
+      <Search className="ml-2 text-gray-600" onClick={() => router.push("/listings/search")} />
     </div>
   );
 };

--- a/src/features/listings/ui/listingsHeaders/listingsSearchForm.tsx
+++ b/src/features/listings/ui/listingsHeaders/listingsSearchForm.tsx
@@ -21,11 +21,11 @@ export const SearchForm = () => {
   };
 
   return (
-    <div>
-      <div className="flex gap-2 pb-2">
-        <LeftButton onClick={handleRouter} className="cursor-pointer hover:cursor-pointer" />
-        <p className="absolute left-1/2 -translate-x-1/2 font-suit font-bold">검색</p>
-      </div>
+    <div className="items-cente relative flex p-2">
+      <LeftButton onClick={handleRouter} className="h-7 w-7 cursor-pointer" />
+      <p className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 font-suit font-bold">
+        검색
+      </p>
     </div>
   );
 };

--- a/src/features/listings/ui/listingsHeaders/listingsSearchHistory.tsx
+++ b/src/features/listings/ui/listingsHeaders/listingsSearchHistory.tsx
@@ -1,6 +1,8 @@
 import { CloseButton } from "@/src/assets/icons/button";
 import { useSearchState } from "@/src/shared/hooks/store";
 import { SearchResultsProps } from "../../model";
+import { TagButton } from "@/src/shared/ui/button/tagButton";
+import { cn } from "@/lib/utils";
 
 export const SearchHistory = ({ handleSearch }: SearchResultsProps) => {
   const { searchQuery, removeSearchQuery, setQuery } = useSearchState();
@@ -14,20 +16,30 @@ export const SearchHistory = ({ handleSearch }: SearchResultsProps) => {
     <section className="mt-4">
       <h3 className="mb-2 text-sm font-semibold">최근 검색어</h3>
       <div className="flex flex-wrap gap-2">
-        {searchQuery.map(word => (
-          <span
-            key={word}
-            className="flex items-center justify-between gap-2 rounded-full border px-2 py-1 text-xs"
+        {searchQuery.map((word, index) => (
+          <TagButton
+            key={index}
+            size="sm"
             onClick={() => {
               setQuery(word);
               handleSearch(word);
             }}
+            className={cn(
+              "transition-al gap-2 rounded-full border px-2 py-1 font-suit text-sm text-text-greyscale-grey-85"
+            )}
+            variant={"ghost"}
           >
             {word}
-            <span className="h-3.5 w-3.5">
-              <CloseButton className="h-full w-full" onClick={() => handleDelete(word)} />
+            <span
+              className="h-4 w-4"
+              onClick={e => {
+                e.stopPropagation();
+                handleDelete(word);
+              }}
+            >
+              <CloseButton className="h-full w-full" />
             </span>
-          </span>
+          </TagButton>
         ))}
       </div>
     </section>

--- a/src/features/listings/ui/listingsNoSearchResult/listingNoSearchResult.tsx
+++ b/src/features/listings/ui/listingsNoSearchResult/listingNoSearchResult.tsx
@@ -1,13 +1,36 @@
 import { SearchEmpty } from "@/src/assets/icons/home/searchEmpty";
+import { AnimatePresence, motion } from "framer-motion";
+type NoSearchReusltType = { text: string };
 
-export const ListingNoSearchResult = () => {
+export const ListingNoSearchResult = ({ text }: NoSearchReusltType) => {
+  const lines = text.split("<br />");
   return (
-    <div className="flex flex-col items-center justify-center gap-4">
-      <SearchEmpty />
-      <p className="text-center text-sm font-bold text-text-primary">
-        검색 결과가 없습니다. <br />
-        다른 검색어로 검색해보세요.
-      </p>
+    <div className="flex items-center justify-center gap-4">
+      <AnimatePresence mode="wait">
+        <motion.div
+          initial={{ x: 100, opacity: 0 }}
+          animate={{ x: 0, opacity: 1 }}
+          exit={{ x: -100, opacity: 0 }}
+          transition={{ duration: 0.2, ease: "easeInOut" }}
+          className="flex flex-col items-center text-center"
+        >
+          <SearchEmpty />
+          <div className="flex flex-col gap-2">
+            {lines.map((line, idx) => (
+              <p
+                key={idx}
+                className={`text-sm ${
+                  idx === 0
+                    ? "text-center text-[20px] font-bold text-text-primary"
+                    : "text-center text-[12px] font-bold text-text-secondary"
+                }`}
+              >
+                {line}
+              </p>
+            ))}
+          </div>
+        </motion.div>
+      </AnimatePresence>
     </div>
   );
 };

--- a/src/shared/ui/dropDown/CaretDropDown/caretDropDown.tsx
+++ b/src/shared/ui/dropDown/CaretDropDown/caretDropDown.tsx
@@ -7,6 +7,7 @@ import { useEffect, useRef, useState } from "react";
 import { dropDownPreset } from "./deafultPreset";
 import { CaretDown } from "@/src/assets/icons/button/caretDown";
 import { CaretUp } from "@/src/assets/icons/button/caretUp";
+import { useListingState } from "@/src/features/listings/model/listingsStore";
 
 export const CaretDropDown = ({
   className,
@@ -15,19 +16,19 @@ export const CaretDropDown = ({
   types,
   children,
   data,
-  setSelect,
-  selected,
   ...props
 }: DropDownProps) => {
   const [open, setOpen] = useState<boolean>(false);
   const optionData = types ? data[types] : [];
   const wrapperRef = useRef<HTMLDivElement>(null);
-  const onChangeButton = () => setOpen(prev => !prev);
+
+  const { status, setStatus } = useListingState();
 
   const onClose = ({ value }: { value: string }) => {
-    setSelect(value);
+    setStatus(value);
     setOpen(false);
   };
+  const onChangeButton = () => setOpen(prev => !prev);
 
   const handleClickOutside = (e: MouseEvent) => {
     if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
@@ -36,7 +37,6 @@ export const CaretDropDown = ({
   };
 
   useEffect(() => {
-    setSelect(optionData[0]?.value);
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
@@ -50,7 +50,7 @@ export const CaretDropDown = ({
       >
         {children}
         <span className="flex w-full items-center justify-between gap-1 text-xs font-bold">
-          {selected || children}
+          {status || children}
           {open ? <CaretUp /> : <CaretDown />}
         </span>
       </button>
@@ -65,7 +65,7 @@ export const CaretDropDown = ({
             <li
               key={item.key}
               onClick={() => onClose({ value: item.value })}
-              className="flex cursor-pointer flex-col px-3 py-2 hover:bg-hover-dropDown hover:text-text-brand"
+              className="hover:bg-hover-dropDown flex cursor-pointer flex-col px-3 py-2 hover:text-text-brand"
             >
               <span className="text-sm">{item.value}</span>
             </li>

--- a/src/widgets/listingsSection/ui/listingsSection.tsx
+++ b/src/widgets/listingsSection/ui/listingsSection.tsx
@@ -8,15 +8,15 @@ import {
 
 export const ListingsSection = () => {
   return (
-    <section className="flex h-full w-full flex-col justify-between overflow-y-auto px-5 scrollbar-hide">
+    <section className="flex h-full w-full flex-col justify-between px-5">
       <div className="flex flex-col gap-2">
         <ListingsHeaders />
         <div className="-mx-5">
           <ListingFilterPanel />
         </div>
-        <div className="min-h-0 flex-1">
-          <ListingsContent />
-        </div>
+      </div>
+      <div className="min-h-0 flex-1">
+        <ListingsContent />
       </div>
       <ListingFilterPartialSheet />
     </section>

--- a/src/widgets/listingsSection/ui/searchSection.tsx/searchSection.tsx
+++ b/src/widgets/listingsSection/ui/searchSection.tsx/searchSection.tsx
@@ -8,6 +8,7 @@ import {
 import { useSearchState } from "@/src/shared/hooks/store";
 import { PageTransition } from "@/src/shared/ui/animation";
 import { SearchBarLabel } from "@/src/shared/ui/searchBarLabel";
+import { AnimatePresence, motion } from "framer-motion";
 import { useRouter, useSearchParams } from "next/navigation";
 import { ChangeEvent, useState } from "react";
 
@@ -33,27 +34,42 @@ export const ListingsSearch = () => {
     <section className="relative h-full overflow-hidden">
       <PageTransition>
         <div className="flex h-screen flex-col">
-          <div className="flex shrink-0 flex-col gap-2 px-5">
+          <div className="flex shrink-0 flex-col gap-2">
             <SearchForm />
-            <SearchBarLabel
-              direction="horizontal"
-              placeholder="검색어를 입력하세요"
-              className="rounded-3xl"
-              value={query}
-              onChange={onChangeHandle}
-              onEnter={handleSearch}
-            />
+            <div className="px-5">
+              <SearchBarLabel
+                direction="horizontal"
+                placeholder="검색어를 입력하세요"
+                className="rounded-3xl"
+                value={query}
+                onChange={onChangeHandle}
+                onEnter={handleSearch}
+              />
+            </div>
           </div>
 
           {keyword && isSearched.length === 0 ? (
-            <div className="flex flex-1 flex-col items-center justify-center overflow-y-auto">
-              <ListingNoSearchResult />
+            <div className="flex flex-1 flex-col items-center justify-center pb-[88px]">
+              <ListingNoSearchResult
+                text={"검색 결과가 없습니다. <br /> 다른 검색어로 검색해보세요."}
+              />
+
               <SearchResults center={true} handleSearch={handleSearch} />
             </div>
           ) : (
-            <div className="flex-1 overflow-y-auto p-5">
-              <SearchHistory handleSearch={handleSearch} />
-              <SearchResults handleSearch={handleSearch} />
+            <div className="flex-1 p-5">
+              <AnimatePresence mode="wait">
+                <motion.div
+                  initial={{ x: 100, opacity: 0 }}
+                  animate={{ x: 0, opacity: 1 }}
+                  exit={{ x: -100, opacity: 0 }}
+                  transition={{ duration: 0.1, ease: "easeInOut" }}
+                  className="flex flex-col"
+                >
+                  <SearchHistory handleSearch={handleSearch} />
+                  <SearchResults handleSearch={handleSearch} />
+                </motion.div>
+              </AnimatePresence>
             </div>
           )}
         </div>


### PR DESCRIPTION
<!--- Pull Request title = 커밋 메시지와 동일/ 해당 이슈를 close 하지 않을 경우, footer #이슈 번호 제외  -->

## #️⃣ Issue Number

#76 

<br/>
<br/>

## 📝 요약(Summary) (선택)
### 필터 시트 & 상태 스토어
- listingsFullSheet.tsx (line 10) 전체 필터 시트 UI(탭 전환, 전체선택 체크박스, 태그 토글, 시트 애니메이션, 하단 CTA) 추가.
- listingsStore.ts (line 8) 모집상태/필터/시트 열림 여부를 관리하는 zustand 스토어 세트 도입.
- listingsModel.ts (line 1) 지역·대상·임대유형 시트 데이터와 옵션 상수 정비.
- listingsContents.tsx (line 12) 필터 시트 닫힘 시 쿼리 재요청, totalCount 0 처리.
- listingsContentsHeader.tsx (line 8) 상태 드롭다운·정렬 토글 UI/로직 연동
- listingsContentsList.tsx (line 8) IntersectionObserver 기반 무한스크롤, 에러/빈 상태 UX 통일.
- listingNoSearchResult.tsx (line 5) 문구 줄바꿈 처리한 빈/에러 뷰 컴포넌트화.
- caretDropDown.tsx (line 12) 전역 모집상태와 연동되는 케어릿 드롭다운.
- useListingHooks.ts (line 13) 새 필터 스토어값으로 infinite query 요청/키 구성

<br/>
<br/>
