### PR TITLE
feat:핀하우스 home / 바텀시트 라우터 설정

### DIFF
--- a/app/home/layout.tsx
+++ b/app/home/layout.tsx
@@ -1,0 +1,11 @@
+import { HomeSheet } from "@/src/features/home/index.server";
+import { ReactNode, Suspense } from "react";
+
+export default function HomeFullSheet({ children }: { children: ReactNode }) {
+  return (
+    <Suspense fallback={null}>
+      {children}
+      <HomeSheet />
+    </Suspense>
+  );
+}

--- a/src/features/home/index.server.ts
+++ b/src/features/home/index.server.ts
@@ -1,0 +1,1 @@
+export * from "./ui/components/homeFullSheet";

--- a/src/features/home/index.ts
+++ b/src/features/home/index.ts
@@ -6,3 +6,4 @@ export * from "./ui/homeHero";
 export * from "./ui/homePersonalShortcutList";
 export * from "./ui/homeQuickStatsList";
 export * from "./ui/homeUrgentNoticeList";
+export * from "./ui/components/homeFullSheet";

--- a/src/features/home/model/homeStore.ts
+++ b/src/features/home/model/homeStore.ts
@@ -15,3 +15,15 @@ export const useRouteStore = create<RouteState>(set => ({
   setListingEntry: entry => set({ listingEntry: entry }),
   reset: () => set({ prevPath: null, listingEntry: null }),
 }));
+
+type HomeSheet = {
+  open: boolean;
+  openSheet: () => void;
+  closeSheet: () => void;
+};
+
+export const useHomeSheetStore = create<HomeSheet>(set => ({
+  open: false,
+  openSheet: () => set({ open: true }),
+  closeSheet: () => set({ open: false }),
+}));

--- a/src/features/home/ui/components/homeFullSheet.tsx
+++ b/src/features/home/ui/components/homeFullSheet.tsx
@@ -1,0 +1,67 @@
+"use client";
+import { homeSheetParseObject } from "@/src/features/listings/model";
+import { AnimatePresence, motion } from "framer-motion";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useHomeSheetStore } from "../../model/homeStore";
+import { useMemo } from "react";
+import { PinpointRowBox } from "./pinpointRowBoxs";
+
+export const HomeSheet = () => {
+  const open = useHomeSheetStore(s => s.open);
+  const closeSheet = useHomeSheetStore(s => s.closeSheet);
+  const searchParams = useSearchParams();
+
+  const mode = useMemo(() => {
+    return homeSheetParseObject(searchParams);
+  }, [searchParams]);
+
+  const router = useRouter();
+  const replaceRouter = () => {
+    router.replace("/home");
+    closeSheet();
+  };
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <>
+          <motion.div
+            className="fixed inset-0 bg-black/40"
+            onClick={replaceRouter}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+          />
+
+          <motion.div
+            className="fixed bottom-0 left-0 right-0 flex h-[60vh] flex-col rounded-t-2xl bg-white shadow-xl"
+            initial={{ y: "100%" }}
+            animate={{ y: 0 }}
+            exit={{ y: "100%" }}
+            transition={{ type: "spring", stiffness: 260, damping: 30 }}
+          >
+            <div className="mx-auto mb-3 mt-2 h-1.5 w-12 rounded-full bg-gray-300" />
+
+            <div className="flex items-center justify-between px-5 pb-2">
+              <h2 className="text-lg font-bold">{mode?.label}</h2>
+              <button onClick={replaceRouter}>✕</button>
+            </div>
+
+            <div className="flex-1 overflow-y-auto p-5">
+              <motion.div
+                // key={section}
+                initial={{ x: 20, opacity: 0 }}
+                animate={{ x: 0, opacity: 1 }}
+                exit={{ x: -100, opacity: 0 }}
+                transition={{ duration: 0.5, ease: "easeInOut" }}
+                className="h-full"
+              >
+                {mode?.key === "pinpoints" && <PinpointRowBox />}
+              </motion.div>
+            </div>
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  );
+};

--- a/src/features/home/ui/components/pinpointRowBoxs.tsx
+++ b/src/features/home/ui/components/pinpointRowBoxs.tsx
@@ -1,0 +1,3 @@
+export const PinpointRowBox = () => {
+  return <div>핀포인트박스</div>;
+};

--- a/src/features/home/ui/homeQuickStatsList.tsx
+++ b/src/features/home/ui/homeQuickStatsList.tsx
@@ -1,49 +1,58 @@
-import { useMemo } from "react";
+"use client";
 import { CaretDown } from "@/src/assets/icons/button/caretDown";
 import { HomeFiveoclock } from "@/src/assets/icons/home/HomeFiveoclock";
 import { HomePushPin } from "@/src/assets/icons/home/homePushpin";
-
 import { useListingFilterDetail } from "@/src/entities/listings/hooks/useListingDetailHooks";
 import { PinPointPlace } from "@/src/entities/listings/model/type";
