### PR TITLE
feat:공고상세/단지 필터/비용 보증금직접입력 항목추가

### DIFF
--- a/src/features/listings/ui/listingsCardDetail/components/DetailSectionFilter/DetailFilterSheet.tsx
+++ b/src/features/listings/ui/listingsCardDetail/components/DetailSectionFilter/DetailFilterSheet.tsx
@@ -6,7 +6,7 @@ import { useDetailFilterSheetStore } from "@/src/features/listings/model";
 import { DetailFilterTab } from "./DetailFilterTab";
 import { parseDetailSection } from "@/src/features/listings/model";
 import { DistanceFilter } from "./DistanceFilter";
-import { CostFilter } from "./components/costFilter";
+import { CostFilter } from "./components/CostFilter";
 import { RegionFilter } from "./components/regionFilter";
 import { AreaFilter } from "./components/areaFilter";
 

--- a/src/features/listings/ui/listingsCardDetail/components/DetailSectionFilter/components/CostFilter.tsx
+++ b/src/features/listings/ui/listingsCardDetail/components/DetailSectionFilter/components/CostFilter.tsx
@@ -13,7 +13,7 @@ const DEPOSIT_MAX = 1000;
 const DEPOSIT_DEFAULT = 750;
 const DEPOSIT_STEP = 10;
 const WON_UNIT = 1;
-const GAP = 2; // px
+const GAP = 2; //px
 const INITIAL_OFFSET = 4;
 
 export const HISTOGRAM_VALUES = [
@@ -113,9 +113,24 @@ export const CostFilter = () => {
         <label className="flex items-center gap-2">
           <Checkbox checked={isManualDeposit} onCheckedChange={handleManualToggle} />
           <span className="text-sm font-medium leading-[140%] tracking-[-0.01em] text-greyscale-grey-900">
-            직접입력
+            보증금 직접입력
           </span>
         </label>
+
+        <div className="flex flex-col gap-2">
+          <Input
+            size="default"
+            variant="default"
+            value={deposit}
+            disabled={!isManualDeposit}
+            inputMode="numeric"
+            onChange={handleManualDepositChange}
+            className="text-lg font-semibold leading-[140%] tracking-[-0.01em]"
+          />
+          <p className="text-xs font-medium leading-[140%] tracking-[-0.01em] text-greyscale-grey-400">
+            {deposit}만원
+          </p>
+        </div>
       </section>
 
       <div className="mt-6 border-t border-greyscale-grey-50" />
@@ -131,7 +146,7 @@ export const CostFilter = () => {
               variant="default"
               onChange={handleManualDepositChange}
               value={manualDepositInput}
-              disabled={!isManualDeposit}
+              // disabled={!isManualDeposit}
               // inputMode="numeric"
               // type="number"
               className="text-lg font-semibold leading-[140%] tracking-[-0.01em]"


### PR DESCRIPTION
## #️⃣ Issue Number

#202 

<br/>
<br/>

## 📝 요약(Summary) (선택)

변경 - 공고상세/단지 필터/비용 보증금 직접입력 항목추가
추가 - 보증금 직접입력 체크시 항목 활성화
추가 - 보증금 직접입력 체크삭제시 항목 비활성화
추가 -상단 그래프 슬라이더 이동시 금액은 보증금 직접입력 항목과 동기화

<br/>
<br/>

## 📸스크린샷 (선택)2
<img width="373" height="603" alt="스크린샷 2026-01-01 오전 12 00 36" src="https://github.com/user-attachments/assets/09886e86-f272-448f-b802-ab222dfc8de7" />
<img width="374" height="614" alt="스크린샷 2026-01-01 오전 12 00 29" src="https://github.com/user-attachments/assets/6ee54e4c-7c2e-4b4c-b7b4-8c9f751121b2" />

<br/>
<br/>

