### PR TITLE
feat:공고상세 필터/단지 정렬타입 반영

### DIFF
--- a/src/entities/listings/model/type.ts
+++ b/src/entities/listings/model/type.ts
@@ -179,6 +179,11 @@ export interface SearchState {
   reset: () => void;
 }
 
+export interface ListingSearchState {
+  sortType: string;
+  setSortType: (value: string) => void;
+}
+
 /**
  * 인기검색어 Data
  */

--- a/src/features/listings/model/index.ts
+++ b/src/features/listings/model/index.ts
@@ -2,3 +2,4 @@
 export * from "./listingsModel";
 export * from "./filterPanelModel";
 export * from "./listingsStore";
+export * from "./listingDetailStore";

--- a/src/features/listings/model/listingDetailStore.ts
+++ b/src/features/listings/model/listingDetailStore.ts
@@ -1,0 +1,78 @@
+import { ListingSearchState } from "@/src/entities/listings/model/type";
+import { create } from "zustand";
+
+// 사용처: 필터 바/시트에서 선택한 값 저장 및 토글 (listingsFullSheet.tsx, listingsFilterPanel.tsx, useListingHooks.ts)
+// export const useListingsFilterStore = create<ListingsFilterState>(set => ({
+//   regionType: [],
+//   rentalTypes: [],
+//   supplyTypes: [],
+//   houseTypes: [],
+//   status: "",
+//   sortType: "최신공고순",
+
+//   toggleRegionType: region =>
+//     set(state => {
+//       const exists = state.regionType.includes(region);
+//       return {
+//         regionType: exists
+//           ? state.regionType.filter(i => i !== region)
+//           : [...state.regionType, region],
+//       };
+//     }),
+
+//   toggleRentalType: rental =>
+//     set(state => {
+//       const exists = state.rentalTypes.includes(rental);
+//       return {
+//         rentalTypes: exists
+//           ? state.rentalTypes.filter(i => i !== rental)
+//           : [...state.rentalTypes, rental],
+//       };
+//     }),
+
+//   toggleSupplyType: supply =>
+//     set(state => {
+//       const exists = state.supplyTypes.includes(supply);
+//       return {
+//         supplyTypes: exists
+//           ? state.supplyTypes.filter(i => i !== supply)
+//           : [...state.supplyTypes, supply],
+//       };
+//     }),
+
+//   toggleHouseType: house =>
+//     set(state => {
+//       const exists = state.houseTypes.includes(house);
+//       return {
+//         houseTypes: exists
+//           ? state.houseTypes.filter(i => i !== house)
+//           : [...state.houseTypes, house],
+//       };
+//     }),
+
+//   setStatus: status => set({ status }),
+//   setSortType: sort => set({ sortType: sort }),
+
+//   resetRegionType: () =>
+//     set({
+//       regionType: [],
+//     }),
+//   resetRentalTypes: () =>
+//     set({
+//       rentalTypes: [],
+//     }),
+//   resetSupplyTypes: () =>
+//     set({
+//       supplyTypes: [],
+//     }),
+//   resetHouseTypes: () =>
+//     set({
+//       houseTypes: [],
+//     }),
+// }));
+
+// 사용처:  상태/정렬 (useListingHooks.ts, shared dropdown 등)
+export const useListingsDetailTypeStore = create<ListingSearchState>(set => ({
+  sortType: "거리 순",
+  setSortType: value => set({ sortType: value }),
+}));

--- a/src/features/listings/ui/listingsCardDetail/components/listingsCardDetailComplexSection.tsx
+++ b/src/features/listings/ui/listingsCardDetail/components/listingsCardDetailComplexSection.tsx
@@ -3,6 +3,8 @@ import { ListingsCardTile } from "./listingsCardTile";
 import { ComplexList } from "@/src/entities/listings/model/type";
 import { ListingNoSearchResult } from "../../listingsNoSearchResult/listingNoSearchResult";
 import { cn } from "@/lib/utils";
