### PR TITLE
[Feat] - 공고상세/단지 필터 [거리, 지역, 비용, 면적] API 연결

### DIFF
--- a/src/entities/listings/hooks/useListingDetailHooks.ts
+++ b/src/entities/listings/hooks/useListingDetailHooks.ts
@@ -30,11 +30,25 @@ export const useListingDetailBasic = (id: string) => {
   const sortType = useListingsDetailTypeStore(state => state.sortType);
   const distance = useListingDetailFilter(state => state.distance);
   const typeCode = useListingDetailFilter(state => state.typeCode);
-  const debouncedDistance = useDebounce(distance, 500);
+  const maxDeposit = useListingDetailFilter(state => state.maxDeposit);
+  const maxMonthPay = useListingDetailFilter(state => state.maxMonthPay);
   const region = useListingDetailFilter(state => state.region);
-
+  const debouncedDistance = useDebounce(distance, 500);
+  const debouncedMaxDeposit = useDebounce(maxDeposit, 500);
+  const debouncedMaxMonthPay = useDebounce(maxMonthPay, 500);
+  console.log(debouncedMaxDeposit, debouncedMaxMonthPay);
   return useQuery<ListingDetailResponseWithColor>({
-    queryKey: ["listingDetailBasic", id, pinPointId, sortType, debouncedDistance, region, typeCode],
+    queryKey: [
+      "listingDetailBasic",
+      id,
+      pinPointId,
+      sortType,
+      debouncedDistance,
+      region,
+      typeCode,
+      debouncedMaxDeposit,
+      debouncedMaxMonthPay,
+    ],
     enabled: !!id,
     staleTime: 1000 * 60 * 5,
     retry: false,
@@ -49,8 +63,8 @@ export const useListingDetailBasic = (id: string) => {
         sortType,
         pinPointId,
         transitTime: debouncedDistance,
-        maxDeposit: null,
-        maxMonthPay: null,
+        maxDeposit: Number(debouncedMaxDeposit),
+        maxMonthPay: Number(debouncedMaxMonthPay),
         region: region,
         typeCode: typeCode,
         facilities: [],

--- a/src/entities/listings/model/type.ts
+++ b/src/entities/listings/model/type.ts
@@ -194,9 +194,13 @@ export interface ListingDetailFilterState {
   distance: number;
   region: string[];
   typeCode: string[];
+  maxDeposit: string;
+  maxMonthPay: string;
   toggleRegionType: (item: string) => void;
   toggleTypeCode: (typeCode: string) => void;
   setDistance: (value: number) => void;
+  setMaxDeposit: (prev: string) => void;
+  setMaxMonthPay: (value: string) => void;
 }
 
 export interface ListingDetailCountState {

--- a/src/features/listings/model/listingDetailStore.ts
+++ b/src/features/listings/model/listingDetailStore.ts
@@ -15,6 +15,9 @@ export const useListingDetailFilter = create<ListingDetailFilterState>(set => ({
   distance: 0,
   region: [],
   typeCode: [],
+  maxDeposit: "0",
+  maxMonthPay: "0",
+  setDistance: value => set({ distance: value }),
   toggleRegionType: region =>
     set(state => {
       const exists = state.region.includes(region);
@@ -31,7 +34,8 @@ export const useListingDetailFilter = create<ListingDetailFilterState>(set => ({
           : [...state.typeCode, typeCode],
       };
     }),
-  setDistance: value => set({ distance: value }),
+  setMaxDeposit: value => set({ maxDeposit: value }),
+  setMaxMonthPay: value => set({ maxMonthPay: value }),
 }));
 
 export const useListingDetailCountStore = create<ListingDetailCountState>(set => ({

--- a/src/features/listings/ui/listingsContents/listingsContents.tsx
+++ b/src/features/listings/ui/listingsContents/listingsContents.tsx
@@ -5,7 +5,6 @@ import { ListingsContentHeader } from "./listingsContentsHeader";
 import { ListingContentsList } from "./listingsContentsList";
 import { ListingNoSearchResult } from "../listingsNoSearchResult/listingNoSearchResult";
 import { Spinner } from "@/src/shared/ui/spinner/default";
-import { listingKeys } from "@/src/shared/config/queryKeys";
 
 export const ListingsContent = () => {
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isError, isLoading, isSuccess } =


### PR DESCRIPTION
## #️⃣ Issue Number

#216 

<br/>
<br/>

## 📝 요약(Summary) (선택)

변경

### CostFilter
전역 스토어 연동: maxDeposit, maxMonthPay 사용; 로컬 입력 상태 일부 대체
입력/슬라이더 핸들러가 스토어 setter 호출(setMaxDeposit, setMaxMonthPay)
초기화·동기화 useEffect 추가(슬라이더/입력 변경 시 maxDeposit 반영)
하단 버튼 문구를 고정값 → filteredCount 사용
상세: 텍스트 입력 값 처리 로직 정리(숫자만 추출·포맷), UI 값 바인딩을 maxDeposit/maxMonthPay로 일원화

### Hook: useListingDetailBasic
필터 스토어의 maxDeposit, maxMonthPay 도입 및 500ms 디바운스
queryKey에 두 값 포함 → 변경 시 자동 refetch
요청 바디에 maxDeposit, maxMonthPay 숫자 변환 후 반영
디버그 로그 추가(console.log(debouncedMaxDeposit, debouncedMaxMonthPay))

### Type: ListingDetailFilterState
상태 필드 추가: maxDeposit: string, maxMonthPay: string
액션 추가: setMaxDeposit(prev: string), setMaxMonthPay(value: string)

### Store: useListingDetailFilter
기본 상태에 maxDeposit: "0", maxMonthPay: "0" 추가
setter 추가: setMaxDeposit, setMaxMonthPay
기타: setDistance 위치 조정(기능 변화 없음)
ListingsContent

불필요 import 제거: listingKeys

<br/>
<br/>