-import { getDefaultPinPointLabel, mapPinPointToOptions } from "../../listings/hooks/listingsHooks";
-import { useOAuthStore } from "../../login/model";
-import { DropDown } from "@/src/shared/ui/dropDown/deafult";
+import { useHomeSheetStore } from "../model/homeStore";
+import { useRouter, useSearchParams } from "next/navigation";
+
+const splitAddress = (address: string): [string, string] => {
+  const idx = address.indexOf("구");
+  if (idx === -1) {
+    return [address, ""];
+  }
+  return [address.slice(0, idx + 1), address.slice(idx + 1).trim()];
+};
 
 export const QuickStatsList = () => {
-  const { data, isFetching } = useListingFilterDetail<PinPointPlace>();
-  const { setPinPointId } = useOAuthStore();
+  const { data } = useListingFilterDetail<PinPointPlace>();
+  const openSheet = useHomeSheetStore(s => s.openSheet);
+  const name = data?.pinPoints.values().next().value?.name;
+  const id = data?.pinPoints.values().next().value?.id;
 
-  const pinPointOptions = useMemo(() => mapPinPointToOptions(data?.pinPoints), [data?.pinPoints]);
-  const pinPointData = pinPointOptions.myPinPoint;
-  const dropDownTriggerLabel = getDefaultPinPointLabel(pinPointOptions);
+  const [line1, line2] = splitAddress(name ?? "핀포인트 이름 설정해주세요");
+  const searchParams = useSearchParams();
+  const router = useRouter();
 
-  const hasPinPoints = pinPointData.length > 0;
-  const onChangePinPoint = (id: string) => {
-    setPinPointId(id);
+  const onSelectSection = (key: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("mode", key);
+    params.set("id", id ?? "");
+    router.push(`?${params.toString()}`, { scroll: false });
+    openSheet();
   };
+
   return (
     <div className="relative grid grid-cols-2 grid-rows-[auto,1fr] rounded-2xl bg-white p-4">
-      <div className="flex items-center gap-1 text-xs text-greyscale-grey-500">
+      <div className="flex items-center gap-1 text-sm text-greyscale-grey-500">
         <HomePushPin width={17} height={17} />
         <span>핀포인트</span>
       </div>
 
-      <div className="flex items-center gap-1 pl-6 text-xs text-greyscale-grey-500">
+      <div className="flex items-center gap-1 pl-6 text-sm text-greyscale-grey-500">
         <HomeFiveoclock width={15} height={15} />
         <span>최대시간</span>
       </div>
 
-      <div className="flex items-center">
-        <DropDown
-          types="myPinPoint"
-          data={pinPointOptions}
-          icon={<CaretDown />}
-          disabled={isFetching || !hasPinPoints}
-          className="border-none pl-0 text-left text-sm"
-          onChange={onChangePinPoint}
-        >
-          {dropDownTriggerLabel}
-        </DropDown>
+      <div className="mt-2 flex gap-4" onClick={() => onSelectSection("pinpoints")}>
+        <span className="flex flex-col text-lg font-semibold leading-none">
+          <p>{line1}</p>
+          <p>{line2}</p>
+        </span>
+        <span className="flex items-center">
+          <CaretDown />
+        </span>
       </div>
 
       <div className="flex items-center pl-6">

--- a/src/features/listings/model/listingsModel.ts
+++ b/src/features/listings/model/listingsModel.ts
@@ -326,6 +326,29 @@ export const parseDetailSection = (searchParams: URLSearchParams): DetailFilterT
   return isValid ? (raw as DetailFilterTabKey) : DEFAULT_DETAIL_SECTION;
 };
 
+export const HomeSheetTile = {
+  pinpoints: "핀포인트 선택",
+  maxTime: "최대시간",
+} as const;
+
+type HomeSheetKey = keyof typeof HomeSheetTile;
+type HomeSheetResult = {
+  key: HomeSheetKey;
+  label: string;
+};
+
+export const homeSheetParseObject = (searchParams: URLSearchParams): HomeSheetResult | null => {
+  const raw = searchParams.get("mode") as HomeSheetKey | null;
+  if (!raw) return null;
+
+  const label = HomeSheetTile[raw];
+  if (!label) return null;
+
+  return {
+    key: raw,
+    label,
+  };
+};
 // 사용처: 검색 결과가 없을 때/빈 검색어 화면에서 추천 태그 클릭 핸들러와 인기 키워드 전달
 // - listingsSearchResult/components/searchNoResultView.tsx
 // - listingsSearchResult/components/searchEmptyQueryView.tsx

--- a/src/features/listings/ui/listingsCompareRoom/components/listingsCompareCards.tsx
+++ b/src/features/listings/ui/listingsCompareRoom/components/listingsCompareCards.tsx
@@ -13,7 +13,7 @@ export const ListingCompareCard = (unit: UnitType) => {
 
   return (
     <article
-      className="w-[160px] rounded-xl border bg-white"
+      className="w-[200px] rounded-xl border bg-white"
       onClick={e =>
         setSheetState({ open: true, section: "room", listingId: unit.complex.complexId })
       }
@@ -41,7 +41,7 @@ export const ListingCompareCard = (unit: UnitType) => {
             />
           </span>
         </div>
-        <div className="mx-3 rounded-lg bg-[linear-gradient(45deg,#f2f2f2_25%,transparent_25%,transparent_50%,#f2f2f2_50%,#f2f2f2_75%,transparent_75%,transparent)] bg-[length:12px_12px]" />
+        {/* <div className="mx-3 rounded-lg bg-[linear-gradient(45deg,#f2f2f2_25%,transparent_25%,transparent_50%,#f2f2f2_50%,#f2f2f2_75%,transparent_75%,transparent)] bg-[length:12px_12px]" /> */}
       </div>
 
       <div className="p-3">

--- a/src/shared/ui/bottomNavigation/bottomNavigation.tsx
+++ b/src/shared/ui/bottomNavigation/bottomNavigation.tsx
@@ -8,10 +8,6 @@ import { Search } from "@/src/assets/icons/home/search";
 
 const hiddenRoutes = ["/login", "/onboarding", "/listings/search"];
 const hiddenExactRoutes = [
-  "/listings?tab=region",
-  "/listings?tab=target",
-  "/listings?tab=rental",
-  "/listings?tab=housing",
   "/quicksearch/init",
   "/quicksearch/choosePinPoint",
   "/quicksearch/chooseDistance",
@@ -31,14 +27,16 @@ const compareDetailPageRegex = /^\/listings\/[A-Za-z0-9_-]+\/compare$/;
 function BottomNavigationContent() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const queryString = searchParams.toString();
-  const currentPath = queryString ? `${pathname}?${queryString}` : pathname;
+  const tab = searchParams.get("tab");
+
   const router = useRouter();
   const shouldHide =
     hiddenRoutes.some(route => pathname.startsWith(route)) ||
-    hiddenExactRoutes.includes(currentPath) ||
+    hiddenExactRoutes.includes(pathname) ||
+    (pathname === "/listings" && tab !== null) ||
     detailPageRegex.test(pathname) ||
-    compareDetailPageRegex.test(pathname);
+    compareDetailPageRegex.test(pathname) ||
+    (pathname === "/home" && searchParams.has("mode"));
 
   if (shouldHide) return null;
   return (

--- a/src/widgets/listingsSection/ui/listingsCompareRoomSection/listingsCompareRoomSection.tsx
+++ b/src/widgets/listingsSection/ui/listingsCompareRoomSection/listingsCompareRoomSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useListingRoomCompare } from "@/src/entities/listings/hooks/useListingDetailHooks";
 import { UnitTypeRespnse } from "@/src/entities/listings/model/type";
-import { SheetState, useListingState } from "@/src/features/listings/model";
+import { useListingState } from "@/src/features/listings/model";
 import {
   ListingCompareCard,
   ListingCompareHeader,
@@ -36,12 +36,14 @@ export const ListingCompareSection = ({ id }: { id: string }) => {
             ))}
           </div>
         ) : (
-          <div className="grid grid-cols-2 justify-center gap-4 px-4">
-            {unitData?.map(unit => (
-              <div key={unit.typeId}>
-                <ListingCompareCard {...unit} />
-              </div>
-            ))}
+          <div className="px-4">
+            <div className="grid grid-cols-2 gap-3">
+              {unitData?.map(unit => (
+                <div key={unit.typeId} className="flex justify-center">
+                  <ListingCompareCard {...unit} />
+                </div>
+              ))}
+            </div>
           </div>
         )}
       </PageTransition>


### PR DESCRIPTION
<!--- Pull Request title = 커밋 메시지와 동일/ 해당 이슈를 close 하지 않을 경우, footer #이슈 번호 제외  -->

## #️⃣ Issue Number
#282 

<br/>
<br/>

## 📝 요약(Summary) (선택)

#### 추가
- HomeFullSheet : 홈 레이아웃에서 시트를 함께 렌더하는 래퍼
- HomeSheet : 홈 하단 시트(모드 라벨, 오버레이, 애니메이션) 표시
- PinpointRowBox : 핀포인트 영역 박스(현재 임시 텍스트)

#### 변경
- QuickStatsList : 드롭다운 제거, 주소 두 줄 표시 + mode/id 쿼리 설정 후 홈 시트 오픈
- ListingCompareCard : 카드 너비 확대, 중간 구분선 배경 제거(주석 처리)
- ListingCompareSection : 카드 그리드 중앙 정렬 및 간격 조정


<br/>
<br/>

## 📸스크린샷 (선택)2

<img width="424" height="679" alt="Image" src="https://github.com/user-attachments/assets/c00f5795-4f63-42cb-aed4-0dafba371278" />

<br/>
<br/>

## 💬 공유사항 (선택)
- BottomNavigationContent : /listings 탭 쿼리 및 /home mode 쿼리에서 숨김 처리
<br/>
<br/>
