### PR TITLE
feat:공고상세노선정보API,테스트 로직 추가

### DIFF
--- a/src/entities/listings/api/__test__/listing.test.ts
+++ b/src/entities/listings/api/__test__/listing.test.ts
@@ -6,6 +6,7 @@ import {
   LikeReturn,
   ListingItem,
   ListingItemResponse,
+  ListingRouteInfo,
   ListingSummary,
   ListingUnitType,
   PopularKeywordItem,
@@ -13,7 +14,6 @@ import {
 import {
   COMPLEXES_ENDPOINT,
   http,
-  HTTP_METHODS,
   LIKE_ENDPOINT,
   NOTICE_ENDPOINT,
   POPULAR_SEARCH_ENDPOINT,
@@ -673,6 +673,185 @@ describe("방타입상세조회", () => {
     );
     expect(http.get).toHaveBeenCalledWith(`${COMPLEXES_ENDPOINT}/unit/19409#1`, {});
 
+    expect(result).toEqual({ data: mockListingOne });
+  });
+});
+
+describe("노선정보 상세조회", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it("노선정보 상세조회 API 성공", async () => {
+    const mockListingOne: ListingRouteInfo[] = [
+      {
+        totalTime: "1시간 8분",
+        totalTimeMinutes: 68,
+        totalDistance: 284.3,
+        routes: [
+          {
+            type: "AIR",
+            minutesText: "60분",
+            lineText: "항공",
+            line: null,
+            bgColorHex: "#2C7A7B",
+          },
+          {
+            type: "TRAIN",
+            minutesText: "8분",
+            lineText: "KTX",
+            line: {
+              code: 1,
+              label: "KTX",
+              bgColorHex: "#3356B4",
+            },
+            bgColorHex: "#3356B4",
+          },
+        ],
+        stops: [
+          {
+            role: "START",
+            type: "AIR",
+            stopName: "김포국제공항",
+            lineText: "항공",
+            line: null,
+            bgColorHex: "#2C7A7B",
+          },
+          {
+            role: "TRANSFER",
+            type: "TRAIN",
+            stopName: "광주송정",
+            lineText: "KTX",
+            line: {
+              code: 1,
+              label: "KTX",
+              bgColorHex: "#3356B4",
+            },
+            bgColorHex: "#3356B4",
+          },
+          {
+            role: "ARRIVAL",
+            type: "TRAIN",
+            stopName: "나주",
+            lineText: null,
+            line: null,
+            bgColorHex: null,
+          },
+        ],
+      },
+      {
+        totalTime: "1시간 50분",
+        totalTimeMinutes: 110,
+        totalDistance: 322.8,
+        routes: [
+          {
+            type: "TRAIN",
+            minutesText: "41분",
+            lineText: "KTX",
+            line: {
+              code: 1,
+              label: "KTX",
+              bgColorHex: "#3356B4",
+            },
+            bgColorHex: "#3356B4",
+          },
+          {
+            type: "TRAIN",
+            minutesText: "69분",
+            lineText: "SRT",
+            line: {
+              code: 8,
+              label: "SRT",
+              bgColorHex: "#E5046C",
+            },
+            bgColorHex: "#E5046C",
+          },
+        ],
+        stops: [
+          {
+            role: "START",
+            type: "TRAIN",
+            stopName: "서울",
+            lineText: "KTX",
+            line: {
+              code: 1,
+              label: "KTX",
+              bgColorHex: "#3356B4",
+            },
+            bgColorHex: "#3356B4",
+          },
+          {
+            role: "TRANSFER",
+            type: "TRAIN",
+            stopName: "오송",
+            lineText: "SRT",
+            line: {
+              code: 8,
+              label: "SRT",
+              bgColorHex: "#E5046C",
+            },
+            bgColorHex: "#E5046C",
+          },
+          {
+            role: "ARRIVAL",
+            type: "TRAIN",
+            stopName: "나주",
+            lineText: null,
+            line: null,
+            bgColorHex: null,
+          },
+        ],
+      },
+      {
+        totalTime: "1시간 52분",
+        totalTimeMinutes: 112,
+        totalDistance: 305.3,
+        routes: [
+          {
+            type: "TRAIN",
+            minutesText: "112분",
+            lineText: "SRT",
+            line: {
+              code: 8,
+              label: "SRT",
+              bgColorHex: "#E5046C",
+            },
+            bgColorHex: "#E5046C",
+          },
+        ],
+        stops: [
+          {
+            role: "START",
+            type: "TRAIN",
+            stopName: "수서",
+            lineText: "SRT",
+            line: {
+              code: 8,
+              label: "SRT",
+              bgColorHex: "#E5046C",
+            },
+            bgColorHex: "#E5046C",
+          },
+          {
+            role: "ARRIVAL",
+            type: "TRAIN",
+            stopName: "나주",
+            lineText: null,
+            line: null,
+            bgColorHex: null,
+          },
+        ],
+      },
+    ];
+    (http.get as jest.Mock).mockResolvedValue({
+      data: mockListingOne,
+    });
+    const result = await PostBasicRequest<
+      ListingRouteInfo[],
+      IResponse<ListingRouteInfo[]>,
+      {},
+      ListingRouteInfo[]
+    >(`${COMPLEXES_ENDPOINT}/transit/19407#1`, "get", {});
+    expect(http.get).toHaveBeenCalledWith(`${COMPLEXES_ENDPOINT}/transit/19407#1`, {});
     expect(result).toEqual({ data: mockListingOne });
   });
 });

