### PR TITLE
feat:공고상세/단지 필터[거리,지역,비용,면적] API연결

### DIFF
--- a/src/entities/listings/hooks/useListingDetailHooks.ts
+++ b/src/entities/listings/hooks/useListingDetailHooks.ts
@@ -36,7 +36,8 @@ export const useListingDetailBasic = (id: string) => {
   const debouncedDistance = useDebounce(distance, 500);
   const debouncedMaxDeposit = useDebounce(maxDeposit, 500);
   const debouncedMaxMonthPay = useDebounce(maxMonthPay, 500);
-  console.log(debouncedMaxDeposit, debouncedMaxMonthPay);
+  const parseMoney = (value: string) => (value ? Number(value.replace(/[^0-9]/g, "")) : 0);
+
   return useQuery<ListingDetailResponseWithColor>({
     queryKey: [
       "listingDetailBasic",
@@ -63,8 +64,8 @@ export const useListingDetailBasic = (id: string) => {
         sortType,
         pinPointId,
         transitTime: debouncedDistance,
-        maxDeposit: Number(debouncedMaxDeposit),
-        maxMonthPay: Number(debouncedMaxMonthPay),
+        maxDeposit: parseMoney(debouncedMaxDeposit),
+        maxMonthPay: parseMoney(debouncedMaxMonthPay),
         region: region,
         typeCode: typeCode,
         facilities: [],


### PR DESCRIPTION
## #️⃣ Issue Number

#218 

<br/>
<br/>

## 📝 요약(Summary) (선택)
- 공고상세/단지 필터[비용] API연결
- costFilter에서 toLocaleString으로 포맷된 문자열(예: "1,200") Number("1,200")가 NaN이 되기 때문에 JSON 직렬화 시 null이 전달됩니다. 입력을 비우면 "" → Number("") → 0이 되어 0이 보내지는 것도 같은 이유
- 문자열 유지 시 변환 보정: 요청 직전에 구분자를 제거한 뒤 숫자로 변환하는 함수 추가

<br/>
<br/>
