### PR TITLE
feat:핀하우스 home 공고 카운트 API연결

### DIFF
--- a/src/entities/home/api/__test__/home.test.ts
+++ b/src/entities/home/api/__test__/home.test.ts
@@ -1,0 +1,48 @@
+import { HOME_NOTICE_ENDPOINT, http } from "@/src/shared/api";
+import { NoticeCount } from "../../model/type";
+import { IResponse } from "@/src/shared/types";
+import { getNoticeByPinPoint } from "../../interface/homeInterface";
+
+jest.mock("@/src/shared/api/http", () => ({
+  http: {
+    get: jest.fn(),
+    post: jest.fn(),
+    delete: jest.fn(),
+    put: jest.fn(),
+    patch: jest.fn(),
+  },
+}));
+
+interface paramType {
+  pinPoint: string;
+  maxTime: number;
+}
+
+describe("핀포인트 기준 공고 카운트", () => {
+  it("공고 카운트 SUCCESS", async () => {
+    const param: paramType = {
+      pinPoint: "83ec36ce-8fc1-4f62-8983-397c2729fc22",
+      maxTime: 30,
+    };
+    const url = `${HOME_NOTICE_ENDPOINT}-count`;
+    (http.get as jest.Mock).mockResolvedValue({
+      data: {
+        data: {
+          count: 1,
+        },
+      },
+    });
+
+    const result = await getNoticeByPinPoint<IResponse<NoticeCount>>({
+      url,
+      params: param,
+    });
+
+    expect(http.get).toHaveBeenCalledWith(url, param, undefined);
+    expect(result).toEqual({
+      data: {
+        count: 1,
+      },
+    });
+  });
+});