+import { MouseEventHandler } from "react";
+import { useListingsDetailTypeStore } from "../../../model";
 
 type ListingsCardDetailComplexSectionProps = {
   listings: ComplexList;
@@ -13,11 +15,16 @@ export const ListingsCardDetailComplexSection = ({
   listings,
   onFilteredCount,
 }: ListingsCardDetailComplexSectionProps) => {
+  const { sortType, setSortType } = useListingsDetailTypeStore();
+
   if (!listings) return;
 
   const complexesCount =
     listings?.totalCount < 10 ? `0${listings?.totalCount}` : listings?.totalCount;
 
+  const onDangiSortType = () => {
+    setSortType(sortType === "거리 순" ? "생활태그 매칭순" : "거리 순");
+  };
   return (
     <section
       className={cn("p-5", onFilteredCount !== 0 && "border-b-[11px] border-b-greyscale-grey-25")}
@@ -27,8 +34,10 @@ export const ListingsCardDetailComplexSection = ({
           <p className="text-base-17 text-greyscale-grey-900">단지</p>
           <p className="text-base-17 text-greyscale-grey-600">{complexesCount}</p>
         </h2>
-        <div className="flex gap-1">
-          <span className="text-xs font-semibold text-greyscale-grey-900">핀포인트 거리 순</span>
+        <div className="flex gap-1" onClick={onDangiSortType}>
+          <span className="text-xs font-semibold text-greyscale-grey-900">
+            {sortType === "거리 순" ? "핀포인트 거리순" : "주변환경 매칭순"}
+          </span>
           <ArrowUpArrowDown />
         </div>
       </div>

--- a/src/features/listings/ui/listingsCardDetail/infra/components/routeDetail.tsx
+++ b/src/features/listings/ui/listingsCardDetail/infra/components/routeDetail.tsx
@@ -227,7 +227,7 @@ export const RouteDetail = ({ listingId }: { listingId: string }) => {
           const isArrival = s.action?.toUpperCase() === "ARRIVE";
           const isWALK = s.action?.toUpperCase() === "WALK";
           const label = resolveStepLabel(s);
-          console.log(s);
+
           return (
             <li
               key={`${label}-${i}`}

--- a/src/widgets/listingsSection/ui/listingsCardDetailSection/listingsCardDetailSection.tsx
+++ b/src/widgets/listingsSection/ui/listingsCardDetailSection/listingsCardDetailSection.tsx
@@ -10,7 +10,6 @@ import {
 } from "@/src/features/listings";
 import { PageTransition } from "@/src/shared/ui/animation";
 import { Spinner } from "@/src/shared/ui/spinner/default";
-import { useState } from "react";
 
 export const ListingsCardDetailSection = ({ id }: { id: string }) => {
   const { data, isLoading, isFetching } = useListingDetailBasic(id);


### PR DESCRIPTION
## #️⃣ Issue Number

#206

<br/>
<br/>

## 📝 요약(Summary) (선택)

추가
- listingDetailStore.ts (line 1) 새 useListingsDetailTypeStore를 만들어 상세 카드 단지 탭의 정렬 상태(거리 순 ↔ 생활태그 매칭순)를 - zustand 로 전역 관리하도록 했어요.

변경
- useListingDetailHooks.ts (line 26) 상세 공고 조회 훅이 방금 만든 store 의 sortType 과 OAuth pinPointId 셀렉터를 직접 구독
- queryKey 와 요청 본문을 갱신하며, 응답 select 시 기본 정보에서만 색상 계산을 수행하도록 정리됐어요.
- type.ts 상세용 store 를 위해 ListingSearchState 타입을 추가
- index.ts (line 1) 에서 새 store 를 재수출해 어디서든 불러올 수 있게 했어요.
- listingsCardDetailComplexSection.tsx  단지 리스트 헤더가 store 의 정렬 상태를 구독하고, 라벨을 탭하면 정렬 값을 토글하도록 바뀌어 UI 에서 곧바로 정렬 기준을 선택
- routeDetail.tsx (line 221) 경로 상세 렌더링 중 남아있던 console.log 를 제거해 콘솔 노이즈를 없앴어요.
- listingsCardDetailSection.tsx (line 1) 더 이상 사용하지 않는 useState 임포트를 삭제해 불필요한 의존성을 정리했어요
<br/>
<br/>
