### PR TITLE
feat:유저로그인시 핀하우스 home 화면 최초접근시 온보딩 제공여부

### DIFF
--- a/src/features/home/model/homeStore.ts
+++ b/src/features/home/model/homeStore.ts
@@ -6,8 +6,20 @@ type RouteState = {
   reset: () => void;
 };
 
+type FirstAccess = {
+  access: boolean;
+  setAccess: (access: boolean) => void;
+  reset: () => void;
+};
+
 export const useRouteStore = create<RouteState>(set => ({
   prevPath: null,
   setPrevPath: path => set({ prevPath: path }),
   reset: () => set({ prevPath: null }),
+}));
+
+export const useFirstAccess = create<FirstAccess>(set => ({
+  access: true,
+  setAccess: access => set({ access: access }),
+  reset: () => set({ access: true }),
 }));

--- a/src/features/home/ui/homeHero.tsx
+++ b/src/features/home/ui/homeHero.tsx
@@ -11,7 +11,7 @@ export const HomeHero = () => {
         </p>
       </div>
       <div className="relative">
-        <span className="absolute right-2 top-[-12px] z-10 flex items-center justify-center text-2xl text-primary-blue-400">
+        <span className="absolute right-2 top-[-17px] z-10 flex items-center justify-center text-2xl text-primary-blue-400">
           <HomeCharacter width={77} height={77} />
         </span>
       </div>

--- a/src/features/home/ui/homePersonalShortcutList.tsx
+++ b/src/features/home/ui/homePersonalShortcutList.tsx
@@ -1,6 +1,8 @@
 import { LeftButton } from "@/src/assets/icons/button";
 import { HomeScreenHomeIcon } from "@/src/assets/icons/home/home";
 import { HomeScreenTask } from "@/src/assets/icons/home/homeScreenTask";
+import { useEffect, useState } from "react";
+import { useOAuthStore } from "../../login/model";
 
 const PERSONAL_SHORTCUTS = [
   {
@@ -33,12 +35,26 @@ const ShortcutMessage = ({ text }: { text: string }) => {
   );
 };
 
+const messageSeenKey = (userId: string) => `home-shortcut-msg-seen:${userId ?? "anon"}`;
+
 export const PersonalShortcutList = () => {
+  const { userName } = useOAuthStore(); // 실제로 쓰는 user 식별자 넣기
+  const [showMessage, setShowMessage] = useState(false);
+
+  useEffect(() => {
+    const key = messageSeenKey(userName);
+    const seen = sessionStorage.getItem(key);
+    if (!seen) {
+      setShowMessage(true);
+      sessionStorage.setItem(key, "1");
+    }
+  }, [userName]);
+
   return (
     <section className="flex flex-col gap-4">
       {PERSONAL_SHORTCUTS.map(item => (
         <div key={item.id} className="relative">
-          {item.message && <ShortcutMessage text={item.message} />}
+          {showMessage && item.message && <ShortcutMessage text={item.message} />}
 
           <button
             className="shadow- flex w-full items-center gap-2 rounded-2xl border border-greyscale-grey-50 bg-white p-4 text-left"

--- a/src/features/login/utils/logout.ts
+++ b/src/features/login/utils/logout.ts
@@ -7,7 +7,7 @@ export const logout = () => {
 
   // 2. localStorage 정리
   localStorage.clear();
-
+  sessionStorage.clear();
   // 3. 로그인 페이지로 리다이렉트
   window.location.href = "/login";
 

--- a/src/shared/ui/bottomNavigation/bottomNavigation.tsx
+++ b/src/shared/ui/bottomNavigation/bottomNavigation.tsx
@@ -58,7 +58,12 @@ function BottomNavigationContent() {
           <span>공고 탐색</span>
         </button>
         <button className="flex flex-col items-center gap-1 text-xs">
-          <PersonLine width={25} height={25} fill={pathname === "/myhome" ? "black" : "none"} />
+          <PersonLine
+            width={25}
+            height={25}
+            onClick={() => router.push("/hometemporary")}
+            fill={pathname === "/hometemporary" ? "black" : "none"}
+          />
           <span>마이</span>
         </button>
       </div>


### PR DESCRIPTION
<!--- Pull Request title = 커밋 메시지와 동일/ 해당 이슈를 close 하지 않을 경우, footer #이슈 번호 제외  -->

## #️⃣ Issue Number

#237 

<br/>
<br/>
## 📝 요약(Summary) (선택)

- homeStore: useFirstAccess 스토어 추가(첫 접근 여부 상태/리셋).
- homeHero: 캐릭터 위치 top 오프셋 -12px → -17px로 조정.
- homePersonalShortcutList: 로그인 유저 기반 sessionStorage 키로 첫 진입에만 메시지 노출 로직 추가.
- logout: sessionStorage.clear() 추가.
- bottomNavigation: 마이 아이콘 클릭 시 /hometemporary로 이동, 활성 경로도 해당 경로로 변경.

<br/>
<br/>