--- a/src/entities/listings/api/listingsApi.ts
+++ b/src/entities/listings/api/listingsApi.ts
@@ -1,6 +1,6 @@
 import { IResponse } from "@/src/shared/types";
 import { HTTP_METHODS } from "@/src/shared/api";
-import { HttpMethod } from "../model/type";
+import { HttpMethod, RequestOptions } from "../model/type";
 
 export const requestListingList = async <
   TData,
@@ -36,6 +36,27 @@ export const PostBasicRequest = async <
 ): Promise<TReturn> => {
   const apiCall = HTTP_METHODS[method];
   const res = await apiCall<TResponse, TReqBody>(url, body);
+
+  return res as unknown as TReturn;
+};
+
+export const PostParamsBodyRequest = async <
+  TData,
+  TResponse extends IResponse<TData>,
+  TReqBody extends object = {},
+  TReturn = TResponse,
+  TQuery extends object = object,
+>(
+  url: string,
+  method: HttpMethod,
+  body?: TReqBody,
+  options?: RequestOptions<TQuery>
+): Promise<TReturn> => {
+  const apiCall = HTTP_METHODS[method];
+
+  const res = await apiCall<TResponse, TReqBody>(url, body, {
+    params: options?.query,
+  });
 
   return res as unknown as TReturn;
 };

--- a/src/entities/listings/hooks/useListingDetailHooks.ts
+++ b/src/entities/listings/hooks/useListingDetailHooks.ts
@@ -6,10 +6,11 @@ import {
   ListingDetailResponseWithColor,
   ListingRentalDetailVM,
   ListingSummary,
-  ListingUnitType,
   LstingBody,
+  UseListingsHooksType,
+  UseListingsHooksWithParam,
 } from "../model/type";
-import { PostBasicRequest, requestListingList } from "../api/listingsApi";
+import { PostBasicRequest, PostParamsBodyRequest, requestListingList } from "../api/listingsApi";
 import { COMPLEXES_ENDPOINT, NOTICE_ENDPOINT } from "@/src/shared/api";
 import { IResponse } from "@/src/shared/types";
 import { getListingsRental } from "@/src/features/listings/hooks/listingsHooks";
