### PR TITLE
feat:마감임막 공고 라우터 작업 ( 지역 , 마감공고 우선순위 )

### DIFF
--- a/src/features/home/model/homeStore.ts
+++ b/src/features/home/model/homeStore.ts
@@ -2,24 +2,16 @@ import { create } from "zustand";
 
 type RouteState = {
   prevPath: string | null;
+  listingEntry: string | null;
   setPrevPath: (path: string) => void;
-  reset: () => void;
-};
-
-type FirstAccess = {
-  access: boolean;
-  setAccess: (access: boolean) => void;
+  setListingEntry: (entry: string) => void;
   reset: () => void;
 };
 
 export const useRouteStore = create<RouteState>(set => ({
   prevPath: null,
+  listingEntry: null,
   setPrevPath: path => set({ prevPath: path }),
-  reset: () => set({ prevPath: null }),
-}));
-
-export const useFirstAccess = create<FirstAccess>(set => ({
-  access: true,
-  setAccess: access => set({ access: access }),
-  reset: () => set({ access: true }),
+  setListingEntry: entry => set({ listingEntry: entry }),
+  reset: () => set({ prevPath: null, listingEntry: null }),
 }));

--- a/src/features/home/ui/homeUrgentNoticeList.tsx
+++ b/src/features/home/ui/homeUrgentNoticeList.tsx
@@ -4,13 +4,23 @@ import { useNoticeInfinite } from "@/src/entities/home/hooks/homeHooks";
 import { HomeContentsCard } from "@/src/features/home";
 import { ListingNoSearchResult } from "@/src/features/listings";
 import { Button } from "@/src/shared/lib/headlessUi";
-import { AlignRight, ArrowRight, MoveRightIcon } from "lucide-react";
-import Link from "next/link";
+import { useRouteStore } from "../model/homeStore";
+import { useRouter } from "next/navigation";
+import { useListingsFilterStore } from "../../listings/model";
 
 export const UrgentNoticeList = () => {
   const { data, isFetchingNextPage, isError, hasNextPage, fetchNextPage } = useNoticeInfinite();
   const contents = data?.pages?.flatMap(page => page.content) ?? [];
   const region = data?.pages?.flatMap(page => page.region) ?? [];
+  const { setSortType } = useListingsFilterStore();
+  const router = useRouter();
+  const { setPrevPath } = useRouteStore();
+
+  const pageRouter = () => {
+    setPrevPath("/home");
+    setSortType("마감임박순");
+    router.push("/listings");
+  };
 
   return (
     <section className={cn("flex flex-col", contents.length >= 2 ? "pb-[55px]" : "")}>
@@ -18,11 +28,12 @@ export const UrgentNoticeList = () => {
         <div>
           <p className="mb-3 text-lg font-bold text-greyscale-grey-900">마감임박 공고</p>
         </div>
-        <div className="min-w-auto text-xs font-semibold">
-          <Link href="/listings" className="flex items-center text-greyscale-grey-400">
-            <span>{region}</span>
-            <LeftButton width={20} height={20} className="rotate-180" />
-          </Link>
+        <div
+          className="min-w-auto flex items-center text-xs font-semibold text-greyscale-grey-400"
+          onClick={pageRouter}
+        >
+          <span>{region}</span>
+          <LeftButton width={20} height={20} className="rotate-180" />
         </div>
       </div>
 


### PR DESCRIPTION
## #️⃣ Issue Number

#239 

<br/>
<br/>

## 📝 요약(Summary) (선택)

- 핀하우스 home 에서 공고리스트 접근시 마감공고로 우선조회
- 현재 지역은 필터에서 지역이 없고 "도" 만 확인되기 때문에 지역으로는 검색 불가능
#### 변경
- UrgentNoticeList : pageRouter 함수추가 / setPrevPath , setSortType state를 추가 하였고 사용자가 라우팅 할때 "/home" path 를 저장하고 정렬 타입을 "마감임박순" 으로 변경


<br/>
<br/>
