### PR TITLE
feat: 공고탐색 항목필터 클릭시 필터시트 오픈 기능 추가

### DIFF
--- a/src/entities/listings/model/type.ts
+++ b/src/entities/listings/model/type.ts
@@ -1,5 +1,5 @@
-import { http, HTTP_METHODS } from "@/src/shared/api";
-import { ErrorCode, FieldError, IResponse } from "@/src/shared/types";
+import { HTTP_METHODS } from "@/src/shared/api";
+import { IResponse } from "@/src/shared/types";
 import { InfiniteData } from "@tanstack/react-query";
 
 /**
@@ -166,7 +166,7 @@ export interface PopularKeywordResponse extends IResponse {
   data: PopularKeywordItem[];
 }
 
-export type FilterOptionKey = "region" | "targetGroup" | "leaseType" | "housingType";
+export type FilterOptionKey = "region" | "target" | "rental" | "housing";
 
 export interface FilterOption {
   key: FilterOptionKey;

--- a/src/features/listings/model/filterPanelModel.tsx
+++ b/src/features/listings/model/filterPanelModel.tsx
@@ -24,15 +24,15 @@ export type SectionMap = Record<string, ReadonlyArray<City>>;
 export type SectionLabelMap = Record<string, string>;
 export type ListingFilterMap = {
   region: (s: ListingsFilterState) => ListingsFilterState["regionType"];
-  targetGroup: (s: ListingsFilterState) => ListingsFilterState["rentalTypes"];
-  leaseType: (s: ListingsFilterState) => ListingsFilterState["supplyTypes"];
-  housingType: (s: ListingsFilterState) => ListingsFilterState["houseTypes"];
+  target: (s: ListingsFilterState) => ListingsFilterState["rentalTypes"];
+  rental: (s: ListingsFilterState) => ListingsFilterState["supplyTypes"];
+  housing: (s: ListingsFilterState) => ListingsFilterState["houseTypes"];
 };
 export const filterMap: ListingFilterMap = {
   region: s => s.regionType,
-  targetGroup: s => s.rentalTypes,
-  leaseType: s => s.supplyTypes,
-  housingType: s => s.houseTypes,
+  target: s => s.rentalTypes,
+  rental: s => s.supplyTypes,
+  housing: s => s.houseTypes,
 };
 
 export interface SearchResultsProps {
@@ -53,4 +53,32 @@ export const highlight = (text: string, keyword: string) => {
       part
     )
   );
+};
+
+export const HighlightCenteredText = ({
+  text,
+  keyword,
+  range = 5,
+}: {
+  text: string;
+  keyword: string;
+  range?: number;
+}) => {
+  const centered = getKeywordCenteredText(text, keyword, range);
+  return <>{highlight(centered, keyword)}</>;
+};
+
+export const getKeywordCenteredText = (text: string, keyword: string, range: number = 20) => {
+  if (!keyword) return text;
+
+  const index = text.toLowerCase().indexOf(keyword.toLowerCase());
+  if (index === -1) return text;
+
+  const start = Math.max(0, index - range);
+  const end = Math.min(text.length, index + keyword.length + range);
+
+  const prefix = start > 0 ? "…" : "";
+  const suffix = end < text.length ? "…" : "";
+
+  return prefix + text.substring(start, end) + suffix;
 };

--- a/src/features/listings/model/listingsModel.ts
+++ b/src/features/listings/model/listingsModel.ts
@@ -49,19 +49,19 @@ export const FILTER_OPTIONS: FilterOption[] = [
     type: "select",
   },
   {
-    key: "targetGroup",
+    key: "target",
     label: "모집대상",
     component: "TargetGroupFilter",
     type: "select",
   },
   {
-    key: "leaseType",
+    key: "rental",
     label: "임대유형",
     component: "LeaseTypeFilter",
     type: "select",
   },
   {
-    key: "housingType",
+    key: "housing",
     label: "주택유형",
     component: "HousingTypeFilter",
     type: "select",

--- a/src/features/listings/ui/listingsButton/listingsTagButton.tsx
+++ b/src/features/listings/ui/listingsButton/listingsTagButton.tsx
@@ -1,20 +1,27 @@
 "use client";
 import { DownButton } from "@/src/assets/icons/button";
-import { useEnvtagStore } from "@/src/entities/tag/envTag";
+import { FilterOption } from "@/src/entities/listings/model/type";
 import { TagButton } from "@/src/shared/ui/button/tagButton";
-import { useListingsFilterStore } from "../../model";
+import { useFilterSheetStore } from "../../model";
+import { useRouter } from "next/navigation";
 
-export const ListingTagButton = ({ label, count }: { label: string; count: number }) => {
-  const { envTag, toggleEnvtag } = useEnvtagStore();
+export const ListingTagButton = ({ label, count }: { label: FilterOption; count: number }) => {
+  const openSheet = useFilterSheetStore(state => state.openSheet);
+  const router = useRouter();
 
-  const handleClick = () => {
-    toggleEnvtag(label);
+  const handleClick = async () => {
+    await router.push(`/listings?tab=${label.key}`, { scroll: false });
+
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        setTimeout(() => openSheet(), 200);
+      });
+    });
   };
-
   return (
     <TagButton size="sm" onClick={handleClick} variant={"ghost"}>
       <div className="flex gap-1 text-xs">
-        <p>{label}</p>
+        <p>{label.label}</p>
         <p className="text-text-brand">{count}</p>
       </div>
       <div className="mr-[-5px] flex shrink-0">

--- a/src/features/listings/ui/listingsContents/listingsContentCard.tsx
+++ b/src/features/listings/ui/listingsContents/listingsContentCard.tsx
@@ -4,7 +4,7 @@ import { ListingBookMark } from "./listingsBookMark";
 import { HouseICons, HouseRental } from "../../hooks/listingsHooks";
 import { formatApplyPeriod } from "@/src/shared/lib/utils";
 import { useSearchParams } from "next/navigation";
-import { highlight } from "../../model";
+import { HighlightCenteredText } from "../../model";
 
 export const ListingContentsCard = <T extends ListingUnion>({ data }: { data: T[] }) => {
   const searchParams = useSearchParams();
@@ -38,7 +38,7 @@ export const ListingContentsCard = <T extends ListingUnion>({ data }: { data: T[
               </div>
               <div className="max-w-full">
                 <p className="truncate text-sm font-semibold">
-                  {highlight(normalized.name, keyword)}
+                  <HighlightCenteredText text={normalized.name} keyword={keyword} />
                 </p>
               </div>
               <div className="max-w-full">

--- a/src/features/listings/ui/listingsFilter/listingsFilterPanel.tsx
+++ b/src/features/listings/ui/listingsFilter/listingsFilterPanel.tsx
@@ -35,7 +35,7 @@ export const ListingFilterPanel = () => {
               const count = selectedValues.length;
               return (
                 <div key={item.key} className="flex-shrink-0">
-                  <ListingTagButton label={item.label} count={count} />
+                  <ListingTagButton label={item} count={count} />
                 </div>
               );
             })}

--- a/src/shared/ui/dropDown/CaretDropDown/caretDropDown.tsx
+++ b/src/shared/ui/dropDown/CaretDropDown/caretDropDown.tsx
@@ -71,7 +71,8 @@ export const CaretDropDown = ({
       >
         {children}
         <span className="flex w-full items-center justify-between gap-1 text-xs font-bold">
-          {status || children}
+          {isSearchPage ? (searchState === "ALL" ? "전체" : "모집중") : status}
+          {/* {status || children} */}
           {open ? <CaretUp /> : <CaretDown />}
         </span>
       </button>


### PR DESCRIPTION
## #️⃣ Issue Number

#94 

<br/>
<br/>

## 📝 요약(Summary) (선택)
- 공고탐색 태그버튼(지역, 임대, 모집,주택 의 항목 필터)  클릭시  필터 sheet 오픈 기능 추가
- router.push로 url 이동 처리
- router 정상 이동 완료시 sheet 오픈

<br/>
<br/>
