### PR TITLE
feat:공고탐색 검색 필터 기능 추가

### DIFF
--- a/src/features/listings/model/listingsStore.ts
+++ b/src/features/listings/model/listingsStore.ts
@@ -88,8 +88,8 @@ export const useListingsFilterStore = create<ListingsFilterState>(set => ({
 }));
 
 export const useListingsSearchState = create<SearchState>(set => ({
-  sortType: "",
-  status: "",
+  sortType: "LATEST",
+  status: "ALL",
   setStatus: value => set({ status: value }),
   setSortType: value => set({ sortType: value }),
   reset: () => set({ status: "", sortType: "" }),

--- a/src/features/listings/ui/listingsContents/listingsContentsHeader.tsx
+++ b/src/features/listings/ui/listingsContents/listingsContentsHeader.tsx
@@ -1,18 +1,27 @@
 "use client";
 import { ArrowUpArrowDown } from "@/src/assets/icons/button/arrowUpArrowDown";
-import { listingPoint, useListingsFilterStore } from "../../model";
+import { listingPoint, useListingsFilterStore, useListingsSearchState } from "../../model";
 import { CaretDropDown } from "@/src/shared/ui/dropDown/CaretDropDown";
 import { ListingsContentHeaderProps } from "@/src/entities/listings/model/type";
 import { MouseEvent } from "react";
+import { useSearchParams } from "next/navigation";
 
 export const ListingsContentHeader = ({ totalCount }: ListingsContentHeaderProps) => {
   const sortType = useListingsFilterStore(state => state.sortType);
   const setSortType = useListingsFilterStore(state => state.setSortType);
+  const setSearchSortType = useListingsSearchState(state => state.setSortType);
+  const searchSortType = useListingsSearchState(state => state.sortType);
+
+  const searchParams = useSearchParams();
+  const isSearchPage = searchParams.has("query");
 
   const onChange = (e: MouseEvent<HTMLDivElement>) => {
     e.preventDefault();
+    const saveSortType = isSearchPage ? setSearchSortType : setSortType;
     const nextSortType = sortType === "최신공고순" ? "마감임박순" : "최신공고순";
-    setSortType(nextSortType);
+    const nextSearchSortType = searchSortType === "LATEST" ? "DEADLINE" : "LATEST";
+    const sortTypeValue = isSearchPage ? nextSearchSortType : nextSortType;
+    saveSortType(sortTypeValue);
   };
   return (
     <div className="flex items-center justify-between">
@@ -27,7 +36,9 @@ export const ListingsContentHeader = ({ totalCount }: ListingsContentHeaderProps
         </div>
 
         <div className="flex items-center gap-1" onClick={e => onChange(e)}>
-          <div className="text-xs font-bold">{sortType}</div>
+          <div className="text-xs font-bold">
+            {isSearchPage ? (searchSortType === "LATEST" ? "최신공고순" : "마감임박순") : sortType}
+          </div>
           <ArrowUpArrowDown />
         </div>
       </div>

--- a/src/features/listings/ui/listingsHeaders/listingSearchResultList.tsx
+++ b/src/features/listings/ui/listingsHeaders/listingSearchResultList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { SearchResultsProps, useListingsSearchState } from "../../model";
+import { SearchResultsProps } from "../../model";
 import { cn } from "@/lib/utils";
 import {
   useListingSearchInfiniteQuery,
@@ -19,7 +19,6 @@ export const SearchResults = ({ center = false, handleSearch }: SearchResultsPro
   const { setQuery } = useSearchState();
   const { data } = usePopularSearchQuery();
   const { data: searchList } = useListingSearchInfiniteQuery();
-  const { setStatus, setSortType } = useListingsSearchState();
   const pageData = searchList?.pages[0].notices;
   const totalCount = searchList?.pages[0].totalElements;
   const searchParams = useSearchParams();

--- a/src/shared/ui/dropDown/CaretDropDown/caretDropDown.tsx
+++ b/src/shared/ui/dropDown/CaretDropDown/caretDropDown.tsx
@@ -7,7 +7,11 @@ import { useEffect, useRef, useState } from "react";
 import { dropDownPreset } from "./deafultPreset";
 import { CaretDown } from "@/src/assets/icons/button/caretDown";
 import { CaretUp } from "@/src/assets/icons/button/caretUp";
-import { useListingState } from "@/src/features/listings/model/listingsStore";
+import {
+  useListingsSearchState,
+  useListingState,
+} from "@/src/features/listings/model/listingsStore";
+import { useSearchParams } from "next/navigation";
 
 export const CaretDropDown = ({
   className,
@@ -21,11 +25,28 @@ export const CaretDropDown = ({
   const [open, setOpen] = useState<boolean>(false);
   const optionData = types ? data[types] : [];
   const wrapperRef = useRef<HTMLDivElement>(null);
-
   const { status, setStatus } = useListingState();
+  const searchParams = useSearchParams();
+  const isSearchPage = searchParams.has("query");
+
+  const setBaseStatus = useListingState(s => s.setStatus);
+  const setSearchStatus = useListingsSearchState(s => s.setStatus);
+  const searchState = useListingsSearchState(s => s.status);
+
+  const statusValue: Record<string, string> = {
+    전체: "ALL",
+    모집중: "OPEN",
+    ALL: "전체",
+    OPEN: "모집중",
+  };
 
   const onClose = ({ value }: { value: string }) => {
-    setStatus(value);
+    if (isSearchPage) {
+      const nextSearchStatus = statusValue[value] ?? value;
+      setSearchStatus(nextSearchStatus);
+    } else {
+      setBaseStatus(value);
+    }
     setOpen(false);
   };
   const onChangeButton = () => setOpen(prev => !prev);

--- a/src/widgets/listingsSection/ui/searchSection.tsx/searchSection.tsx
+++ b/src/widgets/listingsSection/ui/searchSection.tsx/searchSection.tsx
@@ -1,17 +1,18 @@
 "use client";
 import { SearchForm, SearchResults } from "@/src/features/listings";
+import { useListingsSearchState } from "@/src/features/listings/model";
 import { useSearchState } from "@/src/shared/hooks/store";
 import { PageTransition } from "@/src/shared/ui/animation";
 import { SearchBarLabel } from "@/src/shared/ui/searchBarLabel";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useState } from "react";
 
 export const ListingsSearch = () => {
-  const { setSearchQuery, setQuery, resetQuery } = useSearchState();
+  const { setSearchQuery, setQuery } = useSearchState();
+  const searchRest = useListingsSearchState.getState();
+  const resetQuery = useSearchState.getState();
   const router = useRouter();
   const searchParams = useSearchParams();
   const keyword = searchParams.get("query") ?? "";
-  const [isSearched, setIsSearched] = useState([]);
 
   const handleSearch = (keyword: string) => {
     if (!keyword) return;
@@ -21,7 +22,8 @@ export const ListingsSearch = () => {
   };
 
   const onClear = () => {
-    resetQuery();
+    resetQuery.resetQuery();
+    searchRest.reset();
     router.push("/listings/search?query=");
   };
 
@@ -38,7 +40,6 @@ export const ListingsSearch = () => {
                 className="rounded-3xl"
                 value={keyword}
                 onClear={onClear}
-                // onChange={onChangeHandle}
                 onEnter={handleSearch}
               />
             </div>


### PR DESCRIPTION


## #️⃣ Issue Number

#88 

<br/>
<br/>

## 📝 요약(Summary) (선택)
- queryKey에서 객체(filter) 제거 → 원시 값으로 flat하게 구성
- 리스트 / 검색 페이지 key 분리 강화
- optimistic update 시 두 InfiniteQuery(list/search) 동시에 업데이트
- rollback context 타입 정리
- onMutate에서 React Hook 제거
- 상태(setStatus, setSortType) 리스트/검색 페이지 분기 구조 확립
<br/>
<br/>


