### PR TITLE
feat:노선정보 정렬및 tag 코드 변경

### DIFF
--- a/src/assets/icons/infra/pinAddress.tsx
+++ b/src/assets/icons/infra/pinAddress.tsx
@@ -5,7 +5,7 @@ export const PinPointAddress = ({
   ...props
 }: SVGProps<SVGSVGElement> & { color?: string }) => {
   return (
-    <div className={`flex h-7 w-7 items-center justify-center rounded-full bg-primary-blue-300`}>
+    <div className={`flex h-6 w-6 items-center justify-center rounded-full bg-primary-blue-300`}>
       <svg
         width="13"
         height="13"

--- a/src/assets/icons/route/subway.tsx
+++ b/src/assets/icons/route/subway.tsx
@@ -30,7 +30,7 @@ export const TrainIcon = ({
         style={{
           backgroundColor: color,
           width: "100%",
-          marginLeft: "-2.7px",
+          marginLeft: "-5px",
         }}
       >
         <span className="flex text-xs font-semibold text-white">{`${minutes} 분`}</span>

--- a/src/assets/icons/route/vertical/verticalBusIcon.tsx
+++ b/src/assets/icons/route/vertical/verticalBusIcon.tsx
@@ -10,10 +10,10 @@ export const VerticalTransitIcon = ({
   showLine = true,
 }: VerticalTransitIconProps) => {
   return (
-    <div className="flex flex-col items-center">
+    <div className="flex h-full flex-col items-center">
       {/* 아이콘 원 */}
       <div
-        className="flex h-6 w-6 items-center justify-center rounded-full"
+        className="flex h-[var(--icon-size)] w-[var(--icon-size)] items-center justify-center rounded-full"
         style={{ backgroundColor: color }}
       >
         <svg
@@ -29,22 +29,6 @@ export const VerticalTransitIcon = ({
           />
         </svg>
       </div>
-
-      {/* 점선 */}
-      {showLine && (
-        <div className="my-1 flex flex-col items-center">
-          <span className="h-1 w-1 rounded-full bg-greyscale-grey-300" />
-          <span className="h-1 w-1 rounded-full bg-greyscale-grey-300" />
-          <span className="h-1 w-1 rounded-full bg-greyscale-grey-300" />
-        </div>
-      )}
-
-      {/* 분 배지 */}
-      {typeof minutes === "number" && (
-        <div className="rounded-full px-1 py-[1px]" style={{ backgroundColor: color }}>
-          <span className="text-xs font-semibold text-white"></span>
-        </div>
-      )}
     </div>
   );
 };

--- a/src/assets/icons/route/vertical/verticalSubWayIcon.tsx
+++ b/src/assets/icons/route/vertical/verticalSubWayIcon.tsx
@@ -10,10 +10,10 @@ export const VerticalSubWayIcon = ({
   showLine = true,
 }: VerticalTransitIconProps) => {
   return (
-    <div className="flex flex-col items-center">
+    <div className="flex h-full flex-col items-center">
       {/* 아이콘 원 */}
       <div
-        className="flex h-6 w-6 items-center justify-center rounded-full"
+        className="flex h-[var(--icon-size)] w-[var(--icon-size)] items-center justify-center rounded-full"
         style={{ backgroundColor: color }}
       >
         <svg
@@ -40,11 +40,14 @@ export const VerticalSubWayIcon = ({
       )}
 
       {/* 분 배지 */}
-      {typeof minutes === "number" && (
-        <div className="rounded-full px-1 py-[1px]" style={{ backgroundColor: color }}>
-          <span className="text-xs font-semibold text-white"></span>
+      {/* {typeof minutes === "number" && (
+        <div
+          className="h-full rounded-tl-sm rounded-tr-sm px-1 py-[1px]"
+          style={{ backgroundColor: color }}
+        >
+          <div className="h-full w-[1px] text-white"></div>
         </div>
-      )}
+      )} */}
     </div>
   );
 };

--- a/src/assets/icons/route/vertical/verticalWalkIcon.tsx
+++ b/src/assets/icons/route/vertical/verticalWalkIcon.tsx
@@ -6,10 +6,10 @@ interface VerticalTransitIconProps {
 
 export const VerticalWalkIcon = ({ color, minutes, showLine = true }: VerticalTransitIconProps) => {
   return (
-    <div className="flex flex-col items-center">
+    <div className="flex h-full flex-col items-center">
       {/* 아이콘 원 */}
       <div
-        className="flex h-6 w-6 items-center justify-center rounded-full"
+        className="flex h-[var(--icon-size)] w-[var(--icon-size)] items-center justify-center rounded-full"
         style={{ backgroundColor: color }}
       >
         <svg
@@ -67,11 +67,11 @@ export const VerticalWalkIcon = ({ color, minutes, showLine = true }: VerticalTr
       )}
 
       {/* 분 배지 */}
-      {typeof minutes === "number" && (
-        <div className="rounded-full px-1 py-[1px]" style={{ backgroundColor: color }}>
-          <span className="text-xs font-semibold text-white"></span>
+      {/* {typeof minutes === "number" && (
+        <div className="h-full rounded-full px-1 py-[1px]" style={{ backgroundColor: color }}>
+          <div className="h-full w-[1px] text-white"></div>
         </div>
-      )}
+      )} */}
     </div>
   );
 };

--- a/src/assets/icons/route/walkl.tsx
+++ b/src/assets/icons/route/walkl.tsx
@@ -3,7 +3,6 @@ import { SVGProps } from "react";
 export const WalkIcon = ({
   color = "black",
   minutes = 0,
-
   ...props
 }: SVGProps<SVGSVGElement> & { color?: string; minutes: number }) => {
   return (
@@ -15,7 +14,7 @@ export const WalkIcon = ({
         <svg
           width="12"
           height="12"
-          viewBox="0 0 12 12"
+          viewBox="0 0 14 14"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
         >

--- a/src/features/listings/model/filterPanelModel.tsx
+++ b/src/features/listings/model/filterPanelModel.tsx
@@ -335,8 +335,8 @@ export interface RoomTypeTitleDes {
  */
 export const ROOM_TYPE_TITLE_DES: RoomTypeTitleDes = {
   route: {
-    title: "노선정보",
-    des: "알수없음",
+    title: "주요 노선",
+    des: "노선정보를 확인해보세요.",
   },
   infra: {
     title: "주변환경 정보",

--- a/src/features/listings/ui/listingsCardDetail/infra/infraSheet.tsx
+++ b/src/features/listings/ui/listingsCardDetail/infra/infraSheet.tsx
@@ -56,7 +56,7 @@ export const InfraSheet = ({ onClose, sheetState }: InfraSheetProps) => {
             exit={{ y: "100%" }}
             transition={{ type: "spring", stiffness: 260, damping: 30 }}
           >
-            <section className="flex h-full flex-col">
+            <section className="flex flex-col">
               <header className="flex items-center justify-between border-b border-greyscale-grey-50 p-5">
                 <div className="w-full">
                   <div className="flex w-full items-center justify-between">


### PR DESCRIPTION
<!--- Pull Request title = 커밋 메시지와 동일/ 해당 이슈를 close 하지 않을 경우, footer #이슈 번호 제외  -->

## #️⃣ Issue Number
#140 

<br/>
<br/>

## 📝 요약(Summary) (선택)

### ModeIcon 분기 명시
- before: return <VerticalSubWayIcon ... /> (기본 반환)
- after: if (type === 'SUBWAY') return <VerticalSubWayIcon ... />
- 타임라인 컨테이너에 CSS 변수(clamp) 도입

추가:
--icon-size: clamp(20px, 5vw, 28px)
--line-w: clamp(2px, 0.6vw, 3px)
--item-gap: clamp(18px, 4.5vw, 28px)
--col-gap: clamp(8px, 2.5vw, 14px)

### 예시:
- <ul className="flex-1 overflow-y-auto p-5" style={{ ['--icon-size' as any]: 'clamp(...)', ... }}>
- 핀포인트 주소 아이템 구조/라인 수정

- 왼쪽 컬럼 고정폭 → 변수 기반: w-[var(--icon-size)]
- 점선 위치/방식 변경:
- <span className="absolute -bottom-[calc(var(--item-gap)+var(--icon-size))] left-1/2 top-[var(--icon-size)] w-[var(--line-w)] -translate-x-1/2" style={{ backgroundImage: 'repeating-linear-gradient(...)' }} />
 정류장 목록 아이템 구조/라인 수정

### li 간격/컬럼 폭: className="relative flex gap-[var(--col-gap)] pb-[var(--item-gap)]"
- 왼쪽 컬럼: className="relative z-[1] flex w-[var(--icon-size)] justify-center"
- 세로선(다음 아이템과 연결):
- <span className="absolute -bottom-[22] left-1/2 top-[var(--icon-size)] w-[var(--line-w)] -translate-x-1/2" style={{ - backgroundColor: String(color) }} />

<br/>
<br/>

## 📸스크린샷 (선택)2

<img width="402" height="499" alt="image" src="https://github.com/user-attachments/assets/1e38089f-d2b2-41cc-9e08-4dcbd2755c8d" />
<br/>
<br/>

