### PR TITLE
feat:공고상세 방비교 / 룸 타입 바텀 시트 추가

### DIFF
--- a/src/entities/listings/hooks/useListingDetailHooks.ts
+++ b/src/entities/listings/hooks/useListingDetailHooks.ts
@@ -229,8 +229,8 @@ export const useListingRoomCompare = <T>({ noticeId, sortType, nearbyFacilities 
   };
 
   return useQuery<IResponse<T>, Error, T>({
-    queryKey: ["compareNotice", noticeId, sortType, nearbyFacilities],
+    queryKey: ["compareNotice", noticeId, sortType, nearbyFacilities, pinPointId],
     queryFn: () => getNoticeParam<IResponse<T>>(`${NOTICE_ENDPOINT}/${noticeId}/compare`, params),
-    enabled: Boolean(noticeId && noticeId),
+    enabled: Boolean(noticeId && pinPointId),
   });
 };

--- a/src/features/listings/ui/listingsCardDetail/infra/components/roomTypeDetail.tsx
+++ b/src/features/listings/ui/listingsCardDetail/infra/components/roomTypeDetail.tsx
@@ -48,7 +48,7 @@ export const RoomTypeDetail = ({ listingId }: { listingId: string }) => {
   }
 
   return (
-    <section className="flex h-full flex-col">
+    <section className="flex h-full min-h-0 flex-col overflow-y-auto">
       <div className="relative flex flex-col justify-center bg-greyscale-grey-25">
         <div className="flex justify-between pl-3 pr-3 pt-3">
           <span>

--- a/src/features/listings/ui/listingsCardDetail/infra/infraSheet.tsx
+++ b/src/features/listings/ui/listingsCardDetail/infra/infraSheet.tsx
@@ -42,7 +42,10 @@ export const InfraSheet = ({ onClose, sheetState }: InfraSheetProps) => {
           <motion.div
             key="overlay"
             className="fixed inset-0 bg-black/40"
-            onClick={onClose}
+            onClick={e => {
+              e.stopPropagation();
+              onClose();
+            }}
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
@@ -54,6 +57,7 @@ export const InfraSheet = ({ onClose, sheetState }: InfraSheetProps) => {
             initial={{ y: "100%" }}
             animate={{ y: 0 }}
             exit={{ y: "100%" }}
+            onClick={e => e.stopPropagation()}
             transition={{ type: "spring", stiffness: 260, damping: 30 }}
           >
             <section className="flex flex-col">

--- a/src/features/listings/ui/listingsCardDetail/infra/listingsCardTtileInfra.tsx
+++ b/src/features/listings/ui/listingsCardDetail/infra/listingsCardTtileInfra.tsx
@@ -56,6 +56,7 @@ export const ListingsCardTileDetails = ({
   const [sheetState, setSheetState] = useState<SheetState>({
     open: false,
   });
+
   const route = infra?.distance;
   const infraData = infra?.infra;
   const roomTypes = infra?.unitTypes;

--- a/src/features/listings/ui/listingsCompareRoom/components/listingsCompareCards.tsx
+++ b/src/features/listings/ui/listingsCompareRoom/components/listingsCompareCards.tsx
@@ -2,11 +2,22 @@ import { UnitType } from "@/src/entities/listings/model/type";
 import { formatNumber } from "@/src/shared/lib/numberFormat";
 import { TagButton } from "@/src/shared/ui/button/tagButton";
 import { LikeType } from "../../../hooks/listingsHooks";
+import { useState } from "react";
+import { SheetState } from "../../../model";
+import { InfraSheet } from "../../listingsCardDetail/infra/infraSheet";
 
 export const ListingCompareCard = (unit: UnitType) => {
+  const [sheetState, setSheetState] = useState<SheetState>({
+    open: false,
+  });
+
   return (
-    <article className="w-[160px] rounded-xl border bg-white">
-      {/* HEADER */}
+    <article
+      className="w-[160px] rounded-xl border bg-white"
+      onClick={e =>
+        setSheetState({ open: true, section: "room", listingId: unit.complex.complexId })
+      }
+    >
       <div className="h-[92px] w-full rounded-t-lg rounded-tl-xl rounded-tr-xl bg-greyscale-grey-25 p-2">
         <div className="flex justify-between rounded-full">
           {unit.group.map(item => (
@@ -21,14 +32,16 @@ export const ListingCompareCard = (unit: UnitType) => {
               </TagButton>
             </div>
           ))}
-          <LikeType
-            id={unit.typeId}
-            liked={unit.isLiked}
-            type="ROOM"
-            resetQuery={["useListingRoomTypeDetail"]}
-          />
+          <span onClick={e => e.stopPropagation()}>
+            <LikeType
+              id={unit.typeId}
+              liked={unit.isLiked}
+              type="ROOM"
+              resetQuery={["compareNotice"]}
+            />
+          </span>
         </div>
-        {/* <div className="mx-3 h-[120px] rounded-lg bg-[linear-gradient(45deg,#f2f2f2_25%,transparent_25%,transparent_50%,#f2f2f2_50%,#f2f2f2_75%,transparent_75%,transparent)] bg-[length:12px_12px]" /> */}
+        <div className="mx-3 rounded-lg bg-[linear-gradient(45deg,#f2f2f2_25%,transparent_25%,transparent_50%,#f2f2f2_50%,#f2f2f2_75%,transparent_75%,transparent)] bg-[length:12px_12px]" />
       </div>
 
       <div className="p-3">
@@ -73,6 +86,7 @@ export const ListingCompareCard = (unit: UnitType) => {
           ))}
         </div>
       </div>
+      <InfraSheet sheetState={sheetState} onClose={() => setSheetState({ open: false })} />
     </article>
   );
 };

--- a/src/features/listings/ui/listingsCompareRoom/components/listingsCompareContentHeader.tsx
+++ b/src/features/listings/ui/listingsCompareRoom/components/listingsCompareContentHeader.tsx
@@ -1,4 +1,3 @@
-import { ArrowUpArrowDown } from "@/src/assets/icons/button/arrowUpArrowDown";
 import { CaretDropDown } from "@/src/shared/ui/dropDown/CaretDropDown";
 import { listingsComparePoint } from "../../../model";
 
@@ -15,9 +14,6 @@ export const ListingsCompareContentHeader = ({ count }: { count: string }) => {
           <div className="flex items-center gap-1"></div>
 
           <div className="flex items-center">
-            {/* <span>
-              <p>핀포인트 거리순</p>
-            </span> */}
             <CaretDropDown
               variant="ghost"
               types="drop"
@@ -26,7 +22,7 @@ export const ListingsCompareContentHeader = ({ count }: { count: string }) => {
               fullWidth={false}
               className="w-fit"
               containerClassName="w-auto"
-              menuClassName="left-[-60] w-[100] "
+              menuClassName="left-[-60] w-[100]"
             />
           </div>
         </div>

--- a/src/shared/ui/dropDown/CaretDropDown/caretDropDown.tsx
+++ b/src/shared/ui/dropDown/CaretDropDown/caretDropDown.tsx
@@ -30,10 +30,10 @@ function CaretDropDownContent({
   const [open, setOpen] = useState<boolean>(false);
   const optionData = types ? data[types] : [];
   const wrapperRef = useRef<HTMLDivElement>(null);
-  const { status, setStatus } = useListingState();
+  const { status } = useListingState();
   const searchParams = useSearchParams();
   const isSearchPage = searchParams.has("query");
-
+  const firstValue = optionData.values().next().value?.value;
   const setBaseStatus = useListingState(s => s.setStatus);
   const setSearchStatus = useListingsSearchState(s => s.setStatus);
   const searchState = useListingsSearchState(s => s.status);
@@ -50,6 +50,7 @@ function CaretDropDownContent({
       const nextSearchStatus = statusValue[value] ?? value;
       setSearchStatus(nextSearchStatus);
     } else {
+      console.log(value);
       setBaseStatus(value);
     }
     setOpen(false);
@@ -69,11 +70,7 @@ function CaretDropDownContent({
 
   return (
     <div
-      className={cn(
-        "relative inline-block",
-        fullWidth ? "w-full" : "w-auto",
-        containerClassName
-      )}
+      className={cn("relative inline-block", fullWidth ? "w-full" : "w-auto", containerClassName)}
       ref={wrapperRef}
     >
       <button
@@ -83,7 +80,8 @@ function CaretDropDownContent({
       >
         {children}
         <span className="flex items-center justify-between gap-1 text-xs font-bold">
-          {isSearchPage ? (searchState === "ALL" ? "전체" : "모집중") : status}
+          {isSearchPage && (searchState === "ALL" ? "전체" : "모집중")}
+          {!isSearchPage && status === "전체" ? firstValue : status}
           {/* {status || children} */}
           {open ? <CaretUp /> : <CaretDown />}
         </span>
@@ -92,9 +90,7 @@ function CaretDropDownContent({
       {open && (
         <ul
           className={cn(
-            // default placement and sizing; override via menuClassName
             "absolute left-0 top-8 z-10 rounded-lg border bg-white font-bold text-text-tertiary shadow-lg",
-            // fit to content by default
             "w-fit min-w-fit",
             menuClassName
           )}

--- a/src/shared/ui/dropDown/CaretDropDown/type.ts
+++ b/src/shared/ui/dropDown/CaretDropDown/type.ts
@@ -19,6 +19,7 @@ export interface DropDownProps<T = PinPoint[]>
   data: PinPointMap<T>;
   setSelect?: any;
   selected?: string;
+  firstValue?: string;
   // layout overrides
   containerClassName?: string; // wrapper div
   menuClassName?: string; // dropdown menu ul

--- a/src/widgets/listingsSection/ui/listingsCompareRoomSection/listingsCompareRoomSection.tsx
+++ b/src/widgets/listingsSection/ui/listingsCompareRoomSection/listingsCompareRoomSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useListingRoomCompare } from "@/src/entities/listings/hooks/useListingDetailHooks";
 import { UnitTypeRespnse } from "@/src/entities/listings/model/type";
+import { SheetState, useListingState } from "@/src/features/listings/model";
 import {
   ListingCompareCard,
   ListingCompareHeader,
@@ -10,11 +11,14 @@ import { ListingCompareCardSkeleton } from "@/src/features/listings/ui/listingsC
 import { PageTransition } from "@/src/shared/ui/animation";
 
 export const ListingCompareSection = ({ id }: { id: string }) => {
+  const { status } = useListingState();
+
   const { data, isLoading, error } = useListingRoomCompare<UnitTypeRespnse>({
     noticeId: id,
-    sortType: "핀포인트 거리순",
+    sortType: status === "전체" ? "핀포인트 거리순" : status,
     nearbyFacilities: ["도서관"],
   });
+
   const unitData = data?.unitTypes;
   const count = Number(data?.unitTypes?.length);
   const zeroCount = count <= 10 ? `0${count}` : `${count}`;
@@ -36,7 +40,6 @@ export const ListingCompareSection = ({ id }: { id: string }) => {
             {unitData?.map(unit => (
               <div key={unit.typeId}>
                 <ListingCompareCard {...unit} />
-                {/* <ListingCompareCard /> */}
               </div>
             ))}
           </div>


### PR DESCRIPTION
## #️⃣ Issue Number

#280 

<br/>
<br/>

## 📝 요약(Summary) (선택)

- 공고상세 방비교 / 룸 타입 바텀 시트 추가
- 공고상세 방비교 / srotType 기능 추가
- 공고상세 방비교 / 좋아요 기능 추가
- 공고상세 방비교 / 이벤트 버블 로직 추가

### 변경
- useListingDetailHooks: compare 조회 queryKey에 pinPointId 추가, enabled 조건에 pinPointId 반영
- RoomTypeDetail: 시트 내부 스크롤(min-h-0, overflow-y-auto) 추가
- InfraSheet: overlay/시트 컨테이너에서 e.stopPropagation()으로 닫기 시 재오픈 방지
- ListingsCardTileDetails: 포맷팅(공백) 정리
- ListingCompareCard: 로컬 sheetState 도입, 카드 클릭으로 시트 오픈, LikeType 클릭 전파 차단, resetQuery를 ["compareNotice"]로 수정, 썸네일 그라디언트 블록 추가, 시트 마운트
- ListingsCompareContentHeader: 불필요 import 제거, 클래스/프로퍼티 포맷 정리
- CaretDropDown: setStatus 미사용 제거, 첫 항목 firstValue 계산/표시, 검색/일반 라벨 분기 개선, 클래스 정리, console.log 추가
- CaretDropDown(type): firstValue?: string 프로퍼티 추가
- ListingCompareSection: useListingState 연동으로 sortType 상태 기반 설정, 렌더 주석 정리
<br/>
<br/>

