### PR TITLE
feat:공고상세 정보 필터 UX/UI

### DIFF
--- a/app/listings/[id]/layout.tsx
+++ b/app/listings/[id]/layout.tsx
@@ -1,0 +1,10 @@
+import { DetailFilterSheet } from "@/src/features/listings/index.server";
+
+export default function ListingsDetailLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      {children}
+      <DetailFilterSheet />
+    </>
+  );
+}

--- a/app/listings/[id]/page.tsx
+++ b/app/listings/[id]/page.tsx
@@ -1,5 +1,7 @@
 import { ListingsCardDetailSection } from "@/src/widgets/listingsSection";
 
-export default function Page({ params }: { params: { id: string } }) {
-  return <ListingsCardDetailSection id={params.id} />;
+export default async function Page({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+
+  return <ListingsCardDetailSection id={id} />;
 }

--- a/src/entities/listings/model/type.ts
+++ b/src/entities/listings/model/type.ts
@@ -155,6 +155,7 @@ export interface ListingsContentHeaderProps {
 // 사용처: 전체 필터 시트 상태 (Zustand)
 export interface FilterSheetState {
   open: boolean;
+
   openSheet: () => void;
   closeSheet: () => void;
 }

--- a/src/features/listings/index.server.ts
+++ b/src/features/listings/index.server.ts
@@ -1,0 +1,1 @@
+export * from "./ui/listingsCardDetail/components/DetailSectionFilter/DetailFilterSheet";

--- a/src/features/listings/model/listingsModel.ts
+++ b/src/features/listings/model/listingsModel.ts
@@ -262,7 +262,10 @@ export const FILTER_TABS = [
   { key: "rental", label: "임대유형" },
   { key: "housing", label: "주택유형" },
 ] as const;
-
+// 사용처: 필터 탭 현재값 타입
+// - listingsFullSheet.tsx: 탭 전환/쿼리 파라미터 처리
+// - listingsHooks.tsx: getIndicatorLeft/Width 인자 타입
+export type FilterTabKey = (typeof FILTER_TABS)[number]["key"];
 // 사용처: 탭별 섹션/라벨 구성 (listingsFullSheet.tsx)
 export const TAB_CONFIG: Record<FilterTabKey, { sections: SectionMap; labels: SectionLabelMap }> = {
   region: {
@@ -283,17 +286,23 @@ export const TAB_CONFIG: Record<FilterTabKey, { sections: SectionMap; labels: Se
   },
 };
 
-// 사용처: 필터 탭 현재값 타입
-// - listingsFullSheet.tsx: 탭 전환/쿼리 파라미터 처리
-// - listingsHooks.tsx: getIndicatorLeft/Width 인자 타입
-export type FilterTabKey = (typeof FILTER_TABS)[number]["key"];
 export const DETAIL_FILTERS = [
-  { key: "distance", label: "거리" },
-  { key: "region", label: "지역" },
-  { key: "cost", label: "비용" },
-  { key: "area", label: "면적" },
-  { key: "around", label: "주변" },
+  { key: "distance", label: "거리", isDefault: true },
+  { key: "region", label: "지역", isDefault: false },
+  { key: "cost", label: "비용", isDefault: false },
+  { key: "area", label: "면적", isDefault: false },
+  { key: "around", label: "주변", isDefault: false },
 ] as const;
+
+export type DetailFilterTabKey = (typeof DETAIL_FILTERS)[number]["key"];
+export const DEFAULT_DETAIL_SECTION = DETAIL_FILTERS.find(f => f.isDefault)?.key ?? "distance";
+
+export const parseDetailSection = (searchParams: URLSearchParams): DetailFilterTabKey => {
+  const raw = searchParams.get("section");
+  if (!raw) return DEFAULT_DETAIL_SECTION;
+  const isValid = DETAIL_FILTERS.some(f => f.key === raw);
+  return isValid ? (raw as DetailFilterTabKey) : DEFAULT_DETAIL_SECTION;
+};
 
 // 사용처: 검색 결과가 없을 때/빈 검색어 화면에서 추천 태그 클릭 핸들러와 인기 키워드 전달
 // - listingsSearchResult/components/searchNoResultView.tsx

--- a/src/features/listings/model/listingsStore.ts
+++ b/src/features/listings/model/listingsStore.ts
@@ -27,6 +27,12 @@ export const useFilterSheetStore = create<FilterSheetState>(set => ({
   closeSheet: () => set({ open: false }),
 }));
 
+export const useDetailFilterSheetStore = create<FilterSheetState>(set => ({
+  open: false,
+  openSheet: () => set({ open: true }),
+  closeSheet: () => set({ open: false }),
+}));
+
 // 사용처: 필터 바/시트에서 선택한 값 저장 및 토글 (listingsFullSheet.tsx, listingsFilterPanel.tsx, useListingHooks.ts)
 export const useListingsFilterStore = create<ListingsFilterState>(set => ({
   regionType: [],

--- a/src/features/listings/ui/listingsButton/listingsTagButton.tsx
+++ b/src/features/listings/ui/listingsButton/listingsTagButton.tsx
@@ -1,6 +1,5 @@
 "use client";
 import { DownButton } from "@/src/assets/icons/button";
-import { FilterOption } from "@/src/entities/listings/model/type";
 import { TagButton } from "@/src/shared/ui/button/tagButton";
 import { useFilterSheetStore } from "../../model";
 import { useRouter } from "next/navigation";
@@ -10,12 +9,20 @@ type BaseLabel = {
   label: string;
 };
 
-export const ListingTagButton = ({ label, count }: { label: BaseLabel; count: number | null }) => {
+export const ListingTagButton = ({
+  label,
+  count,
+  param,
+}: {
+  label: BaseLabel;
+  count: number | null;
+  param: string;
+}) => {
   const openSheet = useFilterSheetStore(state => state.openSheet);
   const router = useRouter();
 
   const handleClick = async () => {
-    await router.push(`/listings?tab=${label.key}`, { scroll: false });
+    await router.push(`/listings?${param}=${label.key}`, { scroll: false });
 
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {

--- a/src/features/listings/ui/listingsCardDetail/components/DetailSectionFilter/DetailFilterSheet.tsx
+++ b/src/features/listings/ui/listingsCardDetail/components/DetailSectionFilter/DetailFilterSheet.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { AnimatePresence, motion } from "framer-motion";
+import { useSearchParams } from "next/navigation";
+import { useDetailFilterSheetStore } from "@/src/features/listings/model";
+import { DetailFilterTab } from "./DetailFilterTab";
+import { parseDetailSection } from "@/src/features/listings/model";
+
+export const DetailFilterSheet = () => {
+  const open = useDetailFilterSheetStore(s => s.open);
+  const closeSheet = useDetailFilterSheetStore(s => s.closeSheet);
+  const searchParams = useSearchParams();
+  const section = parseDetailSection(searchParams);
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <>
+          <motion.div
+            className="fixed inset-0 z-40 bg-black/40"
+            onClick={closeSheet}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+          />
+
+          <motion.div
+            className="fixed bottom-0 left-0 right-0 z-50 flex h-[95vh] flex-col rounded-t-2xl bg-white shadow-xl"
+            initial={{ y: "100%" }}
+            animate={{ y: 0 }}
+            exit={{ y: "100%" }}
+            transition={{ type: "spring", stiffness: 260, damping: 30 }}
+          >
+            <div className="mx-auto mb-3 mt-2 h-1.5 w-12 rounded-full bg-gray-300" />
+
+            <div className="flex items-center justify-between px-5 pb-2">
+              <h2 className="text-sm font-bold">단지 필터</h2>
+              <button onClick={closeSheet}>✕</button>
+            </div>
+
+            {/* 전체 필터 탭 (항상 표시) */}
+            <DetailFilterTab />
+
+            {/* section별 콘텐츠 */}
+            <div className="flex-1 overflow-y-auto px-5 py-5">
+              {/* {section === "distance" && <DistanceFilter />}
+              {section === "region" && <RegionFilter />}
+              {section === "cost" && <CostFilter />}
+              {section === "area" && <AreaFilter />}
+              {section === "around" && <AroundFilter />} */}
+            </div>
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  );
+};

--- a/src/features/listings/ui/listingsCardDetail/components/DetailSectionFilter/DetailFilterTab.tsx
+++ b/src/features/listings/ui/listingsCardDetail/components/DetailSectionFilter/DetailFilterTab.tsx
@@ -1,0 +1,45 @@
+import { DETAIL_FILTERS, DetailFilterTabKey } from "@/src/features/listings/model";
+import { useRouter, useSearchParams } from "next/navigation";
+
+import { motion, AnimatePresence } from "framer-motion";
+import { getIndicatorLeft, getIndicatorWidth } from "@/src/features/listings/hooks/listingsHooks";
+
+export const DetailFilterTab = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const currentTab = (searchParams.get("section") as DetailFilterTabKey) || "region";
+
+  const changeTab = (tab: DetailFilterTabKey) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("section", tab);
+    router.push(`?${params.toString()}`, { scroll: false });
+  };
+
+  return (
+    <div className="relative border-b">
+      <div className="relative flex gap-6 px-5 pt-3 text-sm font-medium">
+        {DETAIL_FILTERS.map(tab => (
+          <button
+            key={tab.key}
+            onClick={() => changeTab(tab.key)}
+            className={
+              currentTab === tab.key ? "p-1 font-bold text-text-primary" : "p-1 text-gray-500"
+            }
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      {/* <motion.div
+        layoutId="activeUnderline"
+        className="absolute bottom-0 h-[2px] bg-button-primary"
+        initial={false}
+        animate={{
+          left: `${getIndicatorLeft(currentTab)}px`,
+          width: `${getIndicatorWidth(currentTab)}px`,
+        }}
+        transition={{ type: "spring", stiffness: 300, damping: 30 }}
+      /> */}
+    </div>
+  );
+};

--- a/src/features/listings/ui/listingsCardDetail/components/listingsCardDetailFilterBar.tsx
+++ b/src/features/listings/ui/listingsCardDetail/components/listingsCardDetailFilterBar.tsx
@@ -1,16 +1,58 @@
+import { useRouter, useSearchParams } from "next/navigation";
+import {
+  DEFAULT_DETAIL_SECTION,
+  DETAIL_FILTERS,
+  getAllFilterIcon,
+  useDetailFilterSheetStore,
+} from "../../../model";
+
 import { TagButton } from "@/src/shared/ui/button/tagButton";
-import { DETAIL_FILTERS, getAllFilterIcon } from "../../../model";
-import { ListingTagButton } from "../../listingsButton/listingsTagButton";
+import { DownButton } from "@/src/assets/icons/button";
 
 export const ListingsCardDetailFilterBar = () => {
+  const router = useRouter();
+  const openSheet = useDetailFilterSheetStore(state => state.openSheet);
+  const searchParams = useSearchParams();
+
+  const onOpenAllFilters = () => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (!params.get("section")) {
+      params.set("section", DEFAULT_DETAIL_SECTION);
+    }
+    router.push(`?${params.toString()}`, { scroll: false });
+    openSheet();
+  };
+
+  const onSelectSection = (key: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("section", key);
+    router.push(`?${params.toString()}`, { scroll: false });
+    openSheet();
+  };
+
   return (
     <section className="overflow-x-auto border-greyscale-grey-75 py-3 scrollbar-hide">
       <div className="flex min-w-max items-center gap-2 border-y border-b-[11px] border-y-gray-200 border-b-greyscale-grey-25 pb-2 pl-5 pr-5 pt-2">
-        {getAllFilterIcon(false)}
+        <div className="flex-shrink-0" onClick={onOpenAllFilters}>
+          {getAllFilterIcon(false)}
+        </div>
+
         {DETAIL_FILTERS.map(item => (
-          <div key={item.key} className="flex-shrink-0">
-            <ListingTagButton label={item} count={null} />
-          </div>
+          <TagButton
+            key={item.key}
+            size="sm"
+            variant={"ghost"}
+            className="h-9 gap-1 rounded-3xl"
+            onClick={() => onSelectSection(item.key)}
+          >
+            <div className="flex gap-1 text-sm font-bold text-gray-500">
+              <p>{item.label}</p>
+              {/* <p className="text-text-brand">{count === 0 ? null : count}</p> */}
+            </div>
+            <div className="mr-[-5px] flex shrink-0">
+              <DownButton className="h-5 w-4" />
+            </div>
+          </TagButton>
         ))}
       </div>
     </section>

--- a/src/features/listings/ui/listingsFilter/listingsFilterPanel.tsx
+++ b/src/features/listings/ui/listingsFilter/listingsFilterPanel.tsx
@@ -35,7 +35,7 @@ export const ListingFilterPanel = () => {
               const count = selectedValues.length;
               return (
                 <div key={item.key} className="flex-shrink-0">
-                  <ListingTagButton label={item} count={count} />
+                  <ListingTagButton label={item} count={count} param={"tab"} />
                 </div>
               );
             })}

--- a/src/features/listings/ui/listingsFullSheet/listingsFullSheet.tsx
+++ b/src/features/listings/ui/listingsFullSheet/listingsFullSheet.tsx
@@ -11,6 +11,7 @@ import { useListingListInfiniteQuery } from "@/src/entities/listings/hooks/useLi
 export const ListingFilterPartialSheet = () => {
   const open = useFilterSheetStore(s => s.open);
   const closeSheet = useFilterSheetStore(s => s.closeSheet);
+
   const router = useRouter();
   const searchParams = useSearchParams();
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -117,6 +118,7 @@ export const ListingFilterPartialSheet = () => {
 const ListingSheet = () => {
   const searchParams = useSearchParams();
   const currentTab = (searchParams.get("tab") as FilterTabKey) || "region";
+  const tabConfig = currentTab ? TAB_CONFIG[currentTab] : null;
 
   const regionType = useListingsFilterStore(s => s.regionType);
   const rentalTypes = useListingsFilterStore(s => s.rentalTypes);
@@ -127,7 +129,9 @@ const ListingSheet = () => {
   const toggleRental = useListingsFilterStore(s => s.toggleRentalType);
   const toggleSupply = useListingsFilterStore(s => s.toggleSupplyType);
   const toggleHouse = useListingsFilterStore(s => s.toggleHouseType);
-
+  if (!tabConfig) {
+    return null;
+  }
   const { sections, labels } = TAB_CONFIG[currentTab];
 
   const isSelected = (name: string) => {
@@ -205,6 +209,7 @@ const Tag = ({
 const UseCheckBox = () => {
   const searchParams = useSearchParams();
   const currentTab = (searchParams.get("tab") as FilterTabKey) || "region";
+  const tabConfig = currentTab ? TAB_CONFIG[currentTab] : null;
   const regionType = useListingsFilterStore(s => s.regionType);
   const rentalTypes = useListingsFilterStore(s => s.rentalTypes);
   const supplyTypes = useListingsFilterStore(s => s.supplyTypes);
@@ -219,6 +224,9 @@ const UseCheckBox = () => {
   const resetSupplyTypes = useListingsFilterStore(s => s.resetSupplyTypes);
   const resetHouseTypes = useListingsFilterStore(s => s.resetHouseTypes);
 
+  if (!tabConfig) {
+    return null;
+  }
   const { sections } = TAB_CONFIG[currentTab];
   const totalItems = Object.values(sections)
     .flat()


### PR DESCRIPTION
<!--- Pull Request title = 커밋 메시지와 동일/ 해당 이슈를 close 하지 않을 경우, footer #이슈 번호 제외  -->

## #️⃣ Issue Number

#144 

<br/>
<br/>

## 📝 요약(Summary) (선택)

- Page: 서버 컴포넌트를 async로 바꿔서 params 프로미스를 먼저 await한 뒤 ListingsCardDetailSection에 id를 넘깁니다.
ListingsDetailLayout: 상세 페이지 전용 레이아웃을 새로 만들어 모든 자식 페이지 위에 DetailFilterSheet를 항상 렌더링하고, 개별 페이지마다 시트를 따로 두지 않음
- DetailFilterSheet: 새 클라이언트 시트 컴포넌트로, useDetailFilterSheetStore 상태에 따라 프레이머 모션으로 등장/퇴장하고, URL section 값을 parseDetailSection으로 읽어 탭/콘텐츠를 동기화하며, 내부에 DetailFilterTab과 본문 영역을 제공합니다.
DetailFilterTab: 상세 필터용 탭 헤더로, router.push("?section=...")로 쿼리를 갱신하고 현재 탭을 강조(향후 밑줄 애니메이션을 위해 코드 주석 포함)합니다.
- ListingsCardDetailFilterBar: 기존 ListingTagButton 대신 직접 TagButton들을 렌더링하고, 현 쿼리스트링을 기반으로 section만 갱신한 뒤 시트 스토어 openSheet를 호출해 목록 페이지로 이동하지 않고 상세 페이지에서 시트를 엽니다.
- ListingTagButton: param prop을 새로 받아 클릭 시 /listings?${param}=${label.key} 형태로 원하는 쿼리 키만 바꾸고, 이후 시트를 열도록 확장했습니다.
- ListingFilterPanel: 위 변경에 맞춰 ListingTagButton 호출 시 param="tab"을 넘겨 기존 동작을 유지합니다.
- ListingFilterPartialSheet: 훅과 라우터 설정 사이에 구분 줄을 추가한 것뿐이라 동작은 같습니다.
- ListingSheet: TAB_CONFIG[currentTab]가 없는 경우(잘못된 tab 쿼리) 바로 null을 반환해 구조 분해 오류를 막고, 정상일 때만 sections/labels를 사용합니다.
- UseCheckBox: 위와 같은 tabConfig 검증을 추가해 존재하지 않는 탭일 때 전체 선택 로직이 실행되지 않도록 했습니다.
<br/>
<br/>

## 📸스크린샷 (선택)2
<img width="433" height="827" alt="스크린샷 2025-12-19 오후 10 42 25" src="https://github.com/user-attachments/assets/3325bfb6-7403-4b1b-bbba-06081a842a58" />

<br/>
<br/>


