### PR TITLE
feat: 공고상세 /  방비교 라우터 및 구조 작업

### DIFF
--- a/app/listings/[id]/compare/page.tsx
+++ b/app/listings/[id]/compare/page.tsx
@@ -1,0 +1,6 @@
+import { ListingCompareSection } from "@/src/widgets/listingsSection/ui/listingsCompareRoomSection/listingsCompareRoomSection";
+
+export default async function Page({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  return <ListingCompareSection id={id} />;
+}

--- a/src/features/listings/ui/listingsCardDetail/components/listingsCardDetailCompareButton.tsx
+++ b/src/features/listings/ui/listingsCardDetail/components/listingsCardDetailCompareButton.tsx
@@ -1,9 +1,19 @@
 import { SmallHomeLine } from "@/src/assets/icons/home/smallHomeLine";
+import { useRouter } from "next/navigation";
 
-export const ListingsCardDetailCompareButton = () => {
+export const ListingsCardDetailCompareButton = ({ paramId }: { paramId: string }) => {
+  const router = useRouter();
+
+  const handleCompareClick = () => {
+    router.push(`/listings/${paramId}/compare`);
+  };
+
   return (
     <section className="py-1 pl-5 pr-5">
-      <button className="flex h-10 w-full items-center justify-center gap-1 rounded-lg bg-primary-blue-25 text-sm font-medium text-primary-blue-300">
+      <button
+        onClick={handleCompareClick}
+        className="flex h-10 w-full items-center justify-center gap-1 rounded-lg bg-primary-blue-25 text-sm font-medium text-primary-blue-300"
+      >
         <SmallHomeLine /> 방 비교하기
       </button>
     </section>

--- a/src/features/listings/ui/listingsCardDetail/components/listingsCardDetailHeader.tsx
+++ b/src/features/listings/ui/listingsCardDetail/components/listingsCardDetailHeader.tsx
@@ -2,7 +2,6 @@
 import { LeftButton } from "@/src/assets/icons/button";
 import { useRouteStore } from "@/src/features/home/model/homeStore";
 import { useRouter } from "next/navigation";
-import { useEffect } from "react";
 
 export const ListingsCardDetailHeader = () => {
   const router = useRouter();

--- a/src/features/listings/ui/listingsCompareRoom/components/listingsCompareHeader.tsx
+++ b/src/features/listings/ui/listingsCompareRoom/components/listingsCompareHeader.tsx
@@ -1,0 +1,12 @@
+import { CloseButton } from "@/src/assets/icons/button";
+
+export const ListingCompareHeader = () => {
+  return (
+    <header className="sticky top-0 z-10 border-b border-greyscale-grey-100 bg-white">
+      <div className="flex items-center p-5 text-base font-semibold">
+        <CloseButton className="ml-auto" />
+        <p className="absolute left-1/2 -translate-x-1/2 text-base text-lg-19 font-bold">방 비교</p>
+      </div>
+    </header>
+  );
+};

--- a/src/features/listings/ui/listingsCompareRoom/index.ts
+++ b/src/features/listings/ui/listingsCompareRoom/index.ts
@@ -1,0 +1,1 @@
+export * from "./components/listingsCompareHeader";

--- a/src/shared/ui/bottomNavigation/bottomNavigation.tsx
+++ b/src/shared/ui/bottomNavigation/bottomNavigation.tsx
@@ -24,6 +24,7 @@ const hiddenExactRoutes = [
   "/quicksearch/result",
 ];
 const detailPageRegex = /^\/listings\/[A-Za-z0-9_-]+$/;
+const compareDetailPageRegex = /^\/listings\/[A-Za-z0-9_-]+\/compare$/;
 
 function BottomNavigationContent() {
   const pathname = usePathname();
@@ -34,7 +35,8 @@ function BottomNavigationContent() {
   const shouldHide =
     hiddenRoutes.some(route => pathname.startsWith(route)) ||
     hiddenExactRoutes.includes(currentPath) ||
-    detailPageRegex.test(pathname);
+    detailPageRegex.test(pathname) ||
+    compareDetailPageRegex.test(pathname);
 
   if (shouldHide) return null;
   return (

--- a/src/widgets/listingsSection/ui/listingsCardDetailSection/listingsCardDetailSection.tsx
+++ b/src/widgets/listingsSection/ui/listingsCardDetailSection/listingsCardDetailSection.tsx
@@ -63,7 +63,7 @@ export const ListingsCardDetailSection = ({ id }: { id: string }) => {
         <ListingsCardDetailHeader />
         <main>
           <ListingsCardDetailSummary basicInfo={basicInfo} />
-          <ListingsCardDetailCompareButton />
+          <ListingsCardDetailCompareButton paramId={id} />
           <ListingsCardDetailFilterBar />
 
           <ListingsCardDetailComplexSection

--- a/src/widgets/listingsSection/ui/listingsCompareRoomSection/listingsCompareRoomSection.tsx
+++ b/src/widgets/listingsSection/ui/listingsCompareRoomSection/listingsCompareRoomSection.tsx
@@ -1,0 +1,12 @@
+import { ListingCompareHeader } from "@/src/features/listings/ui/listingsCompareRoom";
+import { PageTransition } from "@/src/shared/ui/animation";
+
+export const ListingCompareSection = ({ id }: { id: string }) => {
+  return (
+    <section className="mx-auto min-h-full w-full">
+      <PageTransition>
+        <ListingCompareHeader />
+      </PageTransition>
+    </section>
+  );
+};


### PR DESCRIPTION
## #️⃣ Issue Number

#243 

<br/>
<br/>

## 📝 요약(Summary) (선택)

### 공고상세/ 방비교 라우터 및 구조 작업
#### 추가
- Page
- 동적 compare 페이지 컴포넌트. params.id를 받아 ListingCompareSection 렌더링.
- ListingCompareSection
- 페이지 전환 래퍼(PageTransition) 안에 ListingCompareHeader 포함. id prop 수신.
- ListingCompareHeader
- 상단 고정 헤더. 닫기 버튼과 “비교” 타이틀 표시.
- index.ts
- ListingCompareHeader 재‑export
#### 변경
- ListingsCardDetailCompareButton
- paramId prop 수신하도록 인터페이스 변경.
- 이동 경로를 /listings/${paramId}/compare로 수정.
- 클릭 핸들러를 버튼에 직접 바인딩

<br/>
<br/>

## 📸스크린샷 (선택)2
<img width="420" height="851" alt="Image" src="https://github.com/user-attachments/assets/3df0e909-2901-4682-9add-e1d4406e9d89" />
<br/>
<br/>

