### PR TITLE
feat: 로그인 후 기본 핀포인트 자동 설정 기능 추가

### DIFF
--- a/src/entities/auth/hooks/useAuthHook.ts
+++ b/src/entities/auth/hooks/useAuthHook.ts
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { http } from "@/src/shared/api/http";
 import { IResponse } from "@/src/shared/types";
 import { USER_JWT_TOKEN_VALIDATE_ENDPOINT } from "@/src/shared/api";
+import { useSetDefaultPinpoint } from "@/src/entities/pinpoint";
 
 interface IJwtTokenValidateResponse extends IResponse<boolean> {
   data: boolean;
@@ -28,6 +29,7 @@ const setAuthFailure = () => {
  */
 export const useAuthCheck = () => {
   const router = useRouter();
+  const { setDefaultPinpoint } = useSetDefaultPinpoint();
 
   useEffect(() => {
     const checkAuthStatus = async () => {
@@ -39,6 +41,15 @@ export const useAuthCheck = () => {
 
         if (response.data) {
           setAuthSuccess();
+
+          // 로그인 성공 후 기본 핀포인트 설정
+          try {
+            await setDefaultPinpoint();
+          } catch (error) {
+            console.error("❌ 기본 핀포인트 설정 실패:", error);
+            // 에러가 발생해도 로그인은 계속 진행
+          }
+
           router.push("/home");
         } else {
           setAuthFailure();
@@ -52,5 +63,5 @@ export const useAuthCheck = () => {
     };
 
     checkAuthStatus();
-  }, [router]);
+  }, [router, setDefaultPinpoint]);
 };

--- a/src/entities/pinpoint/hooks/useSetDefaultPinpoint.ts
+++ b/src/entities/pinpoint/hooks/useSetDefaultPinpoint.ts
@@ -1,0 +1,33 @@
+"use client";
+import { useCallback } from "react";
+import { getPinPoints } from "../api/pinpointApi";
+import { useOAuthStore } from "@/src/features/login/model/authStore";
+
+/**
+ * 기본 핀포인트를 가져와서 store에 저장하는 커스텀 훅
+ * @returns setDefaultPinpoint 함수
+ */
+export const useSetDefaultPinpoint = () => {
+  const { setPinPointId, pinPointId } = useOAuthStore();
+
+  const setDefaultPinpoint = useCallback(async () => {
+    try {
+      // 이미 pinPointId가 설정되어 있으면 스킵
+      if (pinPointId) {
+        return;
+      }
+
+      // 핀포인트 목록 조회
+      const pinPoints = await getPinPoints();
+
+      if (pinPoints && pinPoints.length > 0) {
+        setPinPointId(pinPoints[0].id); // 첫 번째 핀포인트를 기본값으로 설정
+      }
+    } catch (error) {
+      console.error("❌ 기본 핀포인트 설정 실패:", error);
+      throw error;
+    }
+  }, [pinPointId, setPinPointId]);
+
+  return { setDefaultPinpoint };
+};

--- a/src/entities/pinpoint/index.ts
+++ b/src/entities/pinpoint/index.ts
@@ -1,3 +1,4 @@
 export * from "./api/pinpointApi";
 export * from "./hooks/usePinPoints";
+export * from "./hooks/useSetDefaultPinpoint";
 export * from "./model/pinpoint.type";

--- a/src/features/login/model/authStore.ts
+++ b/src/features/login/model/authStore.ts
@@ -5,6 +5,8 @@ interface IOAuthState {
   tempUserId: string | null;
   setTempUserId: (userId: string) => void;
   clearTempUserId: () => void;
+  pinPointId: string;
+  setPinPointId: (pinPointId: string) => void;
 }
 
 export const useOAuthStore = create<IOAuthState>()(
@@ -13,9 +15,11 @@ export const useOAuthStore = create<IOAuthState>()(
       tempUserId: null,
       setTempUserId: (userId: string) => set({ tempUserId: userId }),
       clearTempUserId: () => set({ tempUserId: null }),
+      pinPointId: "",
+      setPinPointId: (pinPointId: string) => set({ pinPointId }),
     }),
     {
-      name: "oauth-temp-user-storage", // localStorage 키 이름
+      name: "oauth-user-storage", // localStorage 키 이름
     }
   )
 );


### PR DESCRIPTION
- useSetDefaultPinpoint 커스텀 훅 생성
  - pinpoint API 호출하여 첫 번째 핀포인트를 기본값으로 설정
- authStore에 pinPointId 필드 추가
  - localStorage 키 이름 변경 (oauth-temp-user-storage → oauth-user-storage)
- useAuthCheck에서 로그인 성공 시 기본 핀포인트 자동 설정

<!--- Pull Request title = 커밋 메시지와 동일/ 해당 이슈를 close 하지 않을 경우, footer #이슈 번호 제외  -->

## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#176 

<br/>
<br/>
