### PR TITLE
feat:핀하우스 home 핀포인트 API 연결

### DIFF
--- a/src/entities/listings/hooks/useListingDetailHooks.ts
+++ b/src/entities/listings/hooks/useListingDetailHooks.ts
@@ -197,12 +197,16 @@ export const useListingRouteDetail = <T, TParam extends object>({
   });
 };
 
-export const useListingFilterDetail = <T>({ queryK, url }: UseListingsDetailHooksType) => {
-  return useQuery<IResponse<T[]>, Error, T[]>({
-    queryKey: [queryK],
-    enabled: !!queryK,
+export const useListingFilterDetail = <T>() => {
+  return useQuery<IResponse<T>, Error, T>({
+    queryKey: ["pinpoint"],
     staleTime: 1000 * 60 * 5,
-    queryFn: () => PostBasicRequest<T[], IResponse<T[]>, {}, IResponse<T[]>>(endPoint[url], "get"),
-    select: response => response.data ?? [],
+    queryFn: () => PostBasicRequest<T, IResponse<T>, {}, IResponse<T>>(endPoint["pinpoint"], "get"),
+    select: response => {
+      if (response.data === undefined) {
+        throw new Error("Response data is undefined");
+      }
+      return response.data;
+    },
   });
 };

--- a/src/entities/listings/model/type.ts
+++ b/src/entities/listings/model/type.ts
@@ -568,14 +568,18 @@ export const endPoint = {
 
 type EndPointKey = keyof typeof endPoint;
 
-// 사용처: 핀포인트 목록/상세 데이터 타입 (pinpoint 관련 API)
-export interface PinPointPlace {
+type PionPointData = {
   id: string;
   name: string;
   address: string;
   longitude: number;
   latitude: number;
   isFirst: boolean;
+};
+// 사용처: 핀포인트 목록/상세 데이터 타입 (pinpoint 관련 API)
+export interface PinPointPlace {
+  userName: string;
+  pinPoints: PionPointData[];
 }
 
 // 사용처: 공고 단지 지역 응답에서 시 단위 그룹 (regionFilter/areaFilter)

--- a/src/entities/pinpoint/api/pinpointApi.ts
+++ b/src/entities/pinpoint/api/pinpointApi.ts
@@ -3,14 +3,21 @@ import { PINPOINTS_READ_ENDPOINT } from "@/src/shared/api/endpoints";
 import { IResponse } from "@/src/shared/types";
 import { PinPoint } from "../model/pinpoint.type";
 
-export interface PinPointsResponse extends IResponse<PinPoint[]> {
-  data: PinPoint[];
+export type PinPointsResponse = IResponse<PinPointsPayload>;
+export interface PinPointsPayload {
+  userName: string;
+  pinPoints: PinPoint[];
 }
 
 /**
  * 핀포인트 목록 조회 API
  */
-export const getPinPoints = async (): Promise<PinPointsResponse["data"]> => {
+export const getPinPoints = async (): Promise<PinPointsPayload> => {
   const response = await http.get<PinPointsResponse>(PINPOINTS_READ_ENDPOINT);
+
+  if (!response.data) {
+    throw new Error("Invalid pinPoints response");
+  }
+
   return response.data;
 };

--- a/src/entities/pinpoint/hooks/useSetDefaultPinpoint.ts
+++ b/src/entities/pinpoint/hooks/useSetDefaultPinpoint.ts
@@ -8,7 +8,7 @@ import { useOAuthStore } from "@/src/features/login/model/authStore";
  * @returns setDefaultPinpoint 함수
  */
 export const useSetDefaultPinpoint = () => {
-  const { setPinPointId, pinPointId } = useOAuthStore();
+  const { setPinPointId, pinPointId, setUserName } = useOAuthStore();
 
   const setDefaultPinpoint = useCallback(async () => {
     try {
@@ -19,9 +19,11 @@ export const useSetDefaultPinpoint = () => {
 
       // 핀포인트 목록 조회
       const pinPoints = await getPinPoints();
-
-      if (pinPoints && pinPoints.length > 0) {
-        setPinPointId(pinPoints[0].id); // 첫 번째 핀포인트를 기본값으로 설정
+      const myPinpoint = pinPoints.pinPoints;
+      const userName = pinPoints.userName;
+      if (pinPoints && myPinpoint.length > 0) {
+        setPinPointId(myPinpoint[0].id);
+        setUserName(userName);
       }
     } catch (error) {
       console.error("❌ 기본 핀포인트 설정 실패:", error);

--- a/src/features/home/ui/homeHero.tsx
+++ b/src/features/home/ui/homeHero.tsx
@@ -1,10 +1,12 @@
 import { HomeCharacter } from "@/src/assets/icons/home/homeCharacter";
+import { useOAuthStore } from "../../login/model";
 
-export const HomeHero = ({ userName }: { userName: string }) => {
+export const HomeHero = () => {
+  const { userName } = useOAuthStore();
   return (
     <section className="flex items-center justify-between rounded-3xl px-1 py-6">
       <div className="flex flex-col gap-2">
-        <p className="text-xl font-bold leading-tight text-greyscale-grey-900">
+        <p className="text-lg font-bold leading-tight text-greyscale-grey-900">
           {userName}님에게 맞는 <br /> 임대주택을 확인해 보세요
         </p>
       </div>

--- a/src/features/home/ui/homeQuickStatsList.tsx
+++ b/src/features/home/ui/homeQuickStatsList.tsx
@@ -1,36 +1,46 @@
+import { useEffect, useMemo, useState } from "react";
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+
 import { CaretDown } from "@/src/assets/icons/button/caretDown";
 import { HomeFiveoclock } from "@/src/assets/icons/home/HomeFiveoclock";
 import { HomePushPin } from "@/src/assets/icons/home/homePushpin";
 
+import { useListingFilterDetail } from "@/src/entities/listings/hooks/useListingDetailHooks";
+import { PinPointPlace } from "@/src/entities/listings/model/type";
+import { getDefaultPinPointLabel, mapPinPointToOptions } from "../../listings/hooks/listingsHooks";
+import { useOAuthStore } from "../../login/model";
+
 export const QuickStatsList = () => {
+  const { data, isFetching } = useListingFilterDetail<PinPointPlace>();
+  const { setPinPointId } = useOAuthStore();
+
+  const pinPointOptions = useMemo(() => mapPinPointToOptions(data?.pinPoints), [data?.pinPoints]);
+  const pinPointData = pinPointOptions.myPinPoint;
+  const hasPinPoints = pinPointData.length > 0;
+
   return (
     <div className="relative flex items-center rounded-2xl bg-white px-4 py-4">
-      {/* LEFT */}
+      {/* 핀포인트 */}
       <div className="flex flex-1 flex-col gap-1">
         <div className="flex items-center gap-1 text-xs text-greyscale-grey-500">
-          <span>
-            <HomePushPin width={17} height={17} />
-          </span>
+          <HomePushPin width={17} height={17} />
           <span>핀포인트</span>
         </div>
-
-        <button className="flex items-center gap-1 text-lg font-semibold">
-          핀포인트명
+        <button className="text-md flex items-center gap-1 font-semibold">
+          경기 성남시 분당
           <span className="pl-1 text-greyscale-grey-400">
             <CaretDown />
           </span>
         </button>
       </div>
 
-      {/* DIVIDER */}
+      {/* Divider */}
       <span className="pointer-events-none absolute bottom-3 left-1/2 top-3 w-px -translate-x-1/2 bg-greyscale-grey-200" />
 
-      {/* RIGHT */}
-      <div className="flex flex-1 flex-col items-start gap-1 pl-6">
+      {/* 최대시간 */}
+      <div className="flex flex-1 flex-col items-start gap-1 pl-8">
         <div className="flex items-center gap-1 text-xs text-greyscale-grey-500">
-          <span>
-            <HomeFiveoclock width={15} height={15} />
-          </span>
+          <HomeFiveoclock width={15} height={15} />
           <span>최대시간</span>
         </div>
 

--- a/src/features/home/ui/homeUrgentNoticeList.tsx
+++ b/src/features/home/ui/homeUrgentNoticeList.tsx
@@ -48,7 +48,7 @@ export const UrgentNoticeList = () => {
       )}
 
       {!hasNextPage && !isError && data && (
-        <div className="text-center text-sm text-gray-400">더 이상 데이터가 없습니다.</div>
+        <div className="mt-1 text-center text-sm text-gray-400">더 이상 데이터가 없습니다.</div>
       )}
     </section>
   );

--- a/src/features/listings/hooks/listingsHooks.tsx
+++ b/src/features/listings/hooks/listingsHooks.tsx
@@ -2,6 +2,7 @@ import {
   ListingItemMinimal,
   ListingNormalized,
   ListingUnion,
+  PinPointPlace,
   RentType,
   ToggleLikeVariables,
 } from "@/src/entities/listings/model/type";
@@ -216,4 +217,37 @@ export const ComplexesInfo = ({
 
 export const sortTypeChange = (sort: boolean) => {
   return sort ? "주변환경 매칭순" : " 핀포인트 거리순";
+};
+
+export type PinpointOptionValue = {
+  key: string;
+  value: string;
+  description?: string;
+};
+
+export type PinPointOption = {
+  myPinPoint: PinpointOptionValue[];
+};
+
+export const mapPinPointToOptions = (data?: PinPointPlace["pinPoints"]): PinPointOption => {
+  const pinPointList = {
+    myPinPoint:
+      data?.map(item => ({
+        key: item.id,
+        value: item.name,
+        description: item.address,
+      })) ?? [],
+  };
+
+  return pinPointList;
+};
+
+export const getDefaultPinPointLabel = (
+  options: PinPointOption,
+  fallback = "핀포인트를 추가해 주세요"
+) => {
+  const opt = options.myPinPoint;
+  if (opt.length === 0) return fallback;
+  const first = opt[0];
+  return first.value || first.description || fallback;
 };

--- a/src/features/listings/ui/listingsCardDetail/components/DetailSectionFilter/DetailFilterSheet.tsx
+++ b/src/features/listings/ui/listingsCardDetail/components/DetailSectionFilter/DetailFilterSheet.tsx
@@ -42,10 +42,8 @@ export const DetailFilterSheet = () => {
               <button onClick={closeSheet}>✕</button>
             </div>
 
-            {/* 전체 필터 탭 (항상 표시) */}
             <DetailFilterTab />
 
-            {/* section별 콘텐츠 */}
             <div className="flex-1 overflow-y-auto p-5">
               <motion.div
                 key={section}

--- a/src/features/listings/ui/listingsCardDetail/components/DetailSectionFilter/DistanceFilter.tsx
+++ b/src/features/listings/ui/listingsCardDetail/components/DetailSectionFilter/DistanceFilter.tsx
@@ -1,32 +1,26 @@
-import { useMemo, useState } from "react";
 import { useListingFilterDetail } from "@/src/entities/listings/hooks/useListingDetailHooks";
 import { PinPointPlace } from "@/src/entities/listings/model/type";
 import { DropDown } from "@/src/shared/ui/dropDown/deafult";
 import { Slider } from "@/src/shared/ui/slider";
 import { useOAuthStore } from "@/src/features/login/model";
 import { useListingDetailCountStore, useListingDetailFilter } from "@/src/features/listings/model";
+import {
+  getDefaultPinPointLabel,
+  mapPinPointToOptions,
+} from "@/src/features/listings/hooks/listingsHooks";
 
 const SLIDER_MIN = 0;
 const SLIDER_MAX = 120;
 
 export const DistanceFilter = () => {
-  const { data, isFetching } = useListingFilterDetail<PinPointPlace>({
-    queryK: "usePinPointList",
-    url: "pinpoint",
-  });
-
+  const { data, isFetching } = useListingFilterDetail<PinPointPlace>();
+  const pinPointData = data?.pinPoints;
+  const pinPointList = mapPinPointToOptions(pinPointData);
+  const dropDownTriggerLabel = getDefaultPinPointLabel(pinPointList);
+  const hasPinPoints = pinPointList.myPinPoint.length > 0;
   const { setPinPointId } = useOAuthStore();
   const { distance, setDistance } = useListingDetailFilter();
   const { filteredCount } = useListingDetailCountStore();
-
-  const pinPointList = {
-    myPinPoint:
-      data?.map(item => ({
-        key: item.id,
-        value: item.name,
-        description: item.address,
-      })) ?? [],
-  };
 
   const onChageValue = (selectedKey: string) => {
     setPinPointId(selectedKey);
@@ -42,11 +36,7 @@ export const DistanceFilter = () => {
   const sliderValue = [distance];
   const formatMinutes = (value: number) => value.toString().padStart(1, "0");
   const formattedDistance = formatMinutes(distance);
-  const hasPinPoints = pinPointList.myPinPoint.length > 0;
-  const pinPoint = pinPointList.myPinPoint[0];
-  const defaultPinPointName = pinPoint?.value || pinPoint?.description;
-  const dropDownTriggerLabel = hasPinPoints ? defaultPinPointName : "핀포인트를 추가해 주세요";
-  console.log(sliderValue);
+
   return (
     <div className="flex h-full flex-col">
       <section className="flex flex-col gap-3">

--- a/src/features/login/model/authStore.ts
+++ b/src/features/login/model/authStore.ts
@@ -6,6 +6,8 @@ interface IOAuthState {
   setTempUserId: (userId: string) => void;
   clearTempUserId: () => void;
   pinPointId: string;
+  userName: string;
+  setUserName: (userName: string) => void;
   setPinPointId: (pinPointId: string) => void;
 }
 
@@ -17,6 +19,8 @@ export const useOAuthStore = create<IOAuthState>()(
       clearTempUserId: () => set({ tempUserId: null }),
       pinPointId: "",
       setPinPointId: (pinPointId: string) => set({ pinPointId }),
+      userName: "",
+      setUserName: (userName: string) => set({ userName }),
     }),
     {
       name: "oauth-user-storage", // localStorage 키 이름

--- a/src/widgets/homeSection/homeSection.tsx
+++ b/src/widgets/homeSection/homeSection.tsx
@@ -17,7 +17,7 @@ export const HomeSection = () => {
         <div className="flex flex-col pb-6">
           <div className="px-4">
             <HomeHeader />
-            <HomeHero userName="홍길동" />
+            <HomeHero />
           </div>
           <div className="flex flex-col gap-3 border-b-8 border-greyscale-grey-50 px-4">
             <QuickStatsList />

--- a/src/widgets/listingsSection/ui/listingsFilterSection/listingsFilterSection.tsx
+++ b/src/widgets/listingsSection/ui/listingsFilterSection/listingsFilterSection.tsx
@@ -1,3 +1,0 @@
-export const ListingFilterSection = () => {
-  return <div>sdf</div>;
-};


### PR DESCRIPTION
## #️⃣ Issue Number

#229 

<br/>
<br/>

## 📝 요약(Summary) (선택)

### 변경
- 컴포넌트: HomeHero, QuickStatsList, UrgentNoticeList, DetailFilterSheet, DistanceFilter, HomeSection
- 핀포인트 API 응답을 userName + pinPoints 구조로 변경하고 응답 누락 방어 추가
- useListingFilterDetail 훅을 고정 queryKey/endpoint로 단순화하고 데이터 undefined 에러 처리
- 기본 핀포인트 설정 시 첫 핀포인트 id와 userName 저장
- 핀포인트 타입을 userName + pinPoints 구조로 변경

### 추가:
- authStore에 userName 상태/세터
- 핀포인트 옵션 매핑 및 기본 라벨 유틸

### 삭제
컴포넌트: ListingFilterSection
<br/>
<br/>


## 💬 공유사항 (선택)
- quickSearch/ui/choosePinPoint/choosePinPoint.tsx:19:29
- 해당 컴포넌트 빌드시 에러
- 핀포인트 조회시 userName 항목이 추가되어 로지기 변경이 필요함
<br/>
<br/>