--- a/src/entities/home/api/homeApi.ts
+++ b/src/entities/home/api/homeApi.ts
@@ -4,7 +4,7 @@ import { AxiosRequestConfig } from "axios";
 
 export const getWithSlice = async <T, P extends Record<string, any>>(
   url: string,
-  params: P,
+  params?: P,
   options?: AxiosRequestConfig
 ): Promise<T> => {
   const apiCall = HTTP_METHODS["get"];

--- a/src/entities/home/hooks/homeHooks.ts
+++ b/src/entities/home/hooks/homeHooks.ts
@@ -1,32 +1,41 @@
-import { InfiniteData, useInfiniteQuery } from "@tanstack/react-query";
+import { InfiniteData, useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { getNoticeByPinPoint } from "../interface/homeInterface";
-import { NoticeContent, SliceResponse } from "../model/type";
+import { NoticeContent, NoticeCount, SliceResponse } from "../model/type";
 import { useOAuthStore } from "@/src/features/login/model";
 import { HOME_NOTICE_ENDPOINT } from "@/src/shared/api";
 
 export const useNoticeInfinite = () => {
   const pinpointId = useOAuthStore(state => state.pinPointId);
-  return useInfiniteQuery<
-    SliceResponse<NoticeContent>,
-    Error,
-    InfiniteData<SliceResponse<NoticeContent>>,
-    [string, string],
-    number
-  >({
+
+  return useInfiniteQuery({
     queryKey: ["notice", pinpointId],
-    initialPageParam: 1,
     enabled: !!pinpointId,
+    initialPageParam: 1,
     queryFn: ({ pageParam }) =>
-      getNoticeByPinPoint({
+      getNoticeByPinPoint<SliceResponse<NoticeContent>>({
+        url: HOME_NOTICE_ENDPOINT,
         params: {
-          pinpointId: pinpointId,
+          pinpointId,
           page: Number(pageParam),
           offSet: 10,
         },
-        url: HOME_NOTICE_ENDPOINT,
       }),
     getNextPageParam: lastPage => {
       return lastPage.hasNext ? lastPage.pages + 1 : undefined;
     },
+  });
+};
+
+export const useNoticeCount = () => {
+  const pinPointId = useOAuthStore(state => state.pinPointId);
+  const param = {
+    pinPointId,
+    maxTime: 30,
+  };
+  const url = `${HOME_NOTICE_ENDPOINT}-count`;
+  return useQuery({
+    queryKey: ["noticeCount", pinPointId],
+    enabled: !!pinPointId,
+    queryFn: () => getNoticeByPinPoint<NoticeCount>({ url: url, params: param }),
   });
 };

--- a/src/entities/home/interface/homeInterface.ts
+++ b/src/entities/home/interface/homeInterface.ts
@@ -1,13 +1,11 @@
-import { IResponse } from "@/src/shared/types";
-import { NoticeByPinPointParams, NoticeContent, SliceResponse } from "../model/type";
 import { getWithSlice } from "../api/homeApi";
 
-export const getNoticeByPinPoint = ({
+export const getNoticeByPinPoint = <T, P extends Record<string, any> = Record<string, any>>({
   params,
   url,
 }: {
-  params: NoticeByPinPointParams;
+  params?: P;
   url: string;
 }) => {
-  return getWithSlice<SliceResponse<NoticeContent>, NoticeByPinPointParams>(url, params);
+  return getWithSlice<T, P>(url, params);
 };

--- a/src/entities/home/model/type.ts
+++ b/src/entities/home/model/type.ts
@@ -35,3 +35,7 @@ export interface NoticeContent {
   applyPeriod: string; // 신청 기간 (문자열)
   liked: boolean; // 관심 여부
 }
+
+export interface NoticeCount {
+  count: number;
+}

--- a/src/entities/listings/api/__test__/listing.test.ts
+++ b/src/entities/listings/api/__test__/listing.test.ts
@@ -735,6 +735,7 @@ describe("방비교 API 조회", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
+
   it("비교 API 조회", async () => {
     const MOCK_PRICE_DISTRIBUTION: UnitType[] = [
       {
@@ -760,14 +761,20 @@ describe("방비교 API 조회", () => {
       },
     ];
 
-    (http.get as jest.Mock).mockResolvedValue(MOCK_PRICE_DISTRIBUTION);
+    (http.get as jest.Mock).mockResolvedValue({
+      data: MOCK_PRICE_DISTRIBUTION,
+    });
+
     const params = {
       pinPoint: "fec9aba3-0fd9-4b75-bebf-9cb7641fd251",
       sortType: "핀포인트 거리순",
       nearbyFacilities: ["도서관"],
     };
+
     const url = `${NOTICE_ENDPOINT}/18214/compare`;
     const result = await getNoticeParam<UnitTypeRespnse>(url, params);
+
+    expect(http.get).toHaveBeenCalledWith(url, params);
     expect(result).toMatchObject(MOCK_PRICE_DISTRIBUTION);
   });
 });

--- a/src/features/home/ui/homeActionCardList.tsx
+++ b/src/features/home/ui/homeActionCardList.tsx
@@ -1,6 +1,10 @@
 import { ArrowUpRight } from "@/src/assets/icons/button/arrowUpRight";
+import { useNoticeCount } from "@/src/entities/home/hooks/homeHooks";
 
 export const ActionCardList = () => {
+  const { data } = useNoticeCount();
+  const conut = data?.count;
+
   return (
     <div className="mb-4 flex gap-4">
       <div className="flex min-h-[88px] flex-1 flex-col justify-between rounded-lg bg-primary-blue-300 px-4 py-3">
@@ -11,7 +15,7 @@ export const ActionCardList = () => {
           </div>
         </div>
 
-        <p className="text-xl font-bold leading-tight text-white">00건</p>
+        <p className="text-xl font-bold leading-tight text-white">{conut}건</p>
       </div>
 
       <div
@@ -27,7 +31,7 @@ export const ActionCardList = () => {
         </div>
 
         <div className="flex gap-2 text-xl leading-tight">
-          <p className="font-bold text-white">00건</p>
+          <p className="font-bold text-white">0건</p>
           <span
             className="flex items-center rounded-xl bg-greyscale-grey-25 p-1 text-xs font-bold"
             style={{ color: "#FFBA18" }}

--- a/src/features/home/ui/homeUrgentNoticeList.tsx
+++ b/src/features/home/ui/homeUrgentNoticeList.tsx
@@ -9,7 +9,7 @@ import { useRouter } from "next/navigation";
 import { useListingsFilterStore } from "../../listings/model";
 
 export const UrgentNoticeList = () => {
-  const { data, isFetchingNextPage, isError, hasNextPage, fetchNextPage } = useNoticeInfinite();
+  const { data, isFetchingNextPage, isError, fetchNextPage } = useNoticeInfinite();
   const contents = data?.pages?.flatMap(page => page.content) ?? [];
   const dataCount = contents.length === 0;
   const region = data?.pages?.flatMap(page => page.region) ?? [];
@@ -28,7 +28,7 @@ export const UrgentNoticeList = () => {
       <div className="flex items-center justify-between">
         <div>
           <p className="mb-3 text-lg font-bold text-greyscale-grey-900">
-            {isError && dataCount ? "공고 리스트" : "마감임박 공고"}
+            {isError || dataCount ? "공고 리스트" : "마감임박 공고"}
           </p>
         </div>
         <div
@@ -42,7 +42,7 @@ export const UrgentNoticeList = () => {
       </div>
 
       <div className="flex flex-col">
-        {isError && dataCount ? (
+        {isError || dataCount ? (
           <ListingsContent viewSet={false} />
         ) : (
           <HomeContentsCard data={contents} />


### PR DESCRIPTION


## #️⃣ Issue Number

#275 

<br/>
<br/>

## 📝 요약(Summary) (선택)

#### 변경
- homeApi.ts getWithSlice params를 optional로 변경
- homeHooks.ts useNoticeInfinite 정리 + useNoticeCount 추가
- homeInterface.ts getNoticeByPinPoint 제네릭/params optional로 변경
- listing.test.ts mock 응답 형태 수정 + http.get 호출 검증 추가
- homeActionCardList.tsx 공고 카운트를 API로 표시
- homeUrgentNoticeList.tsx 에러/빈데이터 조건 로직 수정 + unused 제거
#### 추가
- home.test.ts 공고 카운트 테스트 신규
- type.ts NoticeCount 타입 추가
<br/>
<br/>

## 📸스크린샷 (선택)2
<img width="195" height="108" alt="Image" src="https://github.com/user-attachments/assets/bf1485ce-8575-4668-85be-6590b8638ce0" />

<br/>
<br/>
