### PR TITLE
feat:공고상세 / 단지 필터 [거리,지역 ] API 연결

### DIFF
--- a/src/entities/listings/model/type.ts
+++ b/src/entities/listings/model/type.ts
@@ -190,6 +190,18 @@ export interface ListingSearchState {
   setSortType: (value: string) => void;
 }
 
+export interface ListingDetailFilterState {
+  distance: number;
+  region: string[];
+  toggleRegionType: (item: string) => void;
+  setDistance: (value: number) => void;
+}
+
+export interface ListingDetailCountState {
+  filteredCount: number;
+  setCounts: (value: number) => void;
+}
+
 /**
  * 인기검색어 Data
  */

--- a/src/features/listings/hooks/listingsHooks.tsx
+++ b/src/features/listings/hooks/listingsHooks.tsx
@@ -13,7 +13,6 @@ import { LineLikeButton } from "@/src/assets/icons/button/lineLikeButton";
 import { SmallHome } from "@/src/assets/icons/home/smallHome";
 import { SmallMapPin } from "@/src/assets/icons/onboarding/smallMapPin";
 import { FireIcon } from "@/src/assets/icons/onboarding/fire";
-import { useQueryClient } from "@tanstack/react-query";
 
 export const formatInfoText = (text: string) => {
   if (!text) return text;
@@ -131,7 +130,6 @@ export const getKeywordCenteredText = (text: string, keyword: string, range: num
 };
 
 export const LikeType = ({ id, liked, type, resetQuery }: ListingItemMinimal) => {
-  const queryClient = useQueryClient();
   const { mutate } = useToogleLike(resetQuery);
   const toggleLike = async () => {
     const body: ToggleLikeVariables = liked

--- a/src/features/listings/model/listingDetailStore.ts
+++ b/src/features/listings/model/listingDetailStore.ts
@@ -1,4 +1,8 @@
-import { ListingSearchState } from "@/src/entities/listings/model/type";
+import {
+  ListingDetailCountState,
+  ListingDetailFilterState,
+  ListingSearchState,
+} from "@/src/entities/listings/model/type";
 import { create } from "zustand";
 
 // 사용처: 필터 바/시트에서 선택한 값 저장 및 토글 (listingsFullSheet.tsx, listingsFilterPanel.tsx, useListingHooks.ts)
@@ -75,4 +79,23 @@ import { create } from "zustand";
 export const useListingsDetailTypeStore = create<ListingSearchState>(set => ({
   sortType: "거리 순",
   setSortType: value => set({ sortType: value }),
+}));
+
+export const useListingDetailFilter = create<ListingDetailFilterState>(set => ({
+  distance: 0,
+  region: [],
+  toggleRegionType: region =>
+    set(state => {
+      const exists = state.region.includes(region);
+      return {
+        region: exists ? state.region.filter(i => i !== region) : [...state.region, region],
+      };
+    }),
+
+  setDistance: value => set({ distance: value }),
+}));
+
+export const useListingDetailCountStore = create<ListingDetailCountState>(set => ({
+  filteredCount: 0,
+  setCounts: value => set({ filteredCount: value }),
 }));

--- a/src/features/listings/model/listingsStore.ts
+++ b/src/features/listings/model/listingsStore.ts
@@ -8,6 +8,7 @@
 import { create } from "zustand";
 import {
   FilterSheetState,
+  ListingDetailFilterState,
   ListingsFilterState,
   ListingState,
   SearchState,

--- a/src/features/listings/ui/listingsCardDetail/components/DetailSectionFilter/DistanceFilter.tsx
+++ b/src/features/listings/ui/listingsCardDetail/components/DetailSectionFilter/DistanceFilter.tsx
@@ -3,6 +3,8 @@ import { useListingFilterDetail } from "@/src/entities/listings/hooks/useListing
 import { PinPointPlace } from "@/src/entities/listings/model/type";
 import { DropDown } from "@/src/shared/ui/dropDown/deafult";
 import { Slider } from "@/src/shared/ui/slider";
+import { useOAuthStore } from "@/src/features/login/model";
+import { useListingDetailCountStore, useListingDetailFilter } from "@/src/features/listings/model";
 
 const SLIDER_MIN = 0;
 const SLIDER_MAX = 120;
@@ -13,7 +15,10 @@ export const DistanceFilter = () => {
     queryK: "usePinPointList",
     url: "pinpoint",
   });
-  const [distance, setDistance] = useState<number>(DEFAULT_DISTANCE);
+
+  const { setPinPointId } = useOAuthStore();
+  const { distance, setDistance } = useListingDetailFilter();
+  const { filteredCount } = useListingDetailCountStore();
 
   const pinPointList = {
     myPinPoint:
@@ -25,8 +30,9 @@ export const DistanceFilter = () => {
   };
 
   const onChageValue = (selectedKey: string) => {
-    console.log(selectedKey);
+    setPinPointId(selectedKey);
   };
+
   const handleDistanceChange = (values: number[]) => {
     const [nextValue] = values;
     if (typeof nextValue === "number") {
@@ -34,11 +40,12 @@ export const DistanceFilter = () => {
     }
   };
 
-  const sliderValue = useMemo(() => [distance], [distance]);
+  const sliderValue = [distance];
   const formatMinutes = (value: number) => value.toString().padStart(2, "0");
   const formattedDistance = formatMinutes(distance);
   const hasPinPoints = pinPointList.myPinPoint.length > 0;
-  const defaultPinPointName = pinPointList.myPinPoint[0]?.value;
+  const pinPoint = pinPointList.myPinPoint[0];
+  const defaultPinPointName = pinPoint?.value || pinPoint?.description;
   const dropDownTriggerLabel = hasPinPoints ? defaultPinPointName : "핀포인트를 추가해 주세요";
 
   return (
@@ -84,7 +91,7 @@ export const DistanceFilter = () => {
           type="button"
           className="w-full rounded-xl bg-greyscale-grey-900 py-4 text-base font-semibold leading-[140%] tracking-[-0.01em] text-white"
         >
-          00개의 단지가 있어요
+          {filteredCount}개의 단지가 있어요
         </button>
       </div>
     </div>

--- a/src/features/listings/ui/listingsCardDetail/components/DetailSectionFilter/components/regionFilter.tsx
+++ b/src/features/listings/ui/listingsCardDetail/components/DetailSectionFilter/components/regionFilter.tsx
@@ -1,28 +1,29 @@
 import { cn } from "@/lib/utils";
 import { useListingDetailNoticeSheet } from "@/src/entities/listings/hooks/useListingDetailSheetHooks";
 import { DistrictResponse } from "@/src/entities/listings/model/type";
-import { REGION_CHECKBOX } from "@/src/features/listings/model";
+import {
+  REGION_CHECKBOX,
+  useListingDetailCountStore,
+  useListingDetailFilter,
+} from "@/src/features/listings/model";
 import { Checkbox } from "@/src/shared/lib/headlessUi/checkBox/checkbox";
 import { TagButton } from "@/src/shared/ui/button/tagButton";
 import { Spinner } from "@/src/shared/ui/spinner/default";
-import { AnimatePresence, motion } from "framer-motion";
 import { useParams } from "next/navigation";
 import { useState } from "react";
 
 export const RegionFilter = () => {
   const { id } = useParams() as { id: string };
-  const [selectedRegions, setSelectedRegions] = useState<string[]>([]);
-
+  const regionType = useListingDetailFilter(state => state.region);
+  const setRegion = useListingDetailFilter(state => state.toggleRegionType);
+  const { filteredCount } = useListingDetailCountStore();
   const { data } = useListingDetailNoticeSheet<DistrictResponse>({
     id: id,
     url: "districts",
   });
   const districts = data?.districts;
-
   const onTagValueChange = (region: string) => {
-    setSelectedRegions(prev =>
-      prev.includes(region) ? prev.filter(r => r !== region) : [...prev, region]
-    );
+    setRegion(region);
   };
 
   if (!districts) return <Spinner title="지역 탐색중..." description="잠시만 기다려주세요" />;
@@ -48,7 +49,7 @@ export const RegionFilter = () => {
                   <Tag
                     onClick={() => onTagValueChange(region)}
                     label={region}
-                    selected={selectedRegions.includes(region)}
+                    selected={regionType.includes(region)}
                   />
                 </div>
               </div>
@@ -61,7 +62,7 @@ export const RegionFilter = () => {
           type="button"
           className="w-full rounded-xl bg-greyscale-grey-900 py-4 text-base font-semibold leading-[140%] tracking-[-0.01em] text-white"
         >
-          00개의 단지가 있어요
+          {filteredCount}개의 단지가 있어요
         </button>
       </div>
     </div>

--- a/src/features/listings/ui/listingsCardDetail/components/listingsCardDetailComplexSection.tsx
+++ b/src/features/listings/ui/listingsCardDetail/components/listingsCardDetailComplexSection.tsx
@@ -4,10 +4,10 @@ import { ComplexList } from "@/src/entities/listings/model/type";
 import { ListingNoSearchResult } from "../../listingsNoSearchResult/listingNoSearchResult";
 import { cn } from "@/lib/utils";
 import { MouseEventHandler } from "react";
-import { useListingsDetailTypeStore } from "../../../model";
+import { useListingDetailCountStore, useListingsDetailTypeStore } from "../../../model";
 
 type ListingsCardDetailComplexSectionProps = {
-  listings: ComplexList;
+  listings?: ComplexList;
   onFilteredCount?: Number;
 };
 

--- a/src/features/listings/ui/listingsContents/listingsContentsCards.tsx
+++ b/src/features/listings/ui/listingsContents/listingsContentsCards.tsx
@@ -2,52 +2,17 @@
 /**
  * 현재 카드 공통 재사용 컴포넌트로 교체 했으나 테스트용으로 보관
  */
-import { useListingState } from "../../model/listingsStore";
-import {
-  ListingContentsCardsProps,
-  ListingItem,
-  ListingItemMinimal,
-  ToggleLikeVariables,
-} from "@/src/entities/listings/model/type";
-import { getListingIcon, getListingsRental } from "../../hooks/listingsHooks";
-import { ListingBgBookMark, ListingBookMark } from "./listingsBookMark";
+import { ListingContentsCardsProps, ListingItem } from "@/src/entities/listings/model/type";
+import { getListingIcon, HouseRental } from "../../hooks/listingsHooks";
+import { ListingBookMark } from "./listingsBookMark";
 import { formatApplyPeriod } from "@/src/shared/lib/utils";
-import { LineLikeButton } from "@/src/assets/icons/button/lineLikeButton";
-import { LikeButton } from "@/src/assets/icons/button/likeButton";
-import { useToogleLike } from "@/src/entities/listings/hooks/useListingHooks";
 
 const HouseICons = (item: ListingItem) => {
   const icon = getListingIcon(item.type, item.housingType);
   return <div>{icon}</div>;
 };
 
-const LikeType = ({ id, liked }: ListingItemMinimal) => {
-  const { mutateAsync } = useToogleLike();
-  const toggleLike = async () => {
-    const body: ToggleLikeVariables = liked
-      ? { method: "delete", targetId: Number(id), type: "NOTICE" }
-      : { method: "post", targetId: Number(id), liked: liked, type: "NOTICE" };
-
-    await mutateAsync(body);
-  };
-
-  return <div onClick={toggleLike}>{liked ? <LikeButton /> : <LineLikeButton />}</div>;
-};
-
-const HouseRental = (item: ListingItem) => {
-  const rantalText = getListingsRental(item.type);
-  if (!rantalText) return null;
-  return (
-    <span className="flex w-full justify-between">
-      <ListingBgBookMark item={item.type} bg={rantalText.bg} text={rantalText.text} border="none" />
-      <LikeType liked={item.liked} id={item.id} />
-    </span>
-  );
-};
-
 export const ListingContentsCards = ({ data }: ListingContentsCardsProps) => {
-  const { status } = useListingState();
-
   return (
     <div className="flex flex-col gap-2">
       {data?.map((item: ListingItem) => (

--- a/src/widgets/listingsSection/ui/listingsCardDetailSection/listingsCardDetailSection.tsx
+++ b/src/widgets/listingsSection/ui/listingsCardDetailSection/listingsCardDetailSection.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useListingDetailBasic } from "@/src/entities/listings/hooks/useListingDetailHooks";
+import { ListingDetailResponseWithColor } from "@/src/entities/listings/model/type";
 import {
   ListingsCardDetailCompareButton,
   ListingsCardDetailComplexSection,
@@ -8,22 +9,53 @@ import {
   ListingsCardDetailOutOfCriteriaSection,
   ListingsCardDetailSummary,
 } from "@/src/features/listings";
+import {
+  useDetailFilterSheetStore,
+  useListingDetailCountStore,
+} from "@/src/features/listings/model";
 import { PageTransition } from "@/src/shared/ui/animation";
 import { Spinner } from "@/src/shared/ui/spinner/default";
+import { useEffect, useState } from "react";
+
+type ListingDetailRenderData = {
+  basicInfo: ListingDetailResponseWithColor["data"]["basicInfo"];
+  filtered: ListingDetailResponseWithColor["data"]["filtered"];
+  nonFiltered: ListingDetailResponseWithColor["data"]["nonFiltered"];
+};
 
 export const ListingsCardDetailSection = ({ id }: { id: string }) => {
-  const { data, isLoading, isFetching } = useListingDetailBasic(id);
-  const basicInfo = data?.data.basicInfo;
-  const filtered = data?.data.filtered;
-  const nonFiltered = data?.data.nonFiltered;
+  const { data, isLoading } = useListingDetailBasic(id);
+  const open = useDetailFilterSheetStore(state => state.open);
+  const setCounts = useListingDetailCountStore(state => state.setCounts);
 
-  if (isLoading || isFetching || !basicInfo || !filtered || !nonFiltered) {
+  const [renderData, setRenderData] = useState<ListingDetailRenderData | null>(null);
+
+  useEffect(() => {
+    if (open) return;
+    if (!data?.data) return;
+
+    const { basicInfo, filtered, nonFiltered } = data.data;
+    if (!basicInfo || !filtered || !nonFiltered) return;
+
+    setRenderData({ basicInfo, filtered, nonFiltered });
+  }, [open, data]);
+
+  useEffect(() => {
+    const liveFiltered = data?.data.filtered;
+    if (!liveFiltered) return;
+
+    setCounts(liveFiltered.totalCount);
+  }, [data?.data.filtered?.totalCount, setCounts]);
+
+  if (!renderData) {
     return (
       <div className="flex h-full items-center justify-center pb-[88px]">
         <Spinner title="공고 탐색중..." description="잠시만 기다려주세요" />
       </div>
     );
   }
+
+  const { basicInfo, filtered, nonFiltered } = renderData;
 
   return (
     <div className="mx-auto min-h-full w-full">
@@ -33,10 +65,12 @@ export const ListingsCardDetailSection = ({ id }: { id: string }) => {
           <ListingsCardDetailSummary basicInfo={basicInfo} />
           <ListingsCardDetailCompareButton />
           <ListingsCardDetailFilterBar />
+
           <ListingsCardDetailComplexSection
             listings={filtered}
-            onFilteredCount={nonFiltered?.totalCount}
+            onFilteredCount={nonFiltered.totalCount}
           />
+
           <ListingsCardDetailOutOfCriteriaSection listings={nonFiltered} />
         </main>
       </PageTransition>


### PR DESCRIPTION
## #️⃣ Issue Number
#210 

<br/>
<br/>

## 📝 요약(Summary) (선택)

### 추가 
- useListingDetailCountStore: 단지 수만 공유하는 zustand 스토어 생김.
ListingDetailFilterState: previewDistance·applyPreviewDistance 같은 필드 추가돼 거리 프리뷰 상태 관리 가능해짐.
### 변경 
- useListingDetailBasic: 요청 로직을 fetchListingDetailBasic으로 분리하고 거리/정렬/핀포인트 기준을 디바운스 후 queryKey 에 반영하도록 손봄.
- DistanceFilter: 슬라이더는 preview 값만 바꾸고, fetchListingDetailBasic을 fetchQuery로 호출해 단지 수 계산 → CTA 클릭 시에만 거리 적용하는 플로우로 조정됨.
- RegionFilter: 거리 필터 패턴에 맞춰 API 파라미터, 상태 업데이트 방식 정리됨.
- ListingsCardDetailComplexSection: useListingsDetailTypeStore 사용해 정렬 토글 라벨·동작만 갱신.
- ListingsContentsCards: 상세 필터 구조에 맞춰 쿼리/상태 전달 최소화.
- ListingsCardDetailSection: 새 필터/카운트 흐름에 맞게 데이터 전달 구조 다듬음.

<br/>
<br/>