### PR TITLE
feat:공고상세/필터 단지/면적 API 추가

### DIFF
--- a/src/entities/listings/api/__test__/listing.test.ts
+++ b/src/entities/listings/api/__test__/listing.test.ts
@@ -8,6 +8,7 @@ import {
   requestListingList,
 } from "@/src/entities/listings/api/listingsApi";
 import {
+  AreaTypeResponse,
   DistrictResponse,
   LikeReturn,
   ListingItem,
@@ -917,29 +918,20 @@ describe("핀포인트 목록 조회", () => {
   });
 });
 
-describe("핀포인트 공고단지 지역 조회", () => {
+describe("핀포인트 공고단지 필터 시트 조회", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
-  it.skip("핀포인트 공고단지 지역 조회", async () => {
+  it("핀포인트 공고단지 필터 시트 조회", async () => {
     const mockResponse = {
-      districts: [
-        {
-          city: "경북",
-          districts: ["구미시", "김천시"],
-        },
-        {
-          city: "대구",
-          districts: ["군위군"],
-        },
-      ],
+      typeCodes: ["26", "33", "36", "39", "46", "51", "59"],
     };
 
     (http.get as jest.Mock).mockResolvedValue(mockResponse);
-    const url = `${NOTICE_ENDPOINT}/19347/filter/districts`;
-    const result = await getNoticeSheetFilter<IResponse<DistrictResponse>, DistrictResponse>(url);
+    const url = `${NOTICE_ENDPOINT}/19347/filter/area`;
+    const result = await getNoticeSheetFilter<IResponse<AreaTypeResponse>, AreaTypeResponse>(url);
 
-    expect(result?.districts).toHaveLength(2);
-    expect(result?.districts[0].city).toBe("경북");
+    expect(result?.typeCodes).toHaveLength(7);
+    expect(result?.typeCodes[0]).toBe("26");
   });
 });

--- a/src/entities/listings/model/type.ts
+++ b/src/entities/listings/model/type.ts
@@ -67,6 +67,7 @@ export interface ListingListPage {
   page: number;
 }
 
+// 사용처: 공고 목록 API 응답 타입 (requestListingList 반환)
 export type ListingItemResponse = IResponse<ListingListPage>;
 /**
  * 개별항목 공고검색
@@ -84,6 +85,7 @@ export interface ListingSearchItem {
   liked: boolean; // 좋아요 여부
 }
 
+// 사용처: 공고 리스트 카드 제네릭 데이터 (ListingContentsCard 등)
 export type ListingUnion = ListingItem | ListingSearchItem;
 
 // 사용처: UI 표준화된 카드 데이터 (filterPanelModel.tsx의 normalizeListing 반환 타입)
@@ -102,6 +104,7 @@ export interface ListingNormalized {
  */
 // 사용처: 좋아요 토글(간소 타입) — listingsHooks.tsx LikeType
 export type ListingItemMinimal = Pick<ListingItem, "id" | "liked">;
+// 사용처: listingsApi 전역 HTTP 메서드 제한 (get/post/default)
 export type HttpMethod = keyof typeof HTTP_METHODS;
 
 /**
@@ -195,6 +198,7 @@ export interface PopularKeywordResponse extends IResponse<PopularKeywordItem[]> 
   data: PopularKeywordItem[];
 }
 
+// 사용처: 필터 탭 key enum (FILTER_OPTIONS)
 export type FilterOptionKey = "region" | "target" | "rental" | "housing";
 
 // 사용처: 필터 탭 정의 — listingsModel.ts의 FILTER_OPTIONS
@@ -300,8 +304,11 @@ export interface LstingBody {
 }
 // 사용처: 임대 유형 키 타입 — RENT_COLOR_CLASS 기반 (listingsHooks.tsx)
 export type RentType = keyof typeof RENT_COLOR_CLASS;
+// 사용처: 공고 상세 API 응답 타입 (useListingDetailHooks)
 export type ListingDetailResponse = IResponse<ListingDetailData>;
+// 사용처: 상세 카드/Infra 카드 테마 구분값 (listingsCardTile.tsx)
 export type RoomVariant = "default" | "muted";
+// 사용처: listingsCardTile 컴포넌트 프롭스 및 스타일 매핑
 export type ListingsCardTileProps = {
   listing: Complex;
   variant: RoomVariant;
@@ -431,15 +438,19 @@ export interface ListingUnitType {
 }
 
 // 공통 Enum (타입 안정성 ↑)
+// 사용처: 이동 경로 상세(TransportIconRenderer, routeDetail) 아이콘 타입
 export type TransportType = "AIR" | "TRAIN" | "BUS" | "SUBWAY" | "WALK";
+// 사용처: 경로 스텝 role (출발/환승/도착) — routeDetail.tsx
 export type StopRole = "START" | "TRANSFER" | "ARRIVE";
 //Line 타입
+// 사용처: 지하철/버스 등 노선 색상/코드 정보 (routeDetail)
 export interface TransportLine {
   code: number;
   label: string;
   bgColorHex: string;
 }
 
+// 사용처: 경로 그래프 거리 정보 (routeDetail distance bar)
 export interface RouteDistance {
   colorHex: string;
   line: string | null;
@@ -448,10 +459,12 @@ export interface RouteDistance {
   type: string;
 }
 
+// 사용처: 각 스텝의 라인 표시 타입 (routeDetail)
 export interface RouteStepLine {
   line: string;
 }
 
+// 사용처: 경로 상세 Step 데이터 (routeDetail item)
 export interface RouteStep {
   action?: string | null;
   colorHex?: string | null;
@@ -464,6 +477,7 @@ export interface RouteStep {
   secondaryText: string;
 }
 
+// 사용처: 경로 요약 정보 (총 시간/거리) — routeDetail header
 export interface RouteSummary {
   displayText?: string;
   totalDistanceKm?: number;
@@ -472,6 +486,7 @@ export interface RouteSummary {
   transferCount?: number;
 }
 //이동구간
+// 사용처: routeDetail 구간 단위 데이터 묶음
 export interface RouteSegment {
   distance: RouteDistance[];
   routeIndex: number;
@@ -479,31 +494,26 @@ export interface RouteSegment {
   summary: RouteSummary[] | RouteSummary;
 }
 
-export interface RouteStop {
-  role: StopRole;
-  type: TransportType;
-  stopName: string;
-  lineText: string | null;
-  line: TransportLine | null;
-  bgColorHex: string | null;
-}
-
+// 사용처: 공고 상세 노선 데이터 응답 (useListingInfraDetail)
 export interface ListingRouteInfo {
   totalCount: number;
   routes: RouteSegment[];
 }
 
+// 사용처: 공고 상세 탭별 API (useListingDetailHooks.ts 공통 파라미터)
 export type UseListingsHooksType = {
   id: string;
   queryK: string;
   url: string;
 };
 
+// 사용처: 상세 필터/노선 등 notice 별 정적 데이터 (useListingDetailHooks.ts)
 export type UseListingsDetailHooksType = {
   queryK: string;
   url: EndPointKey;
 };
 
+// 사용처: 공고 상세 개별 API + 추가 params 필요 시 (useListingDetailHooks.ts)
 export type UseListingsHooksWithParam<TParam extends object> = {
   id: string;
   queryK: string;
@@ -511,20 +521,25 @@ export type UseListingsHooksWithParam<TParam extends object> = {
   params: TParam;
 };
 
+// 사용처: 상세 필터 시트 전용 훅 (useListingDetailNoticeSheet)
 export type UseListingsHooksWithSheet = {
   id: string;
   url: string;
 };
 
+// 사용처: 공통 request wrapper 옵션 (listingsApi.ts)
 export interface RequestOptions<TQuery extends object = object> {
   query?: TQuery;
 }
 
+// 사용처: 상세 훅 endpoint key 관리 (useListingDetailHooks.ts)
 export const endPoint = {
   pinpoint: PINPOINT_CREATE_ENDPOINT,
 } as const;
 
 type EndPointKey = keyof typeof endPoint;
+
+// 사용처: 핀포인트 목록/상세 데이터 타입 (pinpoint 관련 API)
 export interface PinPointPlace {
   id: string;
   name: string;
@@ -534,11 +549,18 @@ export interface PinPointPlace {
   isFirst: boolean;
 }
 
+// 사용처: 공고 단지 지역 응답에서 시 단위 그룹 (regionFilter/areaFilter)
 export interface DistrictGroup {
   city: string;
   districts: string[];
 }
 
+// 사용처: 상세 필터 시트 지역 API 응답 타입 (regionFilter/areaFilter)
 export interface DistrictResponse {
   districts: DistrictGroup[];
+}
+
+// 사용처: 단지 필터 시트 면적 코드 목록 (areaFilter.tsx)
+export interface AreaTypeResponse {
+  typeCodes: string[];
 }

--- a/src/features/listings/ui/listingsCardDetail/components/DetailSectionFilter/DetailFilterSheet.tsx
+++ b/src/features/listings/ui/listingsCardDetail/components/DetailSectionFilter/DetailFilterSheet.tsx
@@ -8,6 +8,7 @@ import { parseDetailSection } from "@/src/features/listings/model";
 import { DistanceFilter } from "./DistanceFilter";
 import { CostFilter } from "./components/CostFilter";
 import { RegionFilter } from "./components/regionFilter";
+import { AreaFilter } from "./components/areaFilter";
 
 export const DetailFilterSheet = () => {
   const open = useDetailFilterSheetStore(s => s.open);
@@ -57,9 +58,8 @@ export const DetailFilterSheet = () => {
                 {section === "distance" && <DistanceFilter />}
                 {section === "cost" && <CostFilter />}
                 {section === "region" && <RegionFilter />}
-
-                {/* {section === "area" && <AreaFilter />}
-              {section === "around" && <AroundFilter />} */}
+                {section === "area" && <AreaFilter />}
+                {/* {section === "around" && <AroundFilter />} */}
               </motion.div>
             </div>
           </motion.div>

--- a/src/features/listings/ui/listingsCardDetail/components/DetailSectionFilter/components/areaFilter.tsx
+++ b/src/features/listings/ui/listingsCardDetail/components/DetailSectionFilter/components/areaFilter.tsx
@@ -1,0 +1,90 @@
+import { cn } from "@/lib/utils";
+import { useListingDetailNoticeSheet } from "@/src/entities/listings/hooks/useListingDetailSheetHooks";
+import { AreaTypeResponse, DistrictResponse } from "@/src/entities/listings/model/type";
+import { REGION_CHECKBOX } from "@/src/features/listings/model";
+import { Checkbox } from "@/src/shared/lib/headlessUi/checkBox/checkbox";
+import { TagButton } from "@/src/shared/ui/button/tagButton";
+import { Spinner } from "@/src/shared/ui/spinner/default";
+import { AnimatePresence, motion } from "framer-motion";
+import { useParams } from "next/navigation";
+import { useState } from "react";
+
+export const AreaFilter = () => {
+  const { id } = useParams() as { id: string };
+  const [selectedRegions, setSelectedRegions] = useState<string[]>([]);
+
+  const { data } = useListingDetailNoticeSheet<AreaTypeResponse>({
+    id: id,
+    url: "area",
+  });
+  const typeCodes = data?.typeCodes;
+
+  const onTagValueChange = (region: string) => {
+    setSelectedRegions(prev =>
+      prev.includes(region) ? prev.filter(r => r !== region) : [...prev, region]
+    );
+  };
+
+  if (!typeCodes) return <Spinner title="지역 탐색중..." description="잠시만 기다려주세요" />;
+  return (
+    <div className="flex h-full flex-col gap-5">
+      <div className="-mx-5 border-b pb-3">
+        <div className="flex w-full gap-4 px-5">
+          {REGION_CHECKBOX.map(item => (
+            <>
+              {item.key !== "pinpoint" && (
+                <label key={item.key} className="flex cursor-pointer items-center gap-2">
+                  <Checkbox />
+                  <span className="text-sm">{item.value}</span>
+                </label>
+              )}
+            </>
+          ))}
+        </div>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {typeCodes.map((typeCode, index) => (
+          <div key={typeCode + String(index)}>
+            <div>
+              <div>
+                <Tag
+                  onClick={() => onTagValueChange(typeCode)}
+                  label={typeCode}
+                  selected={selectedRegions.includes(typeCode)}
+                />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const Tag = ({
+  label,
+  selected,
+  onClick,
+}: {
+  label: string;
+  selected: boolean;
+  onClick: () => void;
+}) => {
+  console.log(selected);
+  return (
+    <>
+      <TagButton
+        key={label}
+        size="xs"
+        variant="chipSelected"
+        className={cn(
+          "border border-greyscale-grey-100 p-3.5 text-xs font-bold text-greyscale-grey-400",
+          selected ? "bg-button-light text-text-inverse" : "bg-gray-100 text-text-secondary"
+        )}
+        onClick={onClick}
+      >
+        {label}
+      </TagButton>
+    </>
+  );
+};


### PR DESCRIPTION
## #️⃣ Issue Number

#198 

<br/>
<br/>

## 📝 요약(Summary) (선택)

변경 – RegionFilter: 지역 API 호출·선택 상태·로딩 스피너·TagButton 칩 렌더링 추가해 지역 필터 UI 전면 개편
추가 – Tag: RegionFilter에서 쓰는 칩 클릭 컴포넌트를 분리해 variant/스타일/토글 로직 캡슐화
변경 – DetailFilterSheet: 콘텐츠 영역 패딩을 p-5로 통일해 새 필터 섹션 레이아웃과 맞춤
추가 – useListingDetailNoticeSheet: 공고 상세 시트 데이터를 React Query로 가져오는 공용 훅 추가
변경 – listingsApi: http 직접 사용과 getNoticeSheetFilter 도입으로 필터 데이터 fetch 로직 정비
변경 – listing.test: 일부 테스트를 it.skip 처리하고 지역 필터 API 흐름을 검증하는 케이스 추가
변경 – type.ts: Listings 도메인 전역 타입에 사용처 주석을 촘촘히 달아 어디서 쓰이는지 명시

<br/>
<br/>

## 📸스크린샷 (선
<img width="387" height="625" alt="스크린샷 2025-12-30 오후 7 48 24" src="https://github.com/user-attachments/assets/3337f174-b8ce-4c89-9f64-ce8f318337a8" />