@@ -68,7 +69,7 @@ export const useListingRentalDetail = (id: string) => {
         { pinPointId: string },
         ListingSummary
       >(`${COMPLEXES_ENDPOINT}/${encodedId}`, "get", {
-        params: { pinPointId: "03cac89e-9b49-4e17-8daf-029be805f7a8" },
+        params: { pinPointId: "fec9aba3-0fd9-4b75-bebf-9cb7641fd251" },
       });
     },
     select: (response): ListingRentalDetailVM => {
@@ -118,24 +119,42 @@ export const useListingInfraDetail = (id: string) => {
   });
 };
 
-export const useListingRoomTypeDetail = (id: string) => {
+export const useListingRoomTypeDetail = <T>({ id, queryK, url }: UseListingsHooksType) => {
+  const encodedId = encodeURIComponent(id);
+  return useQuery<IResponse<T[]>, Error, T[]>({
+    queryKey: [queryK, encodedId],
+    enabled: !!id,
+    staleTime: 1000 * 60 * 5,
+    queryFn: () =>
+      PostBasicRequest<T[], IResponse<T[]>, {}, IResponse<T[]>>(
+        `${COMPLEXES_ENDPOINT}/${url}/${encodedId}`,
+        "get"
+      ),
+    select: response => response.data ?? [],
+  });
+};
+
+export const useListingRouteDetail = <T, TParam extends object>({
+  id,
+  queryK,
+  url,
+  params,
+}: UseListingsHooksWithParam<TParam>) => {
   const encodedId = encodeURIComponent(id);
 
-  return useQuery<IResponse<ListingUnitType[]>, Error, ListingUnitType[]>({
-    queryKey: ["useListingRoomTypeDetail", encodedId],
+  return useQuery<IResponse<T[]>, Error, T[]>({
+    queryKey: [queryK, encodedId, params],
     enabled: !!id,
     staleTime: 1000 * 60 * 5,
 
     queryFn: () =>
-      PostBasicRequest<
-        ListingUnitType[],
-        IResponse<ListingUnitType[]>,
+      PostParamsBodyRequest<T[], IResponse<T[]>, {}, IResponse<T[]>, TParam>(
+        `${COMPLEXES_ENDPOINT}/${url}/${encodedId}`,
+        "get",
         {},
-        IResponse<ListingUnitType[]>
-      >(`${COMPLEXES_ENDPOINT}/unit/${encodedId}`, "get"),
+        { query: params }
+      ),
 
-    select: response => {
-      return response.data ?? [];
-    },
+    select: response => response.data ?? [],
   });
 };

--- a/src/entities/listings/model/type.ts
+++ b/src/entities/listings/model/type.ts
@@ -427,3 +427,55 @@ export interface ListingUnitType {
   /** 관심 여부 */
   liked: boolean;
 }
+
+// 공통 Enum (타입 안정성 ↑)
+export type TransportType = "AIR" | "TRAIN" | "BUS" | "SUBWAY" | "WALK";
+export type StopRole = "START" | "TRANSFER" | "ARRIVAL" | "STOP";
+//Line 타입
+export interface TransportLine {
+  code: number;
+  label: string;
+  bgColorHex: string;
+}
+//이동구간
+export interface RouteSegment {
+  type: TransportType;
+  minutesText: string; // "60분"
+  lineText: string | null; // "KTX", "항공"
+  line: TransportLine | null;
+  bgColorHex: string | null;
+}
+
+export interface RouteStop {
+  role: StopRole;
+  type: TransportType;
+  stopName: string;
+  lineText: string | null;
+  line: TransportLine | null;
+  bgColorHex: string | null;
+}
+
+export interface ListingRouteInfo {
+  totalTime: string;
+  totalTimeMinutes: number;
+  totalDistance: number;
+  routes: RouteSegment[];
+  stops: RouteStop[];
+}
+
+export type UseListingsHooksType = {
+  id: string;
+  queryK: string;
+  url: string;
+};
+
+export type UseListingsHooksWithParam<TParam extends object> = {
+  id: string;
+  queryK: string;
+  url: string;
+  params: TParam;
+};
+
+export interface RequestOptions<TQuery extends object = object> {
+  query?: TQuery;
+}

--- a/src/features/listings/ui/listingsCardDetail/infra/components/roomTypeDetail.tsx
+++ b/src/features/listings/ui/listingsCardDetail/infra/components/roomTypeDetail.tsx
@@ -6,9 +6,14 @@ import { formatNumber } from "@/src/shared/lib/numberFormat";
 import { toPyeong } from "@/src/features/listings/model";
 import { DepositSection } from "./components/roomType/depositSection";
 import { TypeInfoSection } from "./components/roomType/typeInfoSection";
+import { ListingUnitType } from "@/src/entities/listings/model/type";
 
 export const RoomTypeDetail = ({ listingId }: { listingId: string }) => {
-  const { data, isFetching } = useListingRoomTypeDetail(listingId);
+  const { data, isFetching } = useListingRoomTypeDetail<ListingUnitType>({
+    id: listingId,
+    queryK: "useListingRoomTypeDetail",
+    url: "unit",
+  });
   const [currentIndex, setCurrentIndex] = useState(0);
 
   const items = data ?? [];

--- a/src/features/listings/ui/listingsCardDetail/infra/components/routeDetail.tsx
+++ b/src/features/listings/ui/listingsCardDetail/infra/components/routeDetail.tsx
@@ -1,3 +1,15 @@
-export const RouteDetail = () => {
+import { useListingRouteDetail } from "@/src/entities/listings/hooks/useListingDetailHooks";
+import { ListingRouteInfo } from "@/src/entities/listings/model/type";
+
+export const RouteDetail = ({ listingId }: { listingId: string }) => {
+  const { data, isFetching } = useListingRouteDetail<ListingRouteInfo, { pinPointId: string }>({
+    id: listingId,
+    queryK: "useListingRoomTypeDetail",
+    url: "transit",
+    params: {
+      pinPointId: "fec9aba3-0fd9-4b75-bebf-9cb7641fd251",
+    },
+  });
+
   return <div>노선정보</div>;
 };

--- a/src/features/listings/ui/listingsCardDetail/infra/infraSheet.tsx
+++ b/src/features/listings/ui/listingsCardDetail/infra/infraSheet.tsx
@@ -13,7 +13,7 @@ import { RoomTypeDetail } from "./components/roomTypeDetail";
 const RenderContent = ({ section, listingId }: RenderContentProps) => {
   switch (section) {
     case "route":
-      return <RouteDetail />;
+      return <RouteDetail listingId={listingId} />;
 
     case "infra":
       return <Environment listingId={listingId} />;


### PR DESCRIPTION
<!--- Pull Request title = 커밋 메시지와 동일/ 해당 이슈를 close 하지 않을 경우, footer #이슈 번호 제외  -->

## #️⃣ Issue Number

#132 

<br/>
<br/>

## 📝 요약(Summary) (선택)

### InfraSheet
- route 섹션 렌더 시 RouteDetail에 listingId 전달하도록 수정
- RouteDetail

### useListingRouteDetail 훅 도입(제네릭/객체 인자)
- id, queryK, url: "transit", params.pinPointId로 노선정보 조회 구조 반영
- RoomTypeDetail

### useListingRoomTypeDetail 호출을 제네릭/객체 인자로 변경
- id, queryK: "useListingRoomTypeDetail", url: "unit" 형태로 조회
- DefaultTest

### PostParamsBodyRequest 추가(쿼리 파라미터/바디 동시 지원)
- RequestOptions import 반영
- useListingDetailHooks

- useListingRoomTypeDetail를 제네릭 + 객체 인자 시그니처로 변경
- useListingRouteDetail 신규 추가(쿼리 파라미터 포함)
- useListingRentalDetail의 pinPointId 기본값 변경
- ListingRouteInfo(및 관련 타입)

- TransportType, StopRole, TransportLine, RouteSegment, RouteStop, ListingRouteInfo 추가
- 훅 공통 파라미터 타입(UseListingsHooksType, UseListingsHooksWithParam, RequestOptions) 추가

<br/>
<br/>
