### PR TITLE
feat:방비교 조회 API 연결

### DIFF
--- a/src/entities/listings/api/__test__/listing.test.ts
+++ b/src/entities/listings/api/__test__/listing.test.ts
@@ -2,6 +2,7 @@
 import { IResponse } from "@/src/shared/types";
 import axios from "axios";
 import {
+  getNoticeParam,
   getNoticeSheetFilter,
   PostBasicRequest,
   PostParamsBodyRequest,
@@ -19,6 +20,8 @@ import {
   ListingUnitType,
   PinPointPlace,
   PopularKeywordItem,
+  UnitType,
+  UnitTypeRespnse,
 } from "../../model/type";
 import {
   COMPLEXES_ENDPOINT,
@@ -239,261 +242,6 @@ describe("인기검색어", () => {
     expect(result).toEqual(fakeResponse);
   });
 });
-
-// describe("공고상세조회(POST)", () => {
-//   beforeEach(() => {
-//     jest.clearAllMocks();
-//   });
-
-//   it.skip("공고상세조회 SUCCESS", async () => {
-//     const basicInfoMock: BasicInfo = {
-//       id: "19230",
-//       type: "국민임대",
-//       housingType: "아파트",
-//       supplier: "LH",
-//       name: "남양주시지역 국민임대주택 예비입주자모집(2025.11.05공고)",
-//       period: "2025년 11월 17일 ~ 2025년 11월 19일",
-//     };
-
-//     const nonFilteredComplexesMock: Complex[] = [
-//       {
-//         id: "19230#7",
-//         name: "미리내4-2",
-//         address: "경기도 남양주시 별내4로 25",
-//         heating: "지역난방",
-//         infra: ["도서관", "공원", "동물 관련시설", "스포츠 시설", "빨래방"],
-//         unitCount: 3,
-//       },
-//       {
-//         id: "19230#8",
-//         name: "미리내4-4",
-//         address: "경기도 남양주시 별내3로 23",
-//         heating: "지역난방",
-//         infra: ["공원", "동물 관련시설", "스포츠 시설"],
-//         unitCount: 2,
-//       },
-//       {
-//         id: "19230#12",
-//         name: "별빛3-6",
-//         address: "경기도 남양주시 별내3로 64-16",
-//         heating: "지역난방",
-//         infra: ["공원", "동물 관련시설", "스포츠 시설"],
-//         unitCount: 1,
-//       },
-//       {
-//         id: "19230#14",
-//         name: "별사랑2-5",
-//         address: "경기도 남양주시 별내5로 189",
-//         heating: "지역난방",
-//         infra: ["공원", "동물 관련시설", "스포츠 시설"],
-//         unitCount: 2,
-//       },
-//       {
-//         id: "19230#4",
-//         name: "진접24",
-//         address: "경기도 남양주시 진접읍 해밀예당1로 295",
-//         heating: "개별난방",
-//         infra: ["공원", "동물 관련시설", "스포츠 시설"],
-//         unitCount: 1,
-//       },
-//     ];
-
-//     const filterdData: Complex[] = [
-//       {
-//         id: "19230#7",
-//         name: "미리내4-2",
-//         address: "경기도 남양주시 별내4로 25",
-//         heating: "지역난방",
-//         infra: ["도서관", "공원", "동물 관련시설", "스포츠 시설", "빨래방"],
-//         unitCount: 2,
-//       },
-//       {
-//         id: "19230#8",
-//         name: "미리내4-4",
-//         address: "경기도 남양주시 별내3로 23",
-//         heating: "지역난방",
-//         infra: ["공원", "동물 관련시설", "스포츠 시설"],
-//         unitCount: 2,
-//       },
-//       {
-//         id: "19230#12",
-//         name: "별빛3-6",
-//         address: "경기도 남양주시 별내3로 64-16",
-//         heating: "지역난방",
-//         infra: ["공원", "동물 관련시설", "스포츠 시설"],
-//         unitCount: 1,
-//       },
-//       {
-//         id: "19230#14",
-//         name: "별사랑2-5",
-//         address: "경기도 남양주시 별내5로 189",
-//         heating: "지역난방",
-//         infra: ["공원", "동물 관련시설", "스포츠 시설"],
-//         unitCount: 2,
-//       },
-//     ];
-
-//     const listingDetailMock: ListingDetailData = {
-//       basicInfo: basicInfoMock,
-//       filtered: {
-//         totalCount: 4,
-//         complexes: filterdData,
-//       },
-//       nonFiltered: {
-//         totalCount: 5,
-//         complexes: nonFilteredComplexesMock,
-//       },
-//     };
-
-//     const fakeResponse: ListingDetailResponse = {
-//       success: true,
-//       code: 200,
-//       message: "호출이 성공적으로 완료되었습니다.",
-//       data: listingDetailMock,
-//     };
-
-//     const listingDetilBody = {
-//       sortType: "거리 순",
-//       pinPointId: "fec9aba3-0fd9-4b75-bebf-9cb7641fd251",
-//       transitTime: 100,
-//       maxDeposit: 50000000,
-//       maxMonthPay: 300000,
-//     };
-
-//     (http.post as jest.Mock).mockResolvedValue({
-//       fakeResponse,
-//     });
-
-//     const result = await PostBasicRequest(`${NOTICE_ENDPOINT}/19230`, "post", listingDetilBody);
-//     expect(http.post).toHaveBeenCalledWith(`${NOTICE_ENDPOINT}/19230`, listingDetilBody);
-//     expect(result).toEqual({ fakeResponse });
-//   });
-
-//   it.skip("공고상세실패", async () => {
-//     const basicInfoMock: BasicInfo = {
-//       id: "19230",
-//       type: "국민임대",
-//       housingType: "아파트",
-//       supplier: "LH",
-//       name: "남양주시지역 국민임대주택 예비입주자모집(2025.11.05공고)",
-//       period: "2025년 11월 17일 ~ 2025년 11월 19일",
-//     };
-
-//     const nonFilteredComplexesMock: Complex[] = [
-//       {
-//         id: "19230#7",
-//         name: "미리내4-2",
-//         address: "경기도 남양주시 별내4로 25",
-//         heating: "지역난방",
-//         infra: ["도서관", "공원", "동물 관련시설", "스포츠 시설", "빨래방"],
-//         unitCount: 3,
-//       },
-//       {
-//         id: "19230#8",
-//         name: "미리내4-4",
-//         address: "경기도 남양주시 별내3로 23",
-//         heating: "지역난방",
-//         infra: ["공원", "동물 관련시설", "스포츠 시설"],
-//         unitCount: 2,
-//       },
-//       {
-//         id: "19230#12",
-//         name: "별빛3-6",
-//         address: "경기도 남양주시 별내3로 64-16",
-//         heating: "지역난방",
-//         infra: ["공원", "동물 관련시설", "스포츠 시설"],
-//         unitCount: 1,
-//       },
-//       {
-//         id: "19230#14",
-//         name: "별사랑2-5",
-//         address: "경기도 남양주시 별내5로 189",
-//         heating: "지역난방",
-//         infra: ["공원", "동물 관련시설", "스포츠 시설"],
-//         unitCount: 2,
-//       },
-//       {
-//         id: "19230#4",
-//         name: "진접24",
-//         address: "경기도 남양주시 진접읍 해밀예당1로 295",
-//         heating: "개별난방",
-//         infra: ["공원", "동물 관련시설", "스포츠 시설"],
-//         unitCount: 1,
-//       },
-//     ];
-
-//     const filterdData: Complex[] = [
-//       {
-//         id: "19230#7",
-//         name: "미리내4-2",
-//         address: "경기도 남양주시 별내4로 25",
-//         heating: "지역난방",
-//         infra: ["도서관", "공원", "동물 관련시설", "스포츠 시설", "빨래방"],
-//         unitCount: 2,
-//       },
-//       {
-//         id: "19230#8",
-//         name: "미리내4-4",
-//         address: "경기도 남양주시 별내3로 23",
-//         heating: "지역난방",
-//         infra: ["공원", "동물 관련시설", "스포츠 시설"],
-//         unitCount: 2,
-//       },
-//       {
-//         id: "19230#12",
-//         name: "별빛3-6",
-//         address: "경기도 남양주시 별내3로 64-16",
-//         heating: "지역난방",
-//         infra: ["공원", "동물 관련시설", "스포츠 시설"],
-//         unitCount: 1,
-//       },
-//       {
-//         id: "19230#14",
-//         name: "별사랑2-5",
-//         address: "경기도 남양주시 별내5로 189",
-//         heating: "지역난방",
-//         infra: ["공원", "동물 관련시설", "스포츠 시설"],
-//         unitCount: 2,
-//       },
-//     ];
-
-//     const listingDetailMock: ListingDetailData = {
-//       basicInfo: basicInfoMock,
-//       filtered: {
-//         totalCount: 4,
-//         complexes: filterdData,
-//       },
-//       nonFiltered: {
-//         totalCount: 5,
-//         complexes: nonFilteredComplexesMock,
-//       },
-//     };
-
-//     const fakeResponse: ListingDetailResponse = {
-//       success: true,
-//       code: 200,
-//       message: "호출이 성공적으로 완료되었습니다.",
-//       data: listingDetailMock,
-//     };
-
-//     const listingDetilBody = {
-//       sortType: "거리 순",
-//       pinPointId: "fec9aba3-0fd9-4b75-bebf-9cb7641fd251",
-//       transitTime: 100,
-//       maxDeposit: 50000000,
-//       maxMonthPay: 300000,
-//     };
-
-//     const error = new Error("Network Error");
-//     (http.post as jest.Mock).mockRejectedValue(error);
-//     await expect(
-//       PostBasicRequest(`${NOTICE_ENDPOINT}/19230`, "post", listingDetilBody)
-//     ).rejects.toThrow("Network Error");
-//   });
-// });
-
-// 19401#1
-// fec9aba3-0fd9-4b75-bebf-9cb7641fd251
 
 describe("단지정보상세조회API", () => {
   beforeEach(() => {
@@ -941,7 +689,7 @@ describe("핀포인트 공고단지 필터 시트 조회", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
-  it("핀포인트 공고단지 필터 시트 조회", async () => {
+  it.skip("핀포인트 공고단지 필터 시트 조회", async () => {
     const MOCK_PRICE_DISTRIBUTION: CostResponse = {
       minPrice: 8_485_000,
       maxPrice: 28_853_000,
@@ -980,5 +728,46 @@ describe("핀포인트 공고단지 필터 시트 조회", () => {
       rangeStart: 8_485_000,
       count: 2,
     });
+  });
+});
+
+describe("방비교 API 조회", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it("비교 API 조회", async () => {
+    const MOCK_PRICE_DISTRIBUTION: UnitType[] = [
+      {
+        typeId: "fc82f471ebc2480db6c06177",
+        typeCode: "16A",
+        complex: {
+          complexId: "18214#5",
+          name: "양주고읍A-13",
+          address: "경기도 양주시 고읍남로 94",
+        },
+        area: {
+          exclusiveAreaM2: 16.89,
+          exclusiveAreaPyeong: 5.11,
+        },
+        cost: {
+          totalDeposit: 1644,
+          monthlyRent: 75350,
+        },
+        nearbyFacilities: ["공원", "동물 관련시설", "스포츠 시설"],
+        totalTime: "1시간 17분",
+        isLiked: false,
+        group: ["일반"],
+      },
+    ];
+
+    (http.get as jest.Mock).mockResolvedValue(MOCK_PRICE_DISTRIBUTION);
+    const params = {
+      pinPoint: "fec9aba3-0fd9-4b75-bebf-9cb7641fd251",
+      sortType: "핀포인트 거리순",
+      nearbyFacilities: ["도서관"],
+    };
+    const url = `${NOTICE_ENDPOINT}/18214/compare`;
+    const result = await getNoticeParam<UnitTypeRespnse>(url, params);
+    expect(result).toMatchObject(MOCK_PRICE_DISTRIBUTION);
   });
 });

--- a/src/entities/listings/api/listingsApi.ts
+++ b/src/entities/listings/api/listingsApi.ts
@@ -70,3 +70,16 @@ export const getNoticeSheetFilter = async <
   const res = await http.get<TResponse>(url);
   return res as unknown as TData;
 };
+
+export type QueryParams = Record<string, string | string[] | undefined>;
+export const getNoticeParam = async <
+  TData,
+  TResponse extends IResponse<TData> = IResponse<TData>,
+  P extends QueryParams = QueryParams,
+>(
+  url: string,
+  params?: P
+): Promise<TData> => {
+  const res = await http.get<TResponse, P>(url, params);
+  return res.data as unknown as TData;
+};

--- a/src/entities/listings/hooks/useListingDetailHooks.ts
+++ b/src/entities/listings/hooks/useListingDetailHooks.ts
@@ -1,4 +1,4 @@
-import { useQuery, keepPreviousData } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import {
   endPoint,
   Environmnt,
@@ -8,11 +8,17 @@ import {
   ListingRentalDetailVM,
   ListingSummary,
   LstingBody,
-  UseListingsDetailHooksType,
+  UnitTypeRespnse,
   UseListingsHooksType,
   UseListingsHooksWithParam,
 } from "../model/type";
-import { PostBasicRequest, PostParamsBodyRequest, requestListingList } from "../api/listingsApi";
+import {
+  getNoticeParam,
+  PostBasicRequest,
+  PostParamsBodyRequest,
+  QueryParams,
+  requestListingList,
+} from "../api/listingsApi";
 import { COMPLEXES_ENDPOINT, NOTICE_ENDPOINT } from "@/src/shared/api";
 import { IResponse } from "@/src/shared/types";
 import { getListingsRental } from "@/src/features/listings/hooks/listingsHooks";
@@ -198,10 +204,10 @@ export const useListingRouteDetail = <T, TParam extends object>({
 };
 
 export const useListingFilterDetail = <T>() => {
-  const pinPointId = useOAuthStore();
+  const { pinPointId } = useOAuthStore();
 
   return useQuery<IResponse<T>, Error, T>({
-    queryKey: ["pinpoint"],
+    queryKey: [pinPointId],
     staleTime: 1000 * 60 * 5,
     queryFn: () => PostBasicRequest<T, IResponse<T>, {}, IResponse<T>>(endPoint["pinpoint"], "get"),
     select: response => {
@@ -210,5 +216,21 @@ export const useListingFilterDetail = <T>() => {
       }
       return response.data;
     },
+  });
+};
+
+export const useListingRoomCompare = <T>({ noticeId, sortType, nearbyFacilities }: QueryParams) => {
+  const { pinPointId } = useOAuthStore();
+
+  const params: QueryParams = {
+    pinPointId,
+    sortType,
+    nearbyFacilities,
+  };
+
+  return useQuery<IResponse<T>, Error, T>({
+    queryKey: ["compareNotice", noticeId, sortType, nearbyFacilities],
+    queryFn: () => getNoticeParam<IResponse<T>>(`${NOTICE_ENDPOINT}/${noticeId}/compare`, params),
+    enabled: Boolean(noticeId && noticeId),
   });
 };

--- a/src/entities/listings/hooks/useListingHooks.ts
+++ b/src/entities/listings/hooks/useListingHooks.ts
@@ -1,10 +1,4 @@
-import {
-  InfiniteData,
-  useInfiniteQuery,
-  useMutation,
-  useQuery,
-  useQueryClient,
-} from "@tanstack/react-query";
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { PostBasicRequest, requestListingList } from "../api/listingsApi";
 import {

--- a/src/entities/listings/model/type.ts
+++ b/src/entities/listings/model/type.ts
@@ -611,3 +611,39 @@ export interface CostRange {
   rangeEnd: number;
   count: number;
 }
+
+/** 단지 정보 */
+export interface RoomCompareComplex {
+  complexId: string;
+  name: string;
+  address: string;
+}
+
+/** 면적 정보 */
+export interface Area {
+  exclusiveAreaM2: number; // ㎡
+  exclusiveAreaPyeong: number; // 평
+}
+
+/** 비용 정보 */
+export interface Cost {
+  totalDeposit: number; // 보증금 (만원 단위로 보임)
+  monthlyRent: number; // 월세 (원 or 만원 → 백엔드 단위 확인 필요)
+}
+
+/** 유닛 타입 */
+export interface UnitType {
+  typeId: string;
+  typeCode: string;
+  complex: RoomCompareComplex;
+  area: Area;
+  cost: Cost;
+  nearbyFacilities: string[];
+  totalTime: string; // 예: "1시간 17분"
+  isLiked: boolean;
+  group: string[];
+}
+
+export interface UnitTypeRespnse {
+  unitTypes: UnitType[];
+}

--- a/src/features/listings/ui/listingsCompareRoom/components/listingsCompareCards.tsx
+++ b/src/features/listings/ui/listingsCompareRoom/components/listingsCompareCards.tsx
@@ -1,63 +1,65 @@
-export type ListingCompareItem = {
-  id: string;
-  roomType: string; // 대학생, 청년, 신혼부부 등
-  complexName: string; // 단지명
-  distanceText: string; // 거리 정보
-  priceText: string; // 보증금/월세
-  optionText: string; // 면적/옵션
-  tags: string[]; // 인프라 태그
-};
+import { UnitType } from "@/src/entities/listings/model/type";
+import { formatNumber } from "@/src/shared/lib/numberFormat";
+import { TagButton } from "@/src/shared/ui/button/tagButton";
+import { LikeType } from "../../../hooks/listingsHooks";
 
-export type ListingCompareCardProps = {
-  id: string;
-  roomTypeLabel: string;
-  title: string;
-  distance: string;
-  price: string;
-  option: string;
-  tags: string[];
-};
-
-export const mapCompareItemToCardProps = (item: ListingCompareItem): ListingCompareCardProps => ({
-  id: item.id,
-  roomTypeLabel: item.roomType,
-  title: item.complexName,
-  distance: item.distanceText,
-  price: item.priceText,
-  option: item.optionText,
-  tags: item.tags,
-});
-
-export const ListingCompareCard = ({
-  id,
-  roomTypeLabel,
-  title,
-  distance,
-  price,
-  option,
-  tags,
-}: ListingCompareCardProps) => {
+export const ListingCompareCard = (unit: UnitType) => {
   return (
     <article className="flex h-full flex-col rounded-xl border bg-white">
-      <div className="relative h-[92px] w-full rounded-t-lg bg-greyscale-grey-100">
-        {/* <button className="absolute right-2 top-2 rounded-full bg-white p-1 shadow">📌</button> */}
+      <div className="relative h-[92px] w-full rounded-t-lg bg-greyscale-grey-25">
+        <div className="absolute right-2 top-2 rounded-full">
+          <LikeType
+            id={unit.typeId}
+            liked={unit.isLiked}
+            type="ROOM"
+            resetQuery={["useListingRoomTypeDetail"]}
+          />
+        </div>
+        {unit.group.map(item => (
+          <div className="absolute top-[70px] pl-1 text-xs-12" key={item}>
+            <TagButton
+              key={item}
+              size="xxs"
+              variant="ghost"
+              className="rounded-md border border-greyscale-grey-100 bg-white text-xs font-bold text-greyscale-grey-400"
+            >
+              {item}
+            </TagButton>
+          </div>
+        ))}
       </div>
       <div className="p-3">
-        <span className="mb-1 inline-block text-xs font-medium text-greyscale-grey-500">
-          {roomTypeLabel}
-        </span>
-
         <div className="mb-1 flex items-center justify-between">
-          <p className="line-clamp-1 text-sm font-semibold">{title}</p>
+          <p className="line-clamp-1 text-sm font-semibold">{unit.complex.name}</p>
           <button className="text-greyscale-grey-400">⋮</button>
         </div>
-        <p className="line-clamp-1 text-xs text-greyscale-grey-500">{distance}</p>
-        <p className="line-clamp-1 text-xs text-greyscale-grey-500">{option}</p>
-        <div className="mt-2 grid grid-cols-[64px_64px] gap-1">
-          {tags.map((tag, index) => (
+        <div className="mb-1 flex gap-4">
+          <p className="flex flex-col text-xs text-greyscale-grey-600">
+            <span>보증금 </span>
+            <span>{formatNumber(unit.cost.totalDeposit)}만원</span>
+          </p>
+
+          <p className="flex flex-col text-xs text-greyscale-grey-600">
+            <span>월임대료 </span>
+            <span>{formatNumber(unit.cost.monthlyRent)}만원</span>
+          </p>
+        </div>
+
+        <div className="flex gap-4">
+          <p className="flex flex-col text-xs text-greyscale-grey-600">
+            <span>전용면적 </span>
+            <span>
+              {unit.area.exclusiveAreaM2}m<sup>2</sup> ({unit.area.exclusiveAreaPyeong}
+              )평
+            </span>
+          </p>
+        </div>
+
+        <div className="mt-2 grid grid-cols-2 gap-1">
+          {unit.nearbyFacilities.map((tag, index) => (
             <span
               key={index}
-              className="rounded-md border border-greyscale-grey-200 py-[2px] text-center text-xs text-greyscale-grey-600"
+              className="truncate rounded-md border border-greyscale-grey-200 py-[2px] text-center text-xs text-greyscale-grey-600"
             >
               {tag}
             </span>

--- a/src/features/listings/ui/listingsCompareRoom/components/listingsCompareContentHeader.tsx
+++ b/src/features/listings/ui/listingsCompareRoom/components/listingsCompareContentHeader.tsx
@@ -2,22 +2,13 @@ import { ArrowUpArrowDown } from "@/src/assets/icons/button/arrowUpArrowDown";
 import { CaretDropDown } from "@/src/shared/ui/dropDown/CaretDropDown";
 import { listingsComparePoint } from "../../../model";
 
-export const ListingsCompareContentHeader = () => {
-  // const onChange = (e: MouseEvent<HTMLDivElement>) => {
-  //   e.preventDefault();
-  //   const saveSortType = isSearchPage ? setSearchSortType : setSortType;
-  //   const nextSortType = sortType === "최신공고순" ? "마감임박순" : "최신공고순";
-  //   const nextSearchSortType = searchSortType === "LATEST" ? "DEADLINE" : "LATEST";
-  //   const sortTypeValue = isSearchPage ? nextSearchSortType : nextSortType;
-  //   saveSortType(sortTypeValue);
-  // };
-
+export const ListingsCompareContentHeader = ({ count }: { count: string }) => {
   return (
     <section className="border-greyscale-grey-100 bg-white">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-1 text-xl font-bold">
           <p className="text-base-17 text-text-primary">방</p>
-          <p className="text-base-17 text-text-tertiary">{"00"}</p>
+          <p className="text-base-17 text-text-tertiary">{count}</p>
         </div>
 
         <div className="flex items-center">

--- a/src/shared/ui/button/tagButton/button.variants.ts
+++ b/src/shared/ui/button/tagButton/button.variants.ts
@@ -19,6 +19,7 @@ export const buttonVariants = cva(
         md: "h-10 px-4 text-base",
         lg: "h-12 w-full px-5 text-lg",
         xs: "h-6 px-2 text-sm",
+        xxs: "px-1 text-sm",
       },
     },
     defaultVariants: {

--- a/src/widgets/listingsSection/ui/listingsCompareRoomSection/listingsCompareRoomSection.tsx
+++ b/src/widgets/listingsSection/ui/listingsCompareRoomSection/listingsCompareRoomSection.tsx
@@ -1,101 +1,46 @@
+"use client";
+import { useListingRoomCompare } from "@/src/entities/listings/hooks/useListingDetailHooks";
+import { UnitTypeRespnse } from "@/src/entities/listings/model/type";
 import {
   ListingCompareCard,
   ListingCompareHeader,
-  ListingCompareItem,
   ListingsCompareContentHeader,
-  mapCompareItemToCardProps,
 } from "@/src/features/listings/ui/listingsCompareRoom";
 import { ListingCompareCardSkeleton } from "@/src/features/listings/ui/listingsCompareRoom/components/listingsCompareCardSkeleton";
-
 import { PageTransition } from "@/src/shared/ui/animation";
-import { Skeleton } from "@/src/shared/ui/skeleton/skeleton";
-
-export const LISTING_COMPARE_MOCK: ListingCompareItem[] = [
-  {
-    id: "room-001",
-    roomType: "대학생",
-    complexName: "진주가좌올리움",
-    distanceText: "핀포인트로부터 약 09시 00분 거리",
-    priceText: "보증금 0만원 · 월임대료 0만원",
-    optionText: "전용면적 약 26㎡ (8평)",
-    tags: ["버스정류장", "편의점", "마트"],
-  },
-  {
-    id: "room-002",
-    roomType: "청년",
-    complexName: "가좌청년주택",
-    distanceText: "핀포인트로부터 약 12시 00분 거리",
-    priceText: "보증금 300만원 · 월임대료 15만원",
-    optionText: "전용면적 약 31㎡ (9평)",
-    tags: ["지하철", "카페", "병원"],
-  },
-  {
-    id: "room-003",
-    roomType: "신혼부부",
-    complexName: "진주역 행복주택",
-    distanceText: "핀포인트로부터 약 15시 00분 거리",
-    priceText: "보증금 800만원 · 월임대료 25만원",
-    optionText: "전용면적 약 42㎡ (13평)",
-    tags: ["초등학교", "공원", "마트"],
-  },
-  {
-    id: "room-004",
-    roomType: "고령자",
-    complexName: "진주노인복지주택",
-    distanceText: "핀포인트로부터 약 10시 30분 거리",
-    priceText: "보증금 200만원 · 월임대료 10만원",
-    optionText: "전용면적 약 29㎡ (9평)",
-    tags: ["병원", "약국", "복지관"],
-  },
-  {
-    id: "room-005",
-    roomType: "고령자",
-    complexName: "진주노인복지주택",
-    distanceText: "핀포인트로부터 약 10시 30분 거리",
-    priceText: "보증금 200만원 · 월임대료 10만원",
-    optionText: "전용면적 약 29㎡ (9평)",
-    tags: ["병원", "약국", "복지관"],
-  },
-  {
-    id: "room-006",
-    roomType: "고령자",
-    complexName: "진주노인복지주택",
-    distanceText: "핀포인트로부터 약 10시 30분 거리",
-    priceText: "보증금 200만원 · 월임대료 10만원",
-    optionText: "전용면적 약 29㎡ (9평)",
-    tags: ["병원", "약국", "복지관"],
-  },
-  {
-    id: "room-007",
-    roomType: "고령자",
-    complexName: "진주노인복지주택",
-    distanceText: "핀포인트로부터 약 10시 30분 거리",
-    priceText: "보증금 200만원 · 월임대료 10만원",
-    optionText: "전용면적 약 29㎡ (9평)",
-    tags: ["병원", "약국", "복지관"],
-  },
-];
 
 export const ListingCompareSection = ({ id }: { id: string }) => {
-  const data = LISTING_COMPARE_MOCK; // 나중에 API
+  // const data = LISTING_COMPARE_MOCK;
+  const { data, isLoading, error } = useListingRoomCompare<UnitTypeRespnse>({
+    noticeId: id,
+    sortType: "핀포인트 거리순",
+    nearbyFacilities: ["도서관"],
+  });
+  const unitData = data?.unitTypes;
+  const count = Number(data?.unitTypes?.length);
+  const zeroCount = count <= 10 ? `0${count}` : `${count}`;
   return (
     <section className="mx-auto min-h-full w-full">
       <PageTransition>
         <ListingCompareHeader id={id} />
         <div className="p-5">
-          <ListingsCompareContentHeader />
+          <ListingsCompareContentHeader count={zeroCount} />
         </div>
-        <div className="grid grid-cols-2 justify-center gap-4 px-4">
-          {data.map(item => (
-            <ListingCompareCard key={item.id} {...mapCompareItemToCardProps(item)} />
-          ))}
-        </div>
-
-        {/* <div className="grid grid-cols-2 gap-2 p-4">
-          {Array.from({ length: 6 }).map((_, i) => (
-            <ListingCompareCardSkeleton key={i} />
-          ))}
-        </div> */}
+        {isLoading ? (
+          <div className="grid grid-cols-2 gap-2 p-4">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <ListingCompareCardSkeleton key={i} />
+            ))}
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 justify-center gap-4 px-4">
+            {unitData?.map(unit => (
+              <div key={unit.typeId}>
+                <ListingCompareCard {...unit} />
+              </div>
+            ))}
+          </div>
+        )}
       </PageTransition>
     </section>
   );


### PR DESCRIPTION
## #️⃣ Issue Number

#271 

<br/>
<br/>

## 📝 요약(Summary) (선택)

#### 추가
- ListingCompareCard : 좋아요 버튼(LikeType) 렌더링 , 그룹 태그(TagButton) 렌더링
- ListingsCompareContentHeader : count prop 도입
- ListingCompareSection : useListingRoomCompare 데이터 조회 및 로딩 스켈레톤 분기 렌더링
#### 변경
- ListingCompareCard : props 타입 대신 UnitType 직접 사용 , 단지명/보증금/월임대료/전용면적/인프라 표시 구조로 UI 재구성
- ListingsCompareContentHeader : 방 개수 표시를 고정값에서 count로 출력
#### 삭제
ListingCompareItem, ListingCompareCardProps, mapCompareItemToCardProps 타입/매핑 유틸 제거

<br/>
<br/>

## 📸스크린샷 (선택)2

<img width="379" height="304" alt="Image" src="https://github.com/user-attachments/assets/403dfaad-5da2-47f2-acdf-8277268d3e7b" />
<br/>
<br/>

