### PR TITLE
feat:공고상세/단지 필터시트 변경사항 적용

### DIFF
--- a/src/features/listings/ui/listingsCardDetail/components/DetailSectionFilter/DistanceFilter.tsx
+++ b/src/features/listings/ui/listingsCardDetail/components/DetailSectionFilter/DistanceFilter.tsx
@@ -72,7 +72,7 @@ export const DistanceFilter = () => {
         <Slider
           min={SLIDER_MIN}
           max={SLIDER_MAX}
-          step={1}
+          step={10}
           value={sliderValue}
           onValueChange={handleDistanceChange}
           labelSuffix="분"

--- a/src/features/listings/ui/listingsCardDetail/components/DetailSectionFilter/components/HistogramSlider.tsx
+++ b/src/features/listings/ui/listingsCardDetail/components/DetailSectionFilter/components/HistogramSlider.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { useMemo } from "react";
+import { RefObject } from "react";
 
 type Props = {
   minLabel?: string;
@@ -13,6 +13,7 @@ type Props = {
   handleLeftPct: number;
   normalized: number[];
   maxlength: number;
+  histogramRef: RefObject<HTMLDivElement | null>;
 };
 
 export const HistogramSlider = ({
@@ -25,11 +26,12 @@ export const HistogramSlider = ({
   handleLeftPct,
   normalized,
   maxlength,
+  histogramRef,
 }: Props) => {
   return (
     <div className="w-full">
       {/* 히스토그램 */}
-      <div className="relative h-[120px] w-full">
+      <div className="relative h-[120px] w-full" ref={histogramRef}>
         {!disabled && (
           <div
             className="absolute bottom-[100%] mb-2"
@@ -40,7 +42,6 @@ export const HistogramSlider = ({
           >
             <div className="relative rounded-md bg-black px-2 py-1 text-xs text-white">
               {deposit}
-
               {/* 말풍선 꼬리 */}
               <span className="absolute left-1/2 top-full -translate-x-1/2 border-4 border-transparent border-t-black" />
             </div>
@@ -65,15 +66,15 @@ export const HistogramSlider = ({
 
         {/* 슬라이더 핸들 */}
         <div
-          className={cn("absolute bottom-[-7px]")}
+          className={cn("absolute bottom-0")}
           style={{
             left: `${handleLeftPct}%`,
-            transform: "translateX(-50%)",
+            transform: "translate(-50%, 50%)",
           }}
         >
           <div
             className={cn(
-              "h-4 w-4 rounded-full border-2 border-blue-500 bg-white",
+              "h-[12px] w-[12px] rounded-full border-2 border-blue-500 bg-white",
               disabled ? "border-greyscale-grey-200" : "border-primary-light"
             )}
           />


### PR DESCRIPTION
## #️⃣ Issue Number

#194 

<br/>
<br/>

## 📝 요약(Summary) (선택)
### CostFilter 
- 히스토그램 정렬을 위해 useRef/useLayoutEffect로 컨테이너 실제 폭을 측정하고 gap/막대폭 보정한 handleLeftPct를 계산하도록 수정. 
- 초기 값과 단위 상수를 정리, 수동 입력 토글 로직을 비활성화했으며, 내부 패딩·입력 필드 바인딩도 새 요구사항에 맞게 조정.
### HistogramSlider 
- 부모에서 내려준 histogramRef를 받아 컨테이너에 연결, 말풍선·핸들 위치 계산을 새 퍼센트 값에 맞게 변경. 핸들 크기와 transform도 조정해서 새 좌표계와 맞춤.
### DistanceFilter 
- 범위 슬라이더가 10분 단위로만 이동하도록 step 값을 10으로 변경

<br/>
<br/>

## 📸스크린샷 (선택
<img width="62" height="174" alt="스크린샷 2025-12-29 오후 7 44 51" src="https://github.com/user-attachments/assets/649b4453-b61e-4d4d-9324-9de6aee69350" />
)2
<img width="328" height="165" alt="스크린샷 2025-12-29 오후 8 46 59" src="https://github.com/user-attachments/assets/8adc36dc-99a1-4a19-938f-5c971b89f230" />
