### PR TITLE
feat:핀하우스 home / 글로벌 서치 UX/UI 추가

### DIFF
--- a/app/home/search/layout.tsx
+++ b/app/home/search/layout.tsx
@@ -1,0 +1,10 @@
+import { HomeSerachSection } from "@/src/widgets/homeSection";
+
+export default function SearchLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div>
+      <HomeSerachSection />
+      {children}
+    </div>
+  );
+}

--- a/app/home/search/page.tsx
+++ b/app/home/search/page.tsx
@@ -1,0 +1,5 @@
+import { HomeSearchTag, HomeSerachSection } from "@/src/widgets/homeSection";
+
+export default function SearchHomePage() {
+  return <HomeSearchTag />;
+}

--- a/app/home/search/result/page.tsx
+++ b/app/home/search/result/page.tsx
@@ -1,0 +1,5 @@
+import { HomeResultSection } from "@/src/widgets/homeSection";
+
+export default function HomeSearchResults() {
+  return <HomeResultSection />;
+}

--- a/src/features/home/ui/homeHeader.tsx
+++ b/src/features/home/ui/homeHeader.tsx
@@ -9,8 +9,8 @@ export const HomeHeader = () => {
   const { setPrevPath } = useRouteStore();
 
   const pageRouter = () => {
-    setPrevPath("/home");
-    router.push("/listings/search");
+    // setPrevPath("/home");
+    router.push("/home/search");
   };
 
   return (

--- a/src/features/listings/ui/listingsSearchResult/components/searchEmptyQueryView.tsx
+++ b/src/features/listings/ui/listingsSearchResult/components/searchEmptyQueryView.tsx
@@ -1,8 +1,6 @@
 import { AnimatePresence, motion } from "framer-motion";
 import { SearchHistory } from "../../listingsHeaders/listingsSearchHistory";
 import { TagButton } from "@/src/shared/ui/button/tagButton";
-import { usePopularSearchQuery } from "@/src/entities/listings/hooks/useListingHooks";
-
 import { cn } from "@/lib/utils";
 import { HandleSearchTag } from "../../../model";
 

--- a/src/shared/ui/searchBar/searchBar.tsx
+++ b/src/shared/ui/searchBar/searchBar.tsx
@@ -103,6 +103,9 @@ export const SearchBar = ({
               "flex-1 border-none bg-transparent p-0 shadow-none",
               (showInputXButton || showFilledXButton) && "pr-10" // X 버튼 공간
             )}
+            onEnter={(v: string) => {
+              onEnter?.(v);
+            }}
           />
           {showRightSearchIcon && (
             <div className="pointer-events-none flex-shrink-0">

--- a/src/widgets/homeSection/homeResultSection/homeResultSection.tsx
+++ b/src/widgets/homeSection/homeResultSection/homeResultSection.tsx
@@ -1,0 +1,3 @@
+export const HomeResultSection = () => {
+  return <div>검색결과</div>;
+};

--- a/src/widgets/homeSection/homeSearchSection/homeSearchSection.tsx
+++ b/src/widgets/homeSection/homeSearchSection/homeSearchSection.tsx
@@ -1,0 +1,33 @@
+"use client";
+import { LeftButton } from "@/src/assets/icons/button";
+import { SearchBarLabel } from "@/src/shared/ui/searchBarLabel";
+import { useRouter } from "next/navigation";
+
+export const HomeSerachSection = () => {
+  const router = useRouter();
+
+  const handleRouter = () => {
+    router.push("/home");
+  };
+
+  const handleSearch = async (keyword: string) => {
+    if (!keyword) return;
+    router.push(`/home/search/result?query=${keyword}`);
+  };
+
+  return (
+    <div className="items-cente flex items-center gap-2 p-5">
+      <LeftButton
+        onClick={handleRouter}
+        className="h-8 w-8 cursor-pointer text-greyscale-grey-400"
+      />
+      <SearchBarLabel
+        direction="vertical"
+        placeholder="공고·지역·단지를 검색해보세요"
+        className="rounded-3xl"
+        variant={"capsule"}
+        onEnter={handleSearch}
+      />
+    </div>
+  );
+};

--- a/src/widgets/homeSection/homeSearchTag/homeSearchPopuler.tsx
+++ b/src/widgets/homeSection/homeSearchTag/homeSearchPopuler.tsx
@@ -1,0 +1,37 @@
+"use client";
+import { cn } from "@/lib/utils";
+import { useSearchState } from "@/src/shared/hooks/store";
+import { TagButton } from "@/src/shared/ui/button/tagButton";
+import { useRouter } from "next/navigation";
+
+export const HomeSearchPopuler = () => {
+  const router = useRouter();
+
+  const { searchQuery } = useSearchState();
+  if (searchQuery.length === 0) return;
+
+  const handleSearchTag = (keyword: string) => {
+    if (!keyword) return;
+    router.push(`/listings/search?query=${keyword}`);
+  };
+
+  return (
+    <section className="mt-6">
+      <h3 className="mb-2 text-sm font-semibold">인기 검색어</h3>
+      <div className="flex flex-wrap gap-2">
+        {searchQuery?.map((word: any, index: number) => (
+          <TagButton
+            key={index}
+            size="sm"
+            onClick={() => handleSearchTag(word.keyword)}
+            className={cn(
+              "font-suit text-text-greyscale-grey-85 rounded-full border px-3 py-1 text-sm transition-all"
+            )}
+          >
+            {word.keyword}
+          </TagButton>
+        ))}
+      </div>
+    </section>
+  );
+};

--- a/src/widgets/homeSection/homeSearchTag/homeSearchRecent.tsx
+++ b/src/widgets/homeSection/homeSearchTag/homeSearchRecent.tsx
@@ -1,0 +1,55 @@
+"use client";
+import { cn } from "@/lib/utils";
+import { CloseButton } from "@/src/assets/icons/button";
+import { useSearchState } from "@/src/shared/hooks/store";
+import { TagButton } from "@/src/shared/ui/button/tagButton";
+import { useRouter } from "next/navigation";
+
+export const HomeSearchRecent = () => {
+  const { searchQuery, removeSearchQuery, setSearchQuery } = useSearchState();
+
+  const router = useRouter();
+  if (searchQuery.length === 0) return;
+
+  const handleDelete = (word: string) => {
+    removeSearchQuery(word);
+  };
+
+  const handleSearchTag = (keyword: string) => {
+    if (!keyword) return;
+    router.push(`/listings/search?query=${keyword}`);
+    setSearchQuery(keyword);
+  };
+
+  return (
+    <section className="mt-4">
+      <h3 className="mb-2 text-sm font-semibold">최근 검색어</h3>
+      <div className="flex flex-wrap gap-2">
+        {searchQuery.map((word, index) => (
+          <TagButton
+            key={index}
+            size="sm"
+            onClick={() => {
+              handleSearchTag(word);
+            }}
+            className={cn(
+              "transition-al font-suit text-text-greyscale-grey-85 gap-2 rounded-full border px-2 py-1 text-sm"
+            )}
+            variant={"ghost"}
+          >
+            {word}
+            <span
+              className="h-4 w-4"
+              onClick={e => {
+                e.stopPropagation();
+                handleDelete(word);
+              }}
+            >
+              <CloseButton className="h-full w-full" />
+            </span>
+          </TagButton>
+        ))}
+      </div>
+    </section>
+  );
+};

--- a/src/widgets/homeSection/homeSearchTag/homeSearchTag.tsx
+++ b/src/widgets/homeSection/homeSearchTag/homeSearchTag.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { AnimatePresence, motion } from "framer-motion";
+import { HomeSearchRecent } from "./homeSearchRecent";
+import { HomeSearchPopuler } from "./homeSearchPopuler";
+
+export const HomeSearchTag = () => {
+  return (
+    <div className="flex-1 p-5">
+      <AnimatePresence mode="wait">
+        <motion.div
+          initial={{ x: 100, opacity: 0 }}
+          animate={{ x: 0, opacity: 1 }}
+          exit={{ x: -100, opacity: 0 }}
+          transition={{ duration: 0.1, ease: "easeInOut" }}
+          className="flex flex-col"
+        >
+          <HomeSearchRecent />
+          <HomeSearchPopuler />
+        </motion.div>
+      </AnimatePresence>
+    </div>
+  );
+};

--- a/src/widgets/homeSection/index.ts
+++ b/src/widgets/homeSection/index.ts
@@ -1,0 +1,5 @@
+export * from "./homeSearchTag/homeSearchPopuler";
+export * from "./homeSearchTag/homeSearchRecent";
+export * from "./homeSearchSection/homeSearchSection";
+export * from "./homeSearchTag/homeSearchTag";
+export * from "./homeResultSection/homeResultSection";


### PR DESCRIPTION
## #️⃣ Issue Number

#292 

<br/>
<br/>

## 📝 요약(Summary) (선택)


#### 추가
- homeResultSection.tsx: 검색 결과 섹션용 플레이스홀더 컴포넌트 렌더링(문구 일부 깨짐).
- homeSearchPopuler.tsx: 스토어의 검색어 목록을 태그로 렌더; 태그 클릭 시 /listings/search?query=...로 이동; 검색어 없으면 렌더 생략.
- homeSearchRecent.tsx: 최근 검색어 태그 렌더 및 개별 삭제 지원(X 버튼, 이벤트 전파 중지); 태그 클릭 시 /listings/search?query=... 이동과 함께 setSearchQuery 갱신.
- homeSearchSection.tsx: 상단 검색바/뒤로가기 UI; 뒤로가기는 /home, 검색 Enter 시 /home/search/result?query=...로 이동; 컴포넌트명 오타(HomeSerachSection)와 placeholder 문자열 일부 깨짐.
- homeSearchTag.tsx: 전환 애니메이션으로 Recent/Popular 섹션 묶어 표시.
- index.ts: 위의 위젯들을 일괄 re-export.
- layout.tsx: 검색 페이지 레이아웃 구성(헤더 HomeSerachSection + children).
- page.tsx: 검색 초기 페이지 컴포넌트(HomeSearchTag 렌더).

#### 변경
- homeHeader.tsx: 이전 경로 저장(setPrevPath("/home")) 주석 처리; 라우팅을 "/listings/search" → "/home/search"로 변경.
- searchEmptyQueryView.tsx: 사용되지 않는 usePopularSearchQuery import 제거(동작 변화 없음).
- searchBar.tsx: 입력에서 Enter 발생 시 상위 onEnter 콜백을 호출하도록 핸들러 추가.

<br/>
<br/>

## 📸스크린샷 (선택)2
## 추가된UI
<img width="376" height="586" alt="Image" src="https://github.com/user-attachments/assets/cfaef12b-e9c1-424f-b0cd-de112cc148bb" />
<img width="406" height="578" alt="Image" src="https://github.com/user-attachments/assets/34372ce0-69ed-4711-848e-471287c895d9" />
<br/>
<br/>

