### PR TITLE
refactor:공고리스트 필터 함수 분리작업

### DIFF
--- a/src/features/listings/ui/listingsCardDetail/components/DetailSectionFilter/DetailFilterTab.tsx
+++ b/src/features/listings/ui/listingsCardDetail/components/DetailSectionFilter/DetailFilterTab.tsx
@@ -1,6 +1,5 @@
 import { DETAIL_FILTERS, DetailFilterTabKey } from "@/src/features/listings/model";
 import { useRouter, useSearchParams } from "next/navigation";
-
 import { motion, AnimatePresence } from "framer-motion";
 import { getIndicatorLeft, getIndicatorWidth } from "@/src/features/listings/hooks/listingsHooks";
 

--- a/src/features/listings/ui/listingsFullSheet/listingsFullSheet.tsx
+++ b/src/features/listings/ui/listingsFullSheet/listingsFullSheet.tsx
@@ -11,7 +11,6 @@ import { useListingListInfiniteQuery } from "@/src/entities/listings/hooks/useLi
 export const ListingFilterPartialSheet = () => {
   const open = useFilterSheetStore(s => s.open);
   const closeSheet = useFilterSheetStore(s => s.closeSheet);
-
   const router = useRouter();
   const searchParams = useSearchParams();
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -53,63 +52,16 @@ export const ListingFilterPartialSheet = () => {
   return (
     <AnimatePresence>
       {open && (
-        <>
-          <motion.div
-            className="fixed inset-0 z-40 bg-black/40"
-            onClick={handleCloseSheet}
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-          />
-
-          <motion.div
-            className="fixed bottom-0 left-0 right-0 z-50 flex h-[95vh] flex-col rounded-t-2xl bg-white shadow-xl"
-            initial={{ y: "100%" }}
-            animate={{ y: 0 }}
-            exit={{ y: "100%" }}
-            transition={{ type: "spring", stiffness: 260, damping: 30 }}
-          >
-            <div className="mx-auto mb-3 mt-2 h-1.5 w-12 rounded-full bg-gray-300" />
-
-            <div className="flex items-center justify-between px-5 pb-2">
-              <h2 className="text-sm font-bold">공고 필터</h2>
-              <button onClick={handleCloseSheet} className="text-xl font-bold">
-                <CloseButton />
-              </button>
+        <FilterSheetContainer onDismiss={handleCloseSheet}>
+          <FilterSheetHeader onClose={handleCloseSheet} />
+          <FilterSheetContent scrollRef={scrollRef} onScroll={handleScroll} isAtBottom={isAtBottom}>
+            <div className="space-y-6">
+              <UseCheckBox />
+              <ListingSheet />
             </div>
-            <ListingTab />
-
-            <div className="relative flex-1 overflow-hidden">
-              <div
-                ref={scrollRef}
-                onScroll={handleScroll}
-                className="no-scrollbar h-full overflow-y-auto px-5 py-5"
-              >
-                <div className="space-y-6">
-                  <UseCheckBox />
-                  <ListingSheet />
-                </div>
-              </div>
-              <div
-                className={`pointer-events-none absolute inset-x-0 bottom-0 z-10 bg-gradient-to-t from-white to-transparent transition-all duration-300 ${
-                  isAtBottom ? "h-0 opacity-0" : "h-16 opacity-100"
-                }`}
-              />
-            </div>
-
-            <div className="p-5">
-              <button
-                className="w-full rounded-lg bg-button-primary py-3 font-semibold text-white"
-                onClick={handleCloseSheet}
-              >
-                <span className="flex justify-center gap-1 transition-none">
-                  <p className="text-center">{displayTotal}</p>
-                  <p>개의 공고가 있어요</p>
-                </span>
-              </button>
-            </div>
-          </motion.div>
-        </>
+          </FilterSheetContent>
+          <FilterSheetFooter total={displayTotal} onApply={handleCloseSheet} />
+        </FilterSheetContainer>
       )}
     </AnimatePresence>
   );
@@ -310,6 +262,104 @@ const ListingTab = () => {
         }}
         transition={{ type: "spring", stiffness: 300, damping: 30 }}
       />
+    </div>
+  );
+};
+
+const FilterSheetContainer = ({
+  onDismiss,
+  children,
+}: {
+  onDismiss: () => void;
+  children: React.ReactNode;
+}) => {
+  return (
+    <>
+      <motion.div
+        className="fixed inset-0 z-40 bg-black/40"
+        onClick={onDismiss}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+      />
+
+      <motion.div
+        className="fixed bottom-0 left-0 right-0 z-50 flex h-[95vh] flex-col rounded-t-2xl bg-white shadow-xl"
+        initial={{ y: "100%" }}
+        animate={{ y: 0 }}
+        exit={{ y: "100%" }}
+        transition={{ type: "spring", stiffness: 260, damping: 30 }}
+      >
+        {children}
+      </motion.div>
+    </>
+  );
+};
+
+const FilterSheetHeader = ({ onClose }: { onClose: () => void }) => {
+  return (
+    <>
+      <div className="mx-auto mb-3 mt-2 h-1.5 w-12 rounded-full bg-gray-300" />
+
+      <div className="flex items-center justify-between px-5 pb-2">
+        <h2 className="text-sm font-bold">공고 필터</h2>
+        <button onClick={onClose} className="text-xl font-bold">
+          <CloseButton />
+        </button>
+      </div>
+
+      <ListingTab />
+    </>
+  );
+};
+
+const FilterSheetContent = ({
+  children,
+  scrollRef,
+  onScroll,
+  isAtBottom,
+}: {
+  children: React.ReactNode;
+  scrollRef: React.RefObject<HTMLDivElement | null>;
+  onScroll: () => void;
+  isAtBottom: boolean;
+}) => {
+  return (
+    <div className="relative flex-1 overflow-hidden">
+      <div
+        ref={scrollRef}
+        onScroll={onScroll}
+        className="no-scrollbar h-full overflow-y-auto px-5 py-5"
+      >
+        {children}
+      </div>
+      <div
+        className={`pointer-events-none absolute inset-x-0 bottom-0 z-10 bg-gradient-to-t from-white to-transparent transition-all duration-300 ${
+          isAtBottom ? "h-0 opacity-0" : "h-16 opacity-100"
+        }`}
+      />
+    </div>
+  );
+};
+
+const FilterSheetFooter = ({
+  total,
+  onApply,
+}: {
+  total: number | null | undefined;
+  onApply: () => void;
+}) => {
+  return (
+    <div className="p-5">
+      <button
+        className="w-full rounded-lg bg-button-primary py-3 font-semibold text-white"
+        onClick={onApply}
+      >
+        <span className="flex justify-center gap-1 transition-none">
+          <p className="text-center">{total}</p>
+          <p>개의 공고가 있어요</p>
+        </span>
+      </button>
     </div>
   );
 };


### PR DESCRIPTION
## #️⃣ Issue Number

#146 

<br/>
<br/>

## 📝 요약(Summary) (선택)

- refactor:공고리스트 필터 함수 분리작업
- DetailFilterTab: import 구문 사이 불필요한 공백을 제거해 정렬만 맞춤
- ListingFilterPartialSheet: 모달 전체 구조를 FilterSheetContainer/FilterSheetHeader/FilterSheetContent/FilterSheetFooter로 분리하면서 기존 JSX 블록을 재조립했습니다. 덕분에 오버레이·헤더·스크롤 영역·하단 CTA가 각각 독립 컴포넌트로 나뉘었고, 본문에는 이전과 동일하게 UseCheckBox와 ListingSheet를 children으로 전달

<br/>
<br/>

