### PR TITLE
feat:핀하우스 home / 바텀시트 추가 ( 핀포인트 설정 , 최대시간 로직 추가 )

### DIFF
--- a/src/entities/home/hooks/homeHooks.ts
+++ b/src/entities/home/hooks/homeHooks.ts
@@ -1,8 +1,10 @@
-import { InfiniteData, useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { getNoticeByPinPoint } from "../interface/homeInterface";
 import { NoticeContent, NoticeCount, SliceResponse } from "../model/type";
 import { useOAuthStore } from "@/src/features/login/model";
 import { HOME_NOTICE_ENDPOINT } from "@/src/shared/api";
+import { useHomeMaxTime } from "@/src/features/home/model/homeStore";
+import { useDebounce } from "@/src/shared/hooks/useDebounce/useDebounce";
 
 export const useNoticeInfinite = () => {
   const pinpointId = useOAuthStore(state => state.pinPointId);
@@ -28,14 +30,17 @@ export const useNoticeInfinite = () => {
 
 export const useNoticeCount = () => {
   const pinPointId = useOAuthStore(state => state.pinPointId);
+  const maxTime = useHomeMaxTime(s => s.maxTime);
+  const debouncedMaxTime = useDebounce(maxTime, 400);
   const param = {
     pinPointId,
-    maxTime: 30,
+    maxTime: maxTime,
   };
   const url = `${HOME_NOTICE_ENDPOINT}-count`;
   return useQuery({
-    queryKey: ["noticeCount", pinPointId],
+    queryKey: ["noticeCount", pinPointId, debouncedMaxTime],
     enabled: !!pinPointId,
+    placeholderData: previousData => previousData,
     queryFn: () => getNoticeByPinPoint<NoticeCount>({ url: url, params: param }),
   });
 };

--- a/src/entities/listings/hooks/useListingDetailHooks.ts
+++ b/src/entities/listings/hooks/useListingDetailHooks.ts
@@ -204,10 +204,8 @@ export const useListingRouteDetail = <T, TParam extends object>({
 };
 
 export const useListingFilterDetail = <T>() => {
-  const { pinPointId } = useOAuthStore();
-
   return useQuery<IResponse<T>, Error, T>({
-    queryKey: [pinPointId],
+    queryKey: ["pinpoint"],
     staleTime: 1000 * 60 * 5,
     queryFn: () => PostBasicRequest<T, IResponse<T>, {}, IResponse<T>>(endPoint["pinpoint"], "get"),
     select: response => {

--- a/src/entities/listings/model/type.ts
+++ b/src/entities/listings/model/type.ts
@@ -568,7 +568,7 @@ export const endPoint = {
 
 type EndPointKey = keyof typeof endPoint;
 
-type PionPointData = {
+export type PionPointData = {
   id: string;
   name: string;
   address: string;

--- a/src/entities/pinpoint/hooks/useSetDefaultPinpoint.ts
+++ b/src/entities/pinpoint/hooks/useSetDefaultPinpoint.ts
@@ -8,7 +8,7 @@ import { useOAuthStore } from "@/src/features/login/model/authStore";
  * @returns setDefaultPinpoint 함수
  */
 export const useSetDefaultPinpoint = () => {
-  const { setPinPointId, pinPointId, setUserName } = useOAuthStore();
+  const { setPinPointId, pinPointId, setUserName, setPinpointName } = useOAuthStore();
 
   const setDefaultPinpoint = useCallback(async () => {
     try {
@@ -24,6 +24,7 @@ export const useSetDefaultPinpoint = () => {
       if (pinPoints && myPinpoint.length > 0) {
         setPinPointId(myPinpoint[0].id);
         setUserName(userName);
+        setPinpointName(myPinpoint[0].name);
       }
     } catch (error) {
       console.error("❌ 기본 핀포인트 설정 실패:", error);

--- a/src/features/home/model/homeStore.ts
+++ b/src/features/home/model/homeStore.ts
@@ -27,3 +27,15 @@ export const useHomeSheetStore = create<HomeSheet>(set => ({
   openSheet: () => set({ open: true }),
   closeSheet: () => set({ open: false }),
 }));
+
+type HomeMaxSheet = {
+  maxTime: number;
+  setMaxTime: (time: number) => void;
+  reset: (time: number) => void;
+};
+
+export const useHomeMaxTime = create<HomeMaxSheet>(set => ({
+  maxTime: 30,
+  setMaxTime: time => set({ maxTime: time }),
+  reset: () => set({ maxTime: 30 }),
+}));

--- a/src/features/home/ui/components/components/pinpointId.tsx
+++ b/src/features/home/ui/components/components/pinpointId.tsx
@@ -1,0 +1,31 @@
+// PinpointItem.tsx
+import { memo } from "react";
+import { PionPointData } from "@/src/entities/listings/model/type";
+
+interface PinpointItemProps {
+  item: PionPointData;
+  isSelected: boolean;
+  onSelect: ({ id, name }: { id: string; name: string }) => void;
+}
+
+export const PinpointItem = memo(({ item, isSelected, onSelect }: PinpointItemProps) => {
+  return (
+    <li className="p-2" onClick={() => onSelect({ id: item.id, name: item.name })}>
+      <div className="mb-1 flex min-h-[22px] items-center gap-2">
+        <span className="text-md font-semibold text-gray-900">{item.name}</span>
+
+        <span
+          className={`rounded px-2 py-[2px] text-xs font-medium ${
+            isSelected ? "bg-blue-50 text-blue-600" : "invisible"
+          }`}
+        >
+          선택됨
+        </span>
+      </div>
+
+      <p className="text-md mb-2 text-gray-600">{item.address}</p>
+    </li>
+  );
+});
+
+PinpointItem.displayName = "PinpointItem";

--- a/src/features/home/ui/components/homeFullSheet.tsx
+++ b/src/features/home/ui/components/homeFullSheet.tsx
@@ -6,6 +6,8 @@ import { useHomeSheetStore } from "../../model/homeStore";
 import { useMemo } from "react";
 import { PinpointRowBox } from "./pinpointRowBoxs";
 import { MaxTimeSliderBox } from "./maxTime";
+import { Button } from "@/src/shared/lib/headlessUi";
+import { cn } from "@/lib/utils";
 
 export const HomeSheet = () => {
   const open = useHomeSheetStore(s => s.open);
@@ -35,30 +37,49 @@ export const HomeSheet = () => {
           />
 
           <motion.div
-            className="fixed bottom-0 left-0 right-0 flex h-[55vh] flex-col rounded-t-2xl bg-white shadow-xl"
+            className="fixed bottom-0 left-0 right-0 flex h-[55vh] flex-col rounded-t-2xl bg-white p-5 shadow-xl"
             initial={{ y: "100%" }}
             animate={{ y: 0 }}
             exit={{ y: "100%" }}
             transition={{ type: "spring", stiffness: 260, damping: 30 }}
           >
-            <div className="mx-auto mb-3 mt-2 h-1.5 w-12 rounded-full bg-gray-300" />
+            {/* <div className="mx-auto mb-3 mt-2 h-1.5 w-12 rounded-full bg-gray-300" /> */}
 
-            <div className="flex items-center justify-between px-8">
+            <div className="flex items-center justify-between">
               <h2 className="text-lg font-bold">{mode?.label}</h2>
               <button onClick={replaceRouter}>✕</button>
             </div>
 
-            <div className="flex-1 overflow-y-auto px-5">
+            <div className="flex-1 overflow-y-auto overflow-x-hidden">
               <motion.div
                 key={mode?.key}
                 initial={{ x: 20, opacity: 0 }}
                 animate={{ x: 0, opacity: 1 }}
                 exit={{ x: -100, opacity: 0 }}
                 transition={{ duration: 0.5, ease: "easeInOut" }}
-                className="h-full"
+                className="flex h-full flex-col justify-between"
               >
                 {mode?.key === "pinpoints" && <PinpointRowBox />}
                 {mode?.key === "maxTime" && <MaxTimeSliderBox />}
+
+                <div className="flex gap-3">
+                  <Button
+                    className={cn(
+                      "flex-1 border-greyscale-grey-100 bg-white text-sm font-medium text-gray-800",
+                      mode?.key === "maxTime" ? "hidden" : "block"
+                    )}
+                    variant="outline"
+                    radius="sm"
+                  >
+                    핀포인트 설정
+                  </Button>
+                  <Button
+                    className="flex-1 bg-[#2E2A3B] text-sm font-medium text-white"
+                    radius="sm"
+                  >
+                    저장하기
+                  </Button>
+                </div>
               </motion.div>
             </div>
           </motion.div>

--- a/src/features/home/ui/components/maxTime.tsx
+++ b/src/features/home/ui/components/maxTime.tsx
@@ -1,29 +1,33 @@
 import { Slider } from "@/src/shared/ui/slider";
+import { useHomeMaxTime } from "../../model/homeStore";
 
 export const MaxTimeSliderBox = () => {
+  const { maxTime, setMaxTime } = useHomeMaxTime();
+
+  const onSliderValueChange = (values: number[]) => {
+    const [nextValue] = values;
+    if (typeof nextValue === "number") {
+      setMaxTime(nextValue);
+    }
+  };
+
   return (
     <div className="flex h-full flex-col justify-between px-4 py-8">
       <div>
-        {/* 설명 */}
         <p className="mb-4 text-base text-gray-700">
-          핀포인트로부터 <span className="font-semibold text-blue-600">60분 이내</span>
+          핀포인트로부터 <span className="font-semibold text-blue-600">{maxTime}분 이내</span>
         </p>
 
-        {/* 슬라이더 */}
         <div className="mb-2">
-          <Slider labelSuffix="분" />
-        </div>
-
-        {/* 최소 / 최대 */}
-        <div className="mb-8 flex justify-between text-sm text-gray-500">
-          <span>0분</span>
-          <span>120분</span>
+          <Slider
+            min={0}
+            max={120}
+            labelSuffix="분"
+            value={[maxTime]}
+            onValueChange={onSliderValueChange}
+          />
         </div>
       </div>
-      {/* 저장 버튼 */}
-      <button className="mt-auto w-full rounded-lg bg-[#2E2A3B] py-4 text-base font-medium text-white">
-        저장하기
-      </button>
     </div>
   );
 };

--- a/src/features/home/ui/components/pinpointRowBoxs.tsx
+++ b/src/features/home/ui/components/pinpointRowBoxs.tsx
@@ -1,59 +1,30 @@
+import { useListingFilterDetail } from "@/src/entities/listings/hooks/useListingDetailHooks";
+import { PinPointPlace } from "@/src/entities/listings/model/type";
+import { useOAuthStore } from "@/src/features/login/model";
+import { PinpointItem } from "./components/pinpointId";
+
 export const PinpointRowBox = () => {
+  const { data } = useListingFilterDetail<PinPointPlace>();
+  const pinpoints = data?.pinPoints;
+  const pinPointId = useOAuthStore(s => s.pinPointId);
+  const setPinPointId = useOAuthStore(s => s.setPinPointId);
+  const setPinPointName = useOAuthStore(s => s.setPinpointName);
+  const onChangePinpoint = ({ id, name }: { id: string; name: string }) => {
+    setPinPointId(id);
+    setPinPointName(name);
+  };
   return (
-    <div className="flex flex-col p-4">
-      {/* 리스트 */}
+    <div className="flex flex-col pt-4">
       <ul className="flex flex-col divide-y">
-        {/* Item */}
-        <li className="py-4">
-          <div className="mb-1 flex items-center gap-2">
-            <span className="text-sm font-semibold text-gray-900">회사</span>
-            <span className="rounded bg-blue-50 px-2 py-[2px] text-xs font-medium text-blue-600">
-              선택됨
-            </span>
-          </div>
-
-          <p className="mb-2 text-sm text-gray-600">○○도 ○○시 ○○동 000-000</p>
-
-          <div className="flex gap-2">
-            <button className="rounded-md border px-3 py-1 text-xs text-gray-700">수정</button>
-            <button className="rounded-md border px-3 py-1 text-xs text-gray-700">삭제</button>
-          </div>
-        </li>
-
-        {/* Item */}
-        <li className="py-4">
-          <div className="mb-1 text-sm font-semibold text-gray-900">본가</div>
-
-          <p className="mb-2 text-sm text-gray-600">○○도 ○○시 ○○동 000-000</p>
-
-          <div className="flex gap-2">
-            <button className="rounded-md border px-3 py-1 text-xs text-gray-700">수정</button>
-            <button className="rounded-md border px-3 py-1 text-xs text-gray-700">삭제</button>
-          </div>
-        </li>
-
-        {/* Item */}
-        <li className="py-4">
-          <div className="mb-1 text-sm font-semibold text-gray-900">여기저기</div>
-
-          <p className="mb-2 text-sm text-gray-600">○○도 ○○시 ○○동 000-000</p>
-
-          <div className="flex gap-2">
-            <button className="rounded-md border px-3 py-1 text-xs text-gray-700">수정</button>
-            <button className="rounded-md border px-3 py-1 text-xs text-gray-700">삭제</button>
-          </div>
-        </li>
+        {pinpoints?.map(item => (
+          <PinpointItem
+            key={item.id}
+            item={item}
+            isSelected={pinPointId === item.id}
+            onSelect={onChangePinpoint}
+          />
+        ))}
       </ul>
-
-      {/* 하단 버튼 영역 */}
-      <div className="mt-6 flex gap-3">
-        <button className="flex-1 rounded-lg border border-gray-300 py-3 text-sm font-medium text-gray-800">
-          핀포인트 설정
-        </button>
-        <button className="flex-1 rounded-lg bg-gray-900 py-3 text-sm font-medium text-white">
-          저장하기
-        </button>
-      </div>
     </div>
   );
 };

--- a/src/features/home/ui/homeActionCardList.tsx
+++ b/src/features/home/ui/homeActionCardList.tsx
@@ -1,8 +1,9 @@
 import { ArrowUpRight } from "@/src/assets/icons/button/arrowUpRight";
 import { useNoticeCount } from "@/src/entities/home/hooks/homeHooks";
+import { Spinner } from "@/src/shared/ui/spinner/default";
 
 export const ActionCardList = () => {
-  const { data } = useNoticeCount();
+  const { data, isFetching } = useNoticeCount();
   const conut = data?.count;
 
   return (

--- a/src/features/home/ui/homePersonalShortcutList.tsx
+++ b/src/features/home/ui/homePersonalShortcutList.tsx
@@ -25,7 +25,7 @@ const PERSONAL_SHORTCUTS = [
 
 const ShortcutMessage = ({ text }: { text: string }) => {
   return (
-    <div className="absolute -top-2 left-4 z-10">
+    <div className="z-5 absolute -top-2 left-4">
       <div className="relative rounded-lg bg-greyscale-grey-900 px-3 py-1 text-xs text-white">
         {text}
         {/* 말풍선 꼬리 */}

--- a/src/features/home/ui/homeQuickStatsList.tsx
+++ b/src/features/home/ui/homeQuickStatsList.tsx
@@ -2,33 +2,23 @@
 import { CaretDown } from "@/src/assets/icons/button/caretDown";
 import { HomeFiveoclock } from "@/src/assets/icons/home/HomeFiveoclock";
 import { HomePushPin } from "@/src/assets/icons/home/homePushpin";
-import { useListingFilterDetail } from "@/src/entities/listings/hooks/useListingDetailHooks";
-import { PinPointPlace } from "@/src/entities/listings/model/type";
-import { useHomeSheetStore } from "../model/homeStore";
+import { useHomeMaxTime, useHomeSheetStore } from "../model/homeStore";
 import { useRouter, useSearchParams } from "next/navigation";
-
-const splitAddress = (address: string): [string, string] => {
-  const idx = address.indexOf("구");
-  if (idx === -1) {
-    return [address, ""];
-  }
-  return [address.slice(0, idx + 1), address.slice(idx + 1).trim()];
-};
+import { useOAuthStore } from "../../login/model";
+import { splitAddress, transTime } from "@/src/shared/lib/utils";
 
 export const QuickStatsList = () => {
-  const { data } = useListingFilterDetail<PinPointPlace>();
   const openSheet = useHomeSheetStore(s => s.openSheet);
-  const name = data?.pinPoints.values().next().value?.name;
-  const id = data?.pinPoints.values().next().value?.id;
-
-  const [line1, line2] = splitAddress(name ?? "핀포인트 이름 설정해주세요");
+  const { pinPointId, pinPointName } = useOAuthStore();
+  const { maxTime } = useHomeMaxTime();
+  const [line1, line2] = splitAddress(pinPointName ?? "핀포인트 이름 설정해주세요");
   const searchParams = useSearchParams();
   const router = useRouter();
 
   const onSelectSection = (key: string) => {
     const params = new URLSearchParams(searchParams.toString());
     params.set("mode", key);
-    params.set("id", id ?? "");
+    params.set("id", pinPointId ?? "");
     router.push(`?${params.toString()}`, { scroll: false });
     openSheet();
   };
@@ -57,7 +47,7 @@ export const QuickStatsList = () => {
 
       <div className="flex items-center pl-6" onClick={() => onSelectSection("maxTime")}>
         <button className="flex items-center gap-1 text-lg font-semibold leading-none">
-          00시간 00분
+          {transTime(maxTime)}
           <span className="pl-1 text-greyscale-grey-400">
             <CaretDown />
           </span>

--- a/src/features/login/model/authStore.ts
+++ b/src/features/login/model/authStore.ts
@@ -9,6 +9,8 @@ interface IOAuthState {
   userName: string;
   setUserName: (userName: string) => void;
   setPinPointId: (pinPointId: string) => void;
+  pinPointName: string;
+  setPinpointName: (pointName: string) => void;
 }
 
 export const useOAuthStore = create<IOAuthState>()(
@@ -21,6 +23,8 @@ export const useOAuthStore = create<IOAuthState>()(
       setPinPointId: (pinPointId: string) => set({ pinPointId }),
       userName: "",
       setUserName: (userName: string) => set({ userName }),
+      pinPointName: "",
+      setPinpointName: (pinPointName: string) => set({ pinPointName }),
     }),
     {
       name: "oauth-user-storage", // localStorage 키 이름

--- a/src/shared/lib/utils.ts
+++ b/src/shared/lib/utils.ts
@@ -36,3 +36,37 @@ export const formatApplyPeriod = (str: string) => {
   // 단일 날짜만 있을 때
   return toDotFormat(str);
 };
+
+/**
+ * @param address 피포인트 이름
+ * @returns 핀포인트 이름 이나 핀포인트 이름을 지역이름 으로 할시 구를 기준으로 줄넘기기
+ */
+
+export const splitAddress = (address: string): [string, string] => {
+  const idx = address.indexOf("구");
+  if (idx === -1) {
+    return [address, ""];
+  }
+  return [address.slice(0, idx + 1), address.slice(idx + 1).trim()];
+};
+
+/**
+ * @param time 0분 ~ 120분
+ * @returns 분단위 데이터 60분 부터 1시간 00분 으로 리턴
+ */
+export const transTime = (time: number) => {
+  const storeTime = time;
+
+  if (storeTime < 60) {
+    return `0시간 ${storeTime}분`;
+  }
+
+  const hours = Math.floor(storeTime / 60);
+  const restMinutes = storeTime % 60;
+
+  if (restMinutes === 0) {
+    return `${hours}시간 00분`;
+  }
+
+  return `${hours}시간 ${restMinutes}분`;
+};


### PR DESCRIPTION
## #️⃣ Issue Number

 - feat:핀하우스 home / 바텀시트 추가 ( 핀포인트 설정 , 최대시간 로직 추가 )

<br/>
<br/>

## 📝 요약(Summary) (선택)

#### 변경
- homeHooks.ts: 공지 카운트가 maxTime 상태를 사용하도록 변경, 디바운스된 값으로 queryKey 업데이트, placeholderData 유지
- useListingDetailHooks.ts: 핀포인트 리스트 쿼리 queryKey를 고정값으로 변경
- type.ts: PionPointData 타입을 외부에서 쓰도록 export 처리
- useSetDefaultPinpoint.ts: 기본 핀포인트 설정 시 pinPointName도 저장
- homeStore.ts: useHomeMaxTime 스토어 추가 (maxTime 상태 관리)
- homeFullSheet.tsx: 시트 레이아웃 패딩/스크롤 구조 조정, 하단 버튼 영역 추가 (핀포인트 설정/저장하기)
- maxTime.tsx: 슬라이더를 maxTime 상태로 제어하도록 변경, 표시 문구에 현재 값 반영, 하단 저장 버튼 제거
- pinpointRowBoxs.tsx: 하드코딩 목록 삭제, 데이터 기반 렌더링 + PinpointItem 컴포넌트 사용, 선택 시 핀포인트 id/name 업데이트
- homeActionCardList.tsx: isFetching 추가로 읽음, Spinner import 추가 (현재 미사용)
- homePersonalShortcutList.tsx: 말풍선 z-index 클래스 변경
- homeQuickStatsList.tsx: 핀포인트 이름/id를 스토어에서 사용, 시간 표시는 transTime 사용, 주소 분리 유틸로 이동


<br/>
<br/>


## 💬 공유사항 (선택)
#### 추가 
 - authStore.ts: pinPointName 상태/세터 
 - utils.ts: splitAddress, transTime 유틸 추가

<br/>
<br/>
