### PR TITLE
feat:공고상세 / 방비교 UI 작업

### DIFF
--- a/src/features/listings/model/listingsModel.ts
+++ b/src/features/listings/model/listingsModel.ts
@@ -126,6 +126,17 @@ const listingDrop: PinPoint[] = [
   { key: "recruiting", value: "모집중" },
 ];
 
+const listingsCompare: PinPoint[] = [
+  { key: "deistance", value: "핀포인트 거리 순" },
+  { key: "security", value: "보증금 낮은 순" },
+  { key: "area", value: "면적 넓은 순" },
+  { key: "infra", value: "주변환경 매칭 순" },
+];
+
+export const listingsComparePoint: PinPointMap<PinPoint[]> = {
+  drop: listingsCompare,
+};
+
 // 사용처: 상단 드롭다운 데이터 (listingsContentsHeader.tsx)
 export const listingPoint: PinPointMap<PinPoint[]> = {
   drop: listingDrop,

--- a/src/features/listings/ui/listingsCompareRoom/components/listingsCompareCards.tsx
+++ b/src/features/listings/ui/listingsCompareRoom/components/listingsCompareCards.tsx
@@ -1,0 +1,71 @@
+export type ListingCompareItem = {
+  id: string;
+  roomType: string; // 대학생, 청년, 신혼부부 등
+  complexName: string; // 단지명
+  distanceText: string; // 거리 정보
+  priceText: string; // 보증금/월세
+  optionText: string; // 면적/옵션
+  tags: string[]; // 인프라 태그
+};
+
+export type ListingCompareCardProps = {
+  id: string;
+  roomTypeLabel: string;
+  title: string;
+  distance: string;
+  price: string;
+  option: string;
+  tags: string[];
+};
+
+export const mapCompareItemToCardProps = (item: ListingCompareItem): ListingCompareCardProps => ({
+  id: item.id,
+  roomTypeLabel: item.roomType,
+  title: item.complexName,
+  distance: item.distanceText,
+  price: item.priceText,
+  option: item.optionText,
+  tags: item.tags,
+});
+
+export const ListingCompareCard = ({
+  id,
+  roomTypeLabel,
+  title,
+  distance,
+  price,
+  option,
+  tags,
+}: ListingCompareCardProps) => {
+  return (
+    <article className="flex h-full flex-col rounded-xl border bg-white">
+      <div className="relative mb-3 h-[140px] w-full rounded-t-lg bg-greyscale-grey-100">
+        {/* <button className="absolute right-2 top-2 rounded-full bg-white p-1 shadow">📌</button> */}
+      </div>
+      <div className="p-3">
+        <span className="mb-1 inline-block text-xs font-medium text-greyscale-grey-500">
+          {roomTypeLabel}
+        </span>
+
+        <div className="mb-1 flex items-center justify-between">
+          <p className="line-clamp-1 text-sm font-semibold">{title}</p>
+          <button className="text-greyscale-grey-400">⋮</button>
+        </div>
+
+        <p className="line-clamp-1 text-xs text-greyscale-grey-500">{distance}</p>
+
+        <p className="line-clamp-1 text-xs text-greyscale-grey-500">{option}</p>
+        <div className="flex flex-wrap gap-1">
+          {tags.map((tag, index) => (
+            <span
+              key={index}
+              className="rounded-md border border-greyscale-grey-200 px-2 py-[2px] text-xs text-greyscale-grey-600"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      </div>
+    </article>
+  );
+};

--- a/src/features/listings/ui/listingsCompareRoom/components/listingsCompareContentHeader.tsx
+++ b/src/features/listings/ui/listingsCompareRoom/components/listingsCompareContentHeader.tsx
@@ -1,0 +1,45 @@
+import { ArrowUpArrowDown } from "@/src/assets/icons/button/arrowUpArrowDown";
+import { CaretDropDown } from "@/src/shared/ui/dropDown/CaretDropDown";
+import { listingsComparePoint } from "../../../model";
+
+export const ListingsCompareContentHeader = () => {
+  // const onChange = (e: MouseEvent<HTMLDivElement>) => {
+  //   e.preventDefault();
+  //   const saveSortType = isSearchPage ? setSearchSortType : setSortType;
+  //   const nextSortType = sortType === "최신공고순" ? "마감임박순" : "최신공고순";
+  //   const nextSearchSortType = searchSortType === "LATEST" ? "DEADLINE" : "LATEST";
+  //   const sortTypeValue = isSearchPage ? nextSearchSortType : nextSortType;
+  //   saveSortType(sortTypeValue);
+  // };
+
+  return (
+    <section className="border-greyscale-grey-100 bg-white">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-1 text-xl font-bold">
+          <p className="text-base-17 text-text-primary">방</p>
+          <p className="text-base-17 text-text-tertiary">{"00"}</p>
+        </div>
+
+        <div className="flex items-center">
+          <div className="flex items-center gap-1"></div>
+
+          <div className="flex items-center">
+            {/* <span>
+              <p>핀포인트 거리순</p>
+            </span> */}
+            <CaretDropDown
+              variant="ghost"
+              types="drop"
+              size={"xs"}
+              data={listingsComparePoint}
+              fullWidth={false}
+              className="w-fit"
+              containerClassName="w-auto"
+              menuClassName="left-[-60] w-[100] "
+            />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/src/features/listings/ui/listingsCompareRoom/components/listingsCompareHeader.tsx
+++ b/src/features/listings/ui/listingsCompareRoom/components/listingsCompareHeader.tsx
@@ -1,11 +1,19 @@
+"use client";
 import { CloseButton } from "@/src/assets/icons/button";
+import { useRouter } from "next/navigation";
 
-export const ListingCompareHeader = () => {
+export const ListingCompareHeader = ({ id }: { id: string }) => {
+  const router = useRouter();
+
+  const onClose = () => {
+    router.replace(`/listings/${id}`);
+  };
+
   return (
     <header className="sticky top-0 z-10 border-b border-greyscale-grey-100 bg-white">
       <div className="flex items-center p-5 text-base font-semibold">
-        <CloseButton className="ml-auto" />
-        <p className="absolute left-1/2 -translate-x-1/2 text-base text-lg-19 font-bold">방 비교</p>
+        <p className="absolute left-1/2 -translate-x-1/2 text-lg-19 font-bold">방 비교</p>
+        <CloseButton onClick={onClose} className="ml-auto" />
       </div>
     </header>
   );

--- a/src/features/listings/ui/listingsCompareRoom/index.ts
+++ b/src/features/listings/ui/listingsCompareRoom/index.ts
@@ -1,1 +1,3 @@
 export * from "./components/listingsCompareHeader";
+export * from "./components/listingsCompareContentHeader";
+export * from "./components/listingsCompareCards";

--- a/src/features/listings/ui/listingsContents/listingsContentsHeader.tsx
+++ b/src/features/listings/ui/listingsContents/listingsContentsHeader.tsx
@@ -33,7 +33,15 @@ export const ListingsContentHeader = ({ totalCount }: ListingsContentHeaderProps
 
       <div className="flex items-center">
         <div className="flex items-center gap-1">
-          <CaretDropDown variant="ghost" types="drop" data={listingPoint} />
+          <CaretDropDown
+            variant="ghost"
+            types="drop"
+            data={listingPoint}
+            fullWidth={false}
+            className="w-fit"
+            containerClassName="w-auto"
+            menuClassName="left-[5] w-fit"
+          />
         </div>
 
         <div className="flex items-center gap-1" onClick={e => onChange(e)}>

--- a/src/shared/ui/dropDown/CaretDropDown/caretDropDown.tsx
+++ b/src/shared/ui/dropDown/CaretDropDown/caretDropDown.tsx
@@ -22,6 +22,9 @@ function CaretDropDownContent({
   types,
   children,
   data,
+  containerClassName,
+  menuClassName,
+  fullWidth = true,
   ...props
 }: DropDownProps) {
   const [open, setOpen] = useState<boolean>(false);
@@ -65,14 +68,21 @@ function CaretDropDownContent({
   }, []);
 
   return (
-    <div className="relative inline-block w-full" ref={wrapperRef}>
+    <div
+      className={cn(
+        "relative inline-block",
+        fullWidth ? "w-full" : "w-auto",
+        containerClassName
+      )}
+      ref={wrapperRef}
+    >
       <button
         className={cn(dropDownVariants({ variant, size }), className)}
         onClick={onChangeButton}
         {...props}
       >
         {children}
-        <span className="flex w-full items-center justify-between gap-1 text-xs font-bold">
+        <span className="flex items-center justify-between gap-1 text-xs font-bold">
           {isSearchPage ? (searchState === "ALL" ? "전체" : "모집중") : status}
           {/* {status || children} */}
           {open ? <CaretUp /> : <CaretDown />}
@@ -82,16 +92,20 @@ function CaretDropDownContent({
       {open && (
         <ul
           className={cn(
-            "absolute left-0 top-full z-10 mt-1 w-full rounded-lg border bg-white font-bold text-text-tertiary shadow-lg"
+            // default placement and sizing; override via menuClassName
+            "absolute left-0 top-8 z-10 rounded-lg border bg-white font-bold text-text-tertiary shadow-lg",
+            // fit to content by default
+            "w-fit min-w-fit",
+            menuClassName
           )}
         >
           {optionData.map(item => (
             <li
               key={item.key}
               onClick={() => onClose({ value: item.value })}
-              className="hover:bg-hover-dropDown flex cursor-pointer flex-col px-3 py-2 hover:text-text-brand"
+              className="hover:bg-hover-dropDown flex cursor-pointer flex-col p-2 hover:text-text-brand"
             >
-              <span className="text-sm">{item.value}</span>
+              <span className="text-xs">{item.value}</span>
             </li>
           ))}
         </ul>

--- a/src/shared/ui/dropDown/CaretDropDown/dropDown.bariants.ts
+++ b/src/shared/ui/dropDown/CaretDropDown/dropDown.bariants.ts
@@ -10,6 +10,7 @@ export const dropDownVariants = cva(
         ghost: "bg-transparent text-gray-700 hover:bg-gray-100 active:scale-[0.98]",
       },
       size: {
+        xs: "h-8 text-sm",
         sm: "h-8 px-3 text-sm",
         md: "h-10 px-4 text-base",
         lg: "h-12 px-5 text-lg",

--- a/src/shared/ui/dropDown/CaretDropDown/type.ts
+++ b/src/shared/ui/dropDown/CaretDropDown/type.ts
@@ -19,4 +19,8 @@ export interface DropDownProps<T = PinPoint[]>
   data: PinPointMap<T>;
   setSelect?: any;
   selected?: string;
+  // layout overrides
+  containerClassName?: string; // wrapper div
+  menuClassName?: string; // dropdown menu ul
+  fullWidth?: boolean; // wrapper width: true -> w-full, false -> w-auto
 }

--- a/src/widgets/listingsSection/ui/listingsCompareRoomSection/listingsCompareRoomSection.tsx
+++ b/src/widgets/listingsSection/ui/listingsCompareRoomSection/listingsCompareRoomSection.tsx
@@ -1,11 +1,93 @@
-import { ListingCompareHeader } from "@/src/features/listings/ui/listingsCompareRoom";
+import {
+  ListingCompareCard,
+  ListingCompareHeader,
+  ListingCompareItem,
+  ListingsCompareContentHeader,
+  mapCompareItemToCardProps,
+} from "@/src/features/listings/ui/listingsCompareRoom";
+
 import { PageTransition } from "@/src/shared/ui/animation";
 
+export const LISTING_COMPARE_MOCK: ListingCompareItem[] = [
+  {
+    id: "room-001",
+    roomType: "대학생",
+    complexName: "진주가좌올리움",
+    distanceText: "핀포인트로부터 약 09시 00분 거리",
+    priceText: "보증금 0만원 · 월임대료 0만원",
+    optionText: "전용면적 약 26㎡ (8평)",
+    tags: ["버스정류장", "편의점", "마트"],
+  },
+  {
+    id: "room-002",
+    roomType: "청년",
+    complexName: "가좌청년주택",
+    distanceText: "핀포인트로부터 약 12시 00분 거리",
+    priceText: "보증금 300만원 · 월임대료 15만원",
+    optionText: "전용면적 약 31㎡ (9평)",
+    tags: ["지하철", "카페", "병원"],
+  },
+  {
+    id: "room-003",
+    roomType: "신혼부부",
+    complexName: "진주역 행복주택",
+    distanceText: "핀포인트로부터 약 15시 00분 거리",
+    priceText: "보증금 800만원 · 월임대료 25만원",
+    optionText: "전용면적 약 42㎡ (13평)",
+    tags: ["초등학교", "공원", "마트"],
+  },
+  {
+    id: "room-004",
+    roomType: "고령자",
+    complexName: "진주노인복지주택",
+    distanceText: "핀포인트로부터 약 10시 30분 거리",
+    priceText: "보증금 200만원 · 월임대료 10만원",
+    optionText: "전용면적 약 29㎡ (9평)",
+    tags: ["병원", "약국", "복지관"],
+  },
+  {
+    id: "room-005",
+    roomType: "고령자",
+    complexName: "진주노인복지주택",
+    distanceText: "핀포인트로부터 약 10시 30분 거리",
+    priceText: "보증금 200만원 · 월임대료 10만원",
+    optionText: "전용면적 약 29㎡ (9평)",
+    tags: ["병원", "약국", "복지관"],
+  },
+  {
+    id: "room-006",
+    roomType: "고령자",
+    complexName: "진주노인복지주택",
+    distanceText: "핀포인트로부터 약 10시 30분 거리",
+    priceText: "보증금 200만원 · 월임대료 10만원",
+    optionText: "전용면적 약 29㎡ (9평)",
+    tags: ["병원", "약국", "복지관"],
+  },
+  {
+    id: "room-007",
+    roomType: "고령자",
+    complexName: "진주노인복지주택",
+    distanceText: "핀포인트로부터 약 10시 30분 거리",
+    priceText: "보증금 200만원 · 월임대료 10만원",
+    optionText: "전용면적 약 29㎡ (9평)",
+    tags: ["병원", "약국", "복지관"],
+  },
+];
+
 export const ListingCompareSection = ({ id }: { id: string }) => {
+  const data = LISTING_COMPARE_MOCK; // 나중에 API
   return (
     <section className="mx-auto min-h-full w-full">
       <PageTransition>
-        <ListingCompareHeader />
+        <ListingCompareHeader id={id} />
+        <div className="p-4">
+          <ListingsCompareContentHeader />
+        </div>
+        <div className="grid grid-cols-2 items-stretch gap-2 px-4">
+          {data.map(item => (
+            <ListingCompareCard key={item.id} {...mapCompareItemToCardProps(item)} />
+          ))}
+        </div>
       </PageTransition>
     </section>
   );


### PR DESCRIPTION
## #️⃣ Issue Number

#245 

<br/>
<br/>

## 📝 요약(Summary) (선택)

### ListingCompareCard
- 비교 카드 컴포넌트 추가. 태그/가격/거리 표시, mapCompareItemToCardProps 헬퍼 포함.
#### ListingsCompareContentHeader
- 비교 페이지 상단 컨텐츠 헤더 추가. CaretDropDown 사용(ghost/xs).
#### ListingCompareHeader
- id prop 수신 후 닫기 클릭 시 /listings/{id}로 router.replace 이동.
- ListingsContentsHeader
- CaretDropDown에 fullWidth={false}, className="w-fit", containerClassName="w-auto", - menuClassName="left-0 w-fit" 적용해 자동 너비/좌측 정렬.
#### CaretDropDown
- 레이아웃 오버라이드 props 추가: fullWidth, containerClassName, menuClassName.
- 래퍼 기본 w-full→옵션화, 메뉴 기본 위치 left-0로 변경, w-fit/min-w-fit로 콘텐츠 기반 너비 지원.
#### ListingCompareSection
- 헤더에 id 전달, 컨텐츠 헤더 추가, 비교 카드 그리드 및 임시 데이터 렌더링.

<img width="471" height="917" alt="Image" src="https://github.com/user-attachments/assets/34a44156-7548-445b-a4f9-382b307aa4d0" />

<br/>
<br/>

## 📸스크린샷 (선택)2
<img width="471" height="917" alt="스크린샷 2026-01-13 162136" src="https://github.com/user-attachments/assets/4a215fee-ebce-4d3b-b1f2-599f398195c0" />
<br/>
<br/>

