### PR TITLE
style:해당 단지 노선도착 지점 그라데이션 추가

### DIFF
--- a/src/assets/icons/route/vertical/verticalBusIcon.tsx
+++ b/src/assets/icons/route/vertical/verticalBusIcon.tsx
@@ -19,7 +19,7 @@ export const VerticalTransitIcon = ({
         <svg
           width="14"
           height="14"
-          viewBox="0 0 11 11"
+          viewBox="0 0 10 11"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
         >

--- a/src/assets/icons/route/vertical/verticalSubWayIcon.tsx
+++ b/src/assets/icons/route/vertical/verticalSubWayIcon.tsx
@@ -17,9 +17,9 @@ export const VerticalSubWayIcon = ({
         style={{ backgroundColor: color }}
       >
         <svg
-          width="14"
-          height="14"
-          viewBox="0 0 14 14"
+          width="16"
+          height="16"
+          viewBox="0 0 13 14"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
         >

--- a/src/entities/listings/hooks/useListingDetailHooks.ts
+++ b/src/entities/listings/hooks/useListingDetailHooks.ts
@@ -155,6 +155,8 @@ export const useListingRouteDetail = <T, TParam extends object>({
         { query: params }
       ),
 
-    select: response => response.data ?? [],
+    select: response => {
+      return response.data ?? [];
+    },
   });
 };

--- a/src/features/listings/ui/listingsCardDetail/infra/components/components/routeType/routeSegmentBar.tsx
+++ b/src/features/listings/ui/listingsCardDetail/infra/components/components/routeType/routeSegmentBar.tsx
@@ -1,0 +1,3 @@
+export const RouteSegmentBar = () => {
+  return;
+};

--- a/src/features/listings/ui/listingsCardDetail/infra/components/routeDetail.tsx
+++ b/src/features/listings/ui/listingsCardDetail/infra/components/routeDetail.tsx
@@ -42,7 +42,7 @@ export const RouteDetail = ({ listingId }: { listingId: string }) => {
 
   const totalMinutes = useMemo(() => {
     if (!current) return 0;
-    if (current.totalTimeMinutes && current.totalTimeMinutes > 0) return current.totalTimeMinutes;
+    if (current.totalTimeMinutes > 0) return current.totalTimeMinutes;
     return (current.routes ?? []).reduce((sum, r) => sum + (parseMinutes(r.minutesText) || 0), 0);
   }, [current]);
 
@@ -176,18 +176,22 @@ export const RouteDetail = ({ listingId }: { listingId: string }) => {
                 {/* 세로선 (왼쪽 컬럼 기준) */}
                 {!isLast && (
                   <span
-                    className="absolute -bottom-[22] left-1/2 top-[var(--icon-size)] w-[var(--line-w)] -translate-x-1/2"
-                    style={{ backgroundColor: String(color) }}
+                    className="absolute -bottom-[calc(var(--item-gap)+var(--line-extend))] left-1/2 top-[var(--icon-size)] w-[var(--line-w)] -translate-x-1/2"
+                    style={
+                      {
+                        "--line-extend": "10px",
+                        backgroundColor: String(color),
+                      } as React.CSSProperties
+                    }
                   />
                 )}
                 {s.role !== "ARRIVAL" ? (
                   <ModeIcon type={s.type} color={String(color)} minutes={0} />
                 ) : (
-                  <span className="mt-1 flex h-3 w-3 rounded-full bg-primary-blue-400" />
+                  <span className="relative mt-1.5 flex h-2 w-2 rounded-full bg-primary-blue-400 after:absolute after:inset-[-6px] after:-z-10 after:animate-glowBlink after:rounded-full after:bg-primary-blue-400 after:opacity-20 after:blur-sm after:content-['']" />
                 )}
               </div>
 
-              {/* 오른쪽 콘텐츠 */}
               <div className="h-full flex-1">
                 <p className="flex gap-1 text-sm font-medium text-text-primary">
                   {s.stopName}

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -195,12 +195,18 @@ export default {
             opacity: "1",
           },
         },
+        glowBlink: {
+          "0%": { opacity: "0.2" },
+          "50%": { opacity: "0.7" },
+          "100%": { opacity: "0.2" },
+        },
       },
       animation: {
         logoBounce: "logoBounce 1.5s ease-in-out infinite",
         logoPop: "logoPop 0.8s ease-in-out",
         leftMove: "slideOutLeft 0.4s ease-in-out forwards",
         rightMove: "slideInRight 0.4s ease-in-out forwards",
+        glowBlink: "glowBlink 1s ease-in-out infinite",
       },
       borderRadius: {
         lg: "var(--radius)",


### PR DESCRIPTION

## #️⃣ Issue Number

#142 

<br/>
<br/>

## 📝 요약(Summary) (선택)

- RouteSegmentBar: 새 컴포넌트 파일이 추가됐지만 현재는 더미(return;)만 존재하며 실제 구간 막대 UI가 비어있는 상태입니다 
- RouteDetail: 총 소요 시간 계산 시 totalTimeMinutes 존재 여부 체크를 단순화했고, 정류장 타임라인의 연결선 길이를 CSS 변수(--line-- - -- extend)로 조정하면서 도착 지점은 작은 점과 glowBlink 애니메이션이 들어간 하이라이트로 변경됐습니다 
- VerticalTransitIcon(버스): SVG viewBox를 0 0 10 11로 맞춰서 실제 아이콘이 원 안에서 잘리지 않도록 수정했습니다 
- VerticalSubWayIcon: 지하철 아이콘의 width/height를 16으로 키우고 viewBox를 0 0 13 14로 조정해 비율을 맞췄습니다 
- useListingRouteDetail 훅: select를 중괄호 블록으로 바꿔 추후 추가 로직을 넣을 수 있게 정리하면서도 기본적으로 response.data ?? []를 반
### glowBlink 애니메이션 리소스: RouteDetail의 도착 지점 강조를 위해 Tailwind 설정에 glowBlink 키프레임과 애니메이션 유틸을 추가했습니다 
- (tailwind.config.mjs (lines 198-210)).

<br/>
<br/>

## 📸스크린샷 (선택)2

<img width="384" height="410" alt="스크린샷 2025-12-19 오후 6 17 37" src="https://github.com/user-attachments/assets/2d18cd81-56a2-4348-a6a1-734f8c03cb49" />
