### PR TITLE
feat:공고상세/단지 필터 [거리, 비용] UX 수정

### DIFF
--- a/src/features/listings/model/listingDetailStore.ts
+++ b/src/features/listings/model/listingDetailStore.ts
@@ -12,7 +12,7 @@ export const useListingsDetailTypeStore = create<ListingSearchState>(set => ({
 }));
 
 export const useListingDetailFilter = create<ListingDetailFilterState>(set => ({
-  distance: 0,
+  distance: 120,
   region: [],
   typeCode: [],
   maxDeposit: "0",

--- a/src/features/listings/ui/listingsCardDetail/components/DetailSectionFilter/components/CostFilter.tsx
+++ b/src/features/listings/ui/listingsCardDetail/components/DetailSectionFilter/components/CostFilter.tsx
@@ -34,6 +34,8 @@ export const CostFilter = () => {
   });
   const DEPOSIT_MIN = data?.minPrice ?? 0;
   const DEPOSIT_MAX = data?.maxPrice ?? 0;
+  const HISTOGRAM_MIN = formatNumber(toKRW(DEPOSIT_MIN));
+  const HISTOGRAM_MAX = formatNumber(toKRW(DEPOSIT_MAX));
   const AVG_COST = data?.avgPrice ?? 0;
   const [isManualDeposit, setIsManualDeposit] = useState(false);
   const { setMaxDeposit, maxDeposit, maxMonthPay, setMaxMonthPay } = useListingDetailFilter();
@@ -142,8 +144,8 @@ export const CostFilter = () => {
         <div className="rounded-2xl px-2 pb-6 pt-5">
           <div className="relative h-[120px] w-full">
             <HistogramSlider
-              minLabel={DEPOSIT_MIN + "만"}
-              maxLabel={DEPOSIT_MAX + "만"}
+              minLabel={HISTOGRAM_MIN + " 만"}
+              maxLabel={HISTOGRAM_MAX + " 만"}
               disabled={isManualDeposit}
               handleDepositChange={handleDepositChange}
               activeIndex={activeIndex}

--- a/src/features/listings/ui/listingsCardDetail/components/DetailSectionFilter/components/HistogramSlider.tsx
+++ b/src/features/listings/ui/listingsCardDetail/components/DetailSectionFilter/components/HistogramSlider.tsx
@@ -42,7 +42,7 @@ export const HistogramSlider = ({
           >
             <div
               className={`relative rounded-md bg-black px-2 py-1 text-xs text-white ${
-                activeIndex === 20 ? "-translate-x-1/4" : ""
+                activeIndex === 20 ? "-translate-x-1/4" : activeIndex === 0 ? "translate-x-3" : ""
               }`}
             >
               {deposit}
@@ -51,6 +51,14 @@ export const HistogramSlider = ({
                   className="absolute top-full border-4 border-transparent border-t-black"
                   style={{
                     left: `${handleLeftPct}%`,
+                    transform: "translateX(-150%)",
+                  }}
+                />
+              ) : activeIndex === 0 ? (
+                <span
+                  className="absolute top-full border-4 border-transparent border-t-black"
+                  style={{
+                    left: "40%",
                     transform: "translateX(-150%)",
                   }}
                 />


### PR DESCRIPTION
<!--- Pull Request title = 커밋 메시지와 동일/ 해당 이슈를 close 하지 않을 경우, footer #이슈 번호 제외  -->

## #️⃣ Issue Number

#222 

<br/>
<br/>

## 📝 요약(Summary) (선택)

- 비용 히스토그램 비용막대 메세지 박스
- 좌측 끝(0번)에서는 부모 컨테이너 padding 영역 밖으로 translate 되면서 잘림
- 거리 기본 00분에서 기본120분으로 수정

<br/>
<br/>

## 📸스크린샷 (선택)2

<!--- 없을 시 해당 목차 삭제 바람 -->
<br/>
<br/>

## 💬 공유사항 (선택)

<!--- 차후 작업 시 염두해야할 부분 -->
<!--- 없을 시 해당 목차 삭제 바람 -->
<br/>
<br/>
