### PR TITLE
feat:공고상세 / 방비교 카드 디자인 수정

### DIFF
--- a/src/features/listings/ui/listingsCompareRoom/components/listingsCompareCards.tsx
+++ b/src/features/listings/ui/listingsCompareRoom/components/listingsCompareCards.tsx
@@ -39,7 +39,7 @@ export const ListingCompareCard = ({
 }: ListingCompareCardProps) => {
   return (
     <article className="flex h-full flex-col rounded-xl border bg-white">
-      <div className="relative mb-3 h-[140px] w-full rounded-t-lg bg-greyscale-grey-100">
+      <div className="relative h-[92px] w-full rounded-t-lg bg-greyscale-grey-100">
         {/* <button className="absolute right-2 top-2 rounded-full bg-white p-1 shadow">📌</button> */}
       </div>
       <div className="p-3">
@@ -51,15 +51,13 @@ export const ListingCompareCard = ({
           <p className="line-clamp-1 text-sm font-semibold">{title}</p>
           <button className="text-greyscale-grey-400">⋮</button>
         </div>
-
         <p className="line-clamp-1 text-xs text-greyscale-grey-500">{distance}</p>
-
         <p className="line-clamp-1 text-xs text-greyscale-grey-500">{option}</p>
-        <div className="flex flex-wrap gap-1">
+        <div className="mt-2 grid grid-cols-[64px_64px] gap-1">
           {tags.map((tag, index) => (
             <span
               key={index}
-              className="rounded-md border border-greyscale-grey-200 px-2 py-[2px] text-xs text-greyscale-grey-600"
+              className="rounded-md border border-greyscale-grey-200 py-[2px] text-center text-xs text-greyscale-grey-600"
             >
               {tag}
             </span>

--- a/src/widgets/listingsSection/ui/listingsCompareRoomSection/listingsCompareRoomSection.tsx
+++ b/src/widgets/listingsSection/ui/listingsCompareRoomSection/listingsCompareRoomSection.tsx
@@ -82,10 +82,10 @@ export const ListingCompareSection = ({ id }: { id: string }) => {
     <section className="mx-auto min-h-full w-full">
       <PageTransition>
         <ListingCompareHeader id={id} />
-        <div className="p-4">
+        <div className="p-5">
           <ListingsCompareContentHeader />
         </div>
-        <div className="grid grid-cols-2 items-stretch gap-2 px-4">
+        <div className="grid grid-cols-2 justify-center gap-4 px-4">
           {data.map(item => (
             <ListingCompareCard key={item.id} {...mapCompareItemToCardProps(item)} />
           ))}


### PR DESCRIPTION
## #️⃣ Issue Number

#269 

<br/>
<br/>

## 📝 요약(Summary) (선택)

-  공고상세 / 방비교 카드 디자인 수정
#### 변경
- ListingCompareHeader
- 헤더 타이틀 텍스트를 “방 비교” → “방 비교하기”로 변경
- ListingCompareCard
- 상단 이미지 영역 높이 140px → 92px로 축소, 하단 여백 제거
- 태그 영역 레이아웃을 flex-wrap → 2열 그리드(64px 64px)로 변경, 간격 확대 및 상단 여백 추가
- 태그 스타일에 text-center 적용, 가로 패딩 제거로 폭 고정에 맞춘 정렬


<br/>
<br/>

## 📸스크린샷 (선택)2

### 기존 스타일(UI 사진)
<img width="204" height="322" alt="Image" src="https://github.com/user-attachments/assets/4dacd565-1f5a-42a2-a924-52d7b1d77aee" />

### 변경 스타일(UI 사진)
<img width="178" height="282" alt="Image" src="https://github.com/user-attachments/assets/3a95921a-528a-4913-b0a8-03d58431dce8" />
<br/>
<br/>
