### PR TITLE
feat: 방타입 상세 UX/UI 완료

### DIFF
--- a/src/entities/listings/hooks/useListingDetailHooks.ts
+++ b/src/entities/listings/hooks/useListingDetailHooks.ts
@@ -121,14 +121,21 @@ export const useListingInfraDetail = (id: string) => {
 export const useListingRoomTypeDetail = (id: string) => {
   const encodedId = encodeURIComponent(id);
 
-  return useQuery<ListingUnitType[], Error, ListingUnitType[]>({
-    queryKey: ["useListingInfraDetail", encodedId],
+  return useQuery<IResponse<ListingUnitType[]>, Error, ListingUnitType[]>({
+    queryKey: ["useListingRoomTypeDetail", encodedId],
     enabled: !!id,
     staleTime: 1000 * 60 * 5,
+
     queryFn: () =>
-      PostBasicRequest<ListingUnitType[], IResponse<ListingUnitType[]>, {}, ListingUnitType[]>(
-        `${COMPLEXES_ENDPOINT}/unit/${encodedId}`,
-        "get"
-      ),
+      PostBasicRequest<
+        ListingUnitType[],
+        IResponse<ListingUnitType[]>,
+        {},
+        IResponse<ListingUnitType[]>
+      >(`${COMPLEXES_ENDPOINT}/unit/${encodedId}`, "get"),
+
+    select: response => {
+      return response.data ?? [];
+    },
   });
 };

--- a/src/entities/listings/model/type.ts
+++ b/src/entities/listings/model/type.ts
@@ -414,22 +414,16 @@ export interface DepositRange {
 export interface ListingUnitType {
   /** 타입 고유 ID */
   typeId: string;
-
   /** 타입 코드 (ex: 34) */
   typeCode: string;
-
   /** 썸네일 이미지 URL */
   thumbnail: string | null;
-
   /** 공급 세대 수 */
   quota: number;
-
   /** 전용면적 (㎡) */
   exclusiveAreaM2: number;
-
   /** 보증금 정보 */
   deposit: DepositRange;
-
   /** 관심 여부 */
   liked: boolean;
 }

--- a/src/features/listings/model/filterPanelModel.tsx
+++ b/src/features/listings/model/filterPanelModel.tsx
@@ -313,15 +313,26 @@ export const INFRA_ENVIRONMENT_CONFIG: Record<string, InfraConfig> = INFRA_ENVIR
   {} as Record<string, InfraConfig>
 );
 
+/**
+ * 방 타입 관련 섹션 헤더에 쓰이는 텍스트 포맷
+ * - title: 섹션 제목
+ * - des: 부가 설명 문구
+ */
 export type RoomTitleDesType = {
   title: string;
   des: string;
 };
+/**
+ * 방 타입 상세 상단 탭별(노선/주변환경/방타입) 헤더 문구 모음
+ */
 export interface RoomTypeTitleDes {
   route: RoomTitleDesType;
   infra: RoomTitleDesType;
   room: RoomTitleDesType;
 }
+/**
+ * 방 타입 상세 화면에서 사용하는 기본 헤더 문구
+ */
 export const ROOM_TYPE_TITLE_DES: RoomTypeTitleDes = {
   route: {
     title: "노선정보",
@@ -335,4 +346,31 @@ export const ROOM_TYPE_TITLE_DES: RoomTypeTitleDes = {
     title: "방타입",
     des: "방타입 을 상세히",
   },
+};
+
+/**
+ * 보증금 상세 탭 키
+ * - min: 최소 납입
+ * - normal: 기본
+ * - max: 최대 납입
+ */
+export type DepositTab = "min" | "normal" | "max";
+
+/**
+ * 보증금 상세에서 사용하는 탭 구성(라벨 포함)
+ */
+export const DEPOSIT_TABS: { key: DepositTab; label: string }[] = [
+  { key: "min", label: "보증금 최소납입" },
+  { key: "normal", label: "보증금 기본" },
+  { key: "max", label: "보증금 최대납입" },
+];
+
+/**
+ * ㎡(제곱미터)를 평 단위 문자열로 변환
+ * - 소수점 한 자리 고정
+ * - 잘못된 입력(m2 = 0/NaN)은 "0" 반환
+ */
+export const toPyeong = (m2: number) => {
+  if (!m2 || Number.isNaN(m2)) return "0";
+  return (m2 / 3.305785).toFixed(1);
 };

--- a/src/features/listings/ui/listingsCardDetail/infra/components/components/roomType/depositDetail.tsx
+++ b/src/features/listings/ui/listingsCardDetail/infra/components/components/roomType/depositDetail.tsx
@@ -1,0 +1,33 @@
+import { memo } from "react";
+import { formatNumber } from "@/src/shared/lib/numberFormat";
+
+interface Props {
+  deposit?: {
+    total?: number;
+    contract?: number;
+    balance?: number;
+    monthPay?: number;
+  };
+}
+
+export const DepositDetail = memo(({ deposit }: Props) => {
+  return (
+    <div className="p-5">
+      <div className="rounded-xl bg-greyscale-grey-25 p-4">
+        <Row label="보증금 합계" value={deposit?.total} />
+        <Row label="계약금" value={deposit?.contract} />
+        <Row label="잔금" value={deposit?.balance} />
+        <div className="mt-2 border-t border-greyscale-grey-100 pt-2">
+          <Row label="월 임대료" value={deposit?.monthPay} />
+        </div>
+      </div>
+    </div>
+  );
+});
+
+const Row = ({ label, value }: { label: string; value?: number }) => (
+  <div className="flex items-center justify-between py-1 text-sm">
+    <span className="text-text-secondary">{label}</span>
+    <span className="font-semibold text-text-primary">{formatNumber(value ?? 0)}원</span>
+  </div>
+);

--- a/src/features/listings/ui/listingsCardDetail/infra/components/components/roomType/depositSection.tsx
+++ b/src/features/listings/ui/listingsCardDetail/infra/components/components/roomType/depositSection.tsx
@@ -1,0 +1,27 @@
+import { useState, memo, useMemo } from "react";
+import { DepositTabs } from "./depositTab";
+import { DepositDetail } from "./depositDetail";
+import { DepositTab } from "@/src/features/listings/model";
+
+interface DepositSectionProps {
+  deposit?: {
+    min?: any;
+    normal?: any;
+    max?: any;
+  };
+}
+
+export const DepositSection = memo(({ deposit }: DepositSectionProps) => {
+  const [tab, setTab] = useState<DepositTab>("min");
+
+  const currentDeposit = useMemo(() => {
+    return deposit?.[tab];
+  }, [deposit, tab]);
+
+  return (
+    <div className="border-t border-greyscale-grey-50">
+      <DepositTabs tab={tab} onChange={setTab} />
+      <DepositDetail deposit={currentDeposit} />
+    </div>
+  );
+});

--- a/src/features/listings/ui/listingsCardDetail/infra/components/components/roomType/depositTab.tsx
+++ b/src/features/listings/ui/listingsCardDetail/infra/components/components/roomType/depositTab.tsx
@@ -1,0 +1,40 @@
+import { memo } from "react";
+
+type DepositTab = "min" | "normal" | "max";
+
+const TABS: { key: DepositTab; label: string }[] = [
+  { key: "min", label: "보증금 최소납입" },
+  { key: "normal", label: "보증금 기본" },
+  { key: "max", label: "보증금 최대납입" },
+];
+
+interface Props {
+  tab: DepositTab;
+  onChange: (tab: DepositTab) => void;
+}
+
+export const DepositTabs = memo(({ tab, onChange }: Props) => {
+  return (
+    <div className="relative">
+      <div className="flex gap-5 px-5 pt-3 text-sm font-medium">
+        {TABS.map(t => (
+          <button
+            key={t.key}
+            onClick={() => onChange(t.key)}
+            className={tab === t.key ? "p-1 font-bold text-text-primary" : "p-1 text-gray-500"}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      <div
+        className="mt-2 h-[2px] bg-button-primary"
+        style={{
+          width: `${Math.max(0, tab === "min" ? 100 : tab === "normal" ? 90 : 100)}px`,
+          marginLeft: `${tab === "min" ? 20 : tab === "normal" ? 20 + 90 + 20 : 20 + 90 + 20 + 78 + 20}px`,
+        }}
+      />
+    </div>
+  );
+});

--- a/src/features/listings/ui/listingsCardDetail/infra/components/components/roomType/typeInfoSection.tsx
+++ b/src/features/listings/ui/listingsCardDetail/infra/components/components/roomType/typeInfoSection.tsx
@@ -1,0 +1,28 @@
+import { LeftButton } from "@/src/assets/icons/button";
+
+type TypeInfoSectionProps = {
+  onPrev: () => void;
+  onNext: () => void;
+};
+
+export const TypeInfoSection = ({ onPrev, onNext }: TypeInfoSectionProps) => {
+  return (
+    <>
+      <button
+        aria-label="이전 타입"
+        onClick={onPrev}
+        // className="absolute left-2 top-1/2 -translate-y-1/2 rounded-full bg-white/80 p-2 shadow"
+        className="absolute left-2 top-1/2 -translate-y-1/2 rounded-full"
+      >
+        <LeftButton className="size-5" />
+      </button>
+      <button
+        aria-label="다음 타입"
+        onClick={onNext}
+        className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full"
+      >
+        <LeftButton className="size-5 rotate-180" />
+      </button>
+    </>
+  );
+};

--- a/src/features/listings/ui/listingsCardDetail/infra/components/environment.tsx
+++ b/src/features/listings/ui/listingsCardDetail/infra/components/environment.tsx
@@ -7,7 +7,7 @@ export const Environment = ({ listingId }: { listingId: string }) => {
   if (isFetching) {
     return <SmallSpinner title={"인프라 검색중.."} />;
   }
-  console.log(data);
+
   return (
     <section className="flex h-full flex-col">
       <ul className="flex-1 space-y-3 overflow-y-auto p-5">

--- a/src/features/listings/ui/listingsCardDetail/infra/components/roomTypeDetail.tsx
+++ b/src/features/listings/ui/listingsCardDetail/infra/components/roomTypeDetail.tsx
@@ -1,7 +1,73 @@
+"use cilent";
+import { useState, useEffect, useMemo, useCallback } from "react";
 import { useListingRoomTypeDetail } from "@/src/entities/listings/hooks/useListingDetailHooks";
+import { SmallSpinner } from "@/src/shared/ui/spinner/small/smallSpinner";
+import { formatNumber } from "@/src/shared/lib/numberFormat";
+import { toPyeong } from "@/src/features/listings/model";
+import { DepositSection } from "./components/roomType/depositSection";
+import { TypeInfoSection } from "./components/roomType/typeInfoSection";
 
 export const RoomTypeDetail = ({ listingId }: { listingId: string }) => {
-  const { data } = useListingRoomTypeDetail(listingId);
+  const { data, isFetching } = useListingRoomTypeDetail(listingId);
+  const [currentIndex, setCurrentIndex] = useState(0);
 
-  return <div>방타입</div>;
+  const items = data ?? [];
+
+  const current = useMemo(() => {
+    return items[currentIndex];
+  }, [items, currentIndex]);
+
+  const goPrev = useCallback(() => {
+    setCurrentIndex(p => (p - 1 + items.length) % Math.max(items.length, 1));
+  }, [items.length]);
+
+  const goNext = useCallback(() => {
+    setCurrentIndex(p => (p + 1) % Math.max(items.length, 1));
+  }, [items.length]);
+
+  useEffect(() => {
+    setCurrentIndex(0);
+  }, [listingId]);
+
+  if (isFetching) return <SmallSpinner title="방 타입 불러오는 중.." />;
+  if (!items.length) {
+    return (
+      <div className="p-6 text-center text-sm text-text-secondary">
+        표시할 방 타입 정보가 없어요.
+      </div>
+    );
+  }
+
+  return (
+    <section className="flex h-full flex-col">
+      <div className="relative flex items-center justify-center bg-greyscale-grey-25">
+        <div className="relative flex h-60 w-full items-center justify-center">
+          <img
+            src={current?.thumbnail ?? "/area.png"}
+            alt={current?.typeCode ?? "room-type"}
+            className="max-h-full object-contain"
+          />
+          {items.length > 1 && <TypeInfoSection onPrev={goPrev} onNext={goNext} />}
+
+          <div className="pointer-events-none absolute bottom-2 left-1/2 -translate-x-1/2 rounded-full bg-black/50 px-2 py-0.5 text-[11px] text-white">
+            {currentIndex + 1} / {items.length}
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-1 border-t border-greyscale-grey-50 p-5">
+        <h3 className="text-lg font-semibold text-text-primary">{current?.typeCode}</h3>
+        <p className="text-xs text-text-secondary">
+          전용면적 {formatNumber(current?.exclusiveAreaM2 ?? 0)}m² (
+          {toPyeong(current?.exclusiveAreaM2 ?? 0)}평)
+          <span className="mx-2 text-greyscale-grey-200">|</span>
+          모집호수 {formatNumber(current?.quota ?? 0)}호
+        </p>
+      </div>
+
+      <div className="border-t border-greyscale-grey-50">
+        <DepositSection deposit={current?.deposit} />
+      </div>
+    </section>
+  );
 };


### PR DESCRIPTION

## #️⃣ Issue Number

#130 

<br/>
<br/>

## 📝 요약(Summary) (선택)
### useListingRoomTypeDetail
- React Query 키 수정(오타 교정), 응답 제네릭을 IResponse<ListingUnitType[]>로 변경
- PostBasicRequest 제네릭 시그니처 정정
- select 추가로 response.data ?? []만 반환하도록 정제
- ListingUnitType

### 인터페이스 필드 사이 공백/주석 정리(기능 변화 없음)
- filterPanelModel

### DepositTab 타입("min" | "normal" | "max") 추가
- DEPOSIT_TABS 탭 메타정보 추가
- toPyeong(m2) 유틸 추가(㎡ → 평 변환)
- DepositDetail

### 신규 컴포넌트
- 보증금 합계/계약금/잔금/월임대료를 행 단위로 표시, 숫자 포맷 적용
- DepositSection

### 신규 컴포넌트
- 보증금 탭 상태(min/normal/max) 관리 및 선택된 탭의 보증금 상세 렌더
- DepositTabs

### 신규 컴포넌트
- 최소/기본/최대납입 탭 버튼과 하이라이트 바 구현
- TypeInfoSection

###신규 컴포넌트
- 좌/우 네비게이션 버튼(이전/다음 타입) 렌더
- Environment

불필요한 console.log 제거
RoomTypeDetail


#### 타입 목록 내 인덱스 상태/이동(이전·다음) 제어 추가
#### 썸네일 이미지, 타입코드, 전용면적(㎡/평), 모집호수 표시
#### DepositSection 연동으로 보증금 상세 탭 표시
#### 유틸(formatNumber, toPyeong) 및 신규 섹션 컴포넌트 연동

<br/>
<br/>

## 📸스크린샷 (선택)2
<img width="446" height="675" alt="image" src="https://github.com/user-attachments/assets/4718a3b4-5729-41aa-bb3a-72caedab5f5a" />

<br/>
<br/>

