### PR TITLE
feat:핀하우스 home / 글로벌 검색 리스트 API 연동

### DIFF
--- a/app/home/search/result/page.tsx
+++ b/app/home/search/result/page.tsx
@@ -1,5 +1,14 @@
-import { HomeResultSection } from "@/src/widgets/homeSection";
+import { ResultLifecycle } from "./resultLifecycle";
 
-export default function HomeSearchResults() {
-  return <HomeResultSection />;
+export default async function HomeSearchResults({
+  searchParams,
+}: {
+  searchParams: { q?: string; query?: string };
+}) {
+  const params = await searchParams;
+
+  const q =
+    typeof params.q === "string" ? params.q : typeof params.query === "string" ? params.query : "";
+
+  return <ResultLifecycle q={q} />;
 }

--- a/app/home/search/result/resultLifecycle.tsx
+++ b/app/home/search/result/resultLifecycle.tsx
@@ -1,0 +1,21 @@
+// app/home/search/result/ResultLifecycle.tsx
+"use client";
+import { useEffect, useRef } from "react";
+import { useSearchState } from "@/src/shared/hooks/store";
+import { HomeResultSection } from "@/src/widgets/homeSection";
+
+export const ResultLifecycle = ({ q }: { q: string }) => {
+  const { setSearchQuery } = useSearchState();
+
+  const committedRef = useRef(q);
+
+  useEffect(() => {
+    return () => {
+      if (committedRef.current) {
+        setSearchQuery(committedRef.current);
+      }
+    };
+  }, [setSearchQuery]);
+
+  return <HomeResultSection q={q} />;
+};

--- a/src/entities/home/api/__test__/home.test.ts
+++ b/src/entities/home/api/__test__/home.test.ts
@@ -1,5 +1,5 @@
 import { HOME_NOTICE_ENDPOINT, HOME_SEARCH_POPULAR_ENDPOINT, http } from "@/src/shared/api";
-import { NoticeCount } from "../../model/type";
+import { GlobalListType, NoticeCount, PopularResponse } from "../../model/type";
 import { IResponse } from "@/src/shared/types";
 import { getNoticeByPinPoint } from "../../interface/homeInterface";
 
@@ -51,12 +51,6 @@ interface PopularParamType {
   limit: number;
 }
 
-interface PopularResponse {
-  keyword: string;
-  count: number;
-  lastSearchedAt: string;
-}
-
 describe("핀포인트 home 글로벌 서치 인기검색어", () => {
   it.skip("인기검색어 SUCCESS", async () => {
     const param: PopularParamType = {
@@ -82,6 +76,101 @@ describe("핀포인트 home 글로벌 서치 인기검색어", () => {
     });
 
     const result = await getNoticeByPinPoint<IResponse<PopularResponse>>({
+      url,
+      params: param,
+    });
+
+    expect(http.get).toHaveBeenCalledWith(url, param, undefined);
+    expect(result).toEqual(Mock);
+  });
+});
+
+interface OverviewParamType {
+  q: string;
+}
+
+describe("핀포인트 home 글로벌 서치 결과", () => {
+  it("검색 리스트 SUCCESS", async () => {
+    const param: OverviewParamType = {
+      q: "청년",
+    };
+
+    const Mock: GlobalListType = {
+      notices: {
+        category: "notices",
+        content: [
+          {
+            id: "19498",
+            title:
+              "광주역세권 청년혁신타운 통합공공임대주택(일자리연계형 지원주택) 입주자 추가모집공고",
+            agency: "경기주택도시공사",
+            housingType: "오피스텔",
+            supplyType: "통합공공임대",
+            announceDate: "2025-12-23",
+            applyStart: "2026-01-06",
+            applyEnd: "2026-01-09",
+            targetGroups: ["무주택자", "청년"],
+            liked: false,
+          },
+        ],
+        hasNext: false,
+      },
+      complexes: {
+        category: "complexes",
+        content: [
+          {
+            id: "19498",
+            title:
+              "광주역세권 청년혁신타운 통합공공임대주택(일자리연계형 지원주택) 입주자 추가모집공고",
+            agency: "경기주택도시공사",
+            housingType: "오피스텔",
+            supplyType: "통합공공임대",
+            announceDate: "2025-12-23",
+            applyStart: "2026-01-06",
+            applyEnd: "2026-01-09",
+            targetGroups: ["무주택자", "청년"],
+            liked: false,
+          },
+        ],
+        hasNext: false,
+      },
+      targetGroups: {
+        category: "targetGroups",
+        content: [
+          {
+            id: "19498",
+            title:
+              "광주역세권 청년혁신타운 통합공공임대주택(일자리연계형 지원주택) 입주자 추가모집공고",
+            agency: "경기주택도시공사",
+            housingType: "오피스텔",
+            supplyType: "통합공공임대",
+            announceDate: "2025-12-23",
+            applyStart: "2026-01-06",
+            applyEnd: "2026-01-09",
+            targetGroups: ["무주택자", "청년"],
+            liked: false,
+          },
+        ],
+        hasNext: false,
+      },
+      regions: {
+        category: "regions",
+        content: [],
+        hasNext: false,
+      },
+      houseTypes: {
+        category: "houseTypes",
+        content: [],
+        hasNext: false,
+      },
+    };
+
+    const url = `${HOME_SEARCH_POPULAR_ENDPOINT}/overview`;
+    (http.get as jest.Mock).mockResolvedValue({
+      data: Mock,
+    });
+
+    const result = await getNoticeByPinPoint<IResponse<GlobalListType>>({
       url,
       params: param,
     });

--- a/src/entities/home/hooks/homeHooks.ts
+++ b/src/entities/home/hooks/homeHooks.ts
@@ -45,14 +45,14 @@ export const useNoticeCount = () => {
   });
 };
 
-export const useGlobalPopular = () => {
-  const param = {
-    limit: 10,
-  };
-  const url = `${HOME_SEARCH_POPULAR_ENDPOINT}/popular`;
+export const useGlobal = <T>({ params, q }: { params: string; q: string }) => {
+  const url = `${HOME_SEARCH_POPULAR_ENDPOINT}/${params}`;
+
+  const param = params === "popular" ? { limit: 10 } : { q: q };
+
   return useQuery({
-    queryKey: ["globalPopular"],
-    placeholderData: previousData => previousData,
-    queryFn: () => getNoticeByPinPoint<PopularResponse[]>({ url: url, params: param }),
+    queryKey: ["global-search", params, q],
+    queryFn: () => getNoticeByPinPoint<T>({ url, params: param }),
+    enabled: params === "popular" || q?.length > 0,
   });
 };

--- a/src/entities/home/model/type.ts
+++ b/src/entities/home/model/type.ts
@@ -45,3 +45,36 @@ export interface PopularResponse {
   count: number;
   lastSearchedAt: string;
 }
+
+export type SearchCategory = "notices" | "complexes" | "targetGroups" | "regions" | "houseTypes";
+export interface GlobalSearchItem {
+  id: string;
+  title: string;
+  agency: string;
+  housingType: string;
+  supplyType: string;
+  announceDate: string;
+  applyStart: string;
+  applyEnd: string;
+  targetGroups: string[];
+  liked: boolean;
+}
+
+export interface GlobalList<T> {
+  content: T[];
+  hasNext: boolean;
+}
+
+export interface GlobalListType {
+  notices: GlobalList<GlobalSearchItem>;
+  complexes: GlobalList<GlobalSearchItem>;
+  targetGroups: GlobalList<GlobalSearchItem>;
+  regions: GlobalList<GlobalSearchItem>;
+  houseTypes: GlobalList<GlobalSearchItem>;
+}
+
+export interface GlobalSearchSection {
+  category: SearchCategory;
+  content: GlobalSearchItem[];
+  hasNext: boolean;
+}

--- a/src/features/home/hooks/hooks.tsx
+++ b/src/features/home/hooks/hooks.tsx
@@ -1,0 +1,51 @@
+import { GlobalBuilding } from "@/src/assets/icons/home/globalBuilding";
+import { GlobalNoticeIncon } from "@/src/assets/icons/home/globalDoc";
+import { GlobalHouse } from "@/src/assets/icons/home/globalHouse";
+import { GlobalMapPin } from "@/src/assets/icons/home/globalMappin";
+import { GlobalPerson } from "@/src/assets/icons/home/globalPerson";
+import {
+  GlobalListType,
+  GlobalSearchSection,
+  SearchCategory,
+} from "@/src/entities/home/model/type";
+import { ReactNode } from "react";
+
+export const SEARCH_CATEGORY_CONFIG: Record<SearchCategory, { label: string; icon: ReactNode }> = {
+  notices: { label: "공고명", icon: <GlobalNoticeIncon /> },
+  complexes: { label: "단지명", icon: <GlobalBuilding /> },
+  targetGroups: { label: "모집대상", icon: <GlobalPerson /> },
+  regions: { label: "지역", icon: <GlobalMapPin /> },
+  houseTypes: { label: "주택유형", icon: <GlobalHouse /> },
+};
+
+export const useHomeGlobalSearch = (globalData?: GlobalListType): GlobalSearchSection[] => {
+  if (!globalData) return [];
+
+  return [
+    {
+      category: "notices",
+      content: globalData.notices.content,
+      hasNext: globalData.notices.hasNext,
+    },
+    {
+      category: "complexes",
+      content: globalData.complexes.content,
+      hasNext: globalData.complexes.hasNext,
+    },
+    {
+      category: "targetGroups",
+      content: globalData.targetGroups.content,
+      hasNext: globalData.targetGroups.hasNext,
+    },
+    {
+      category: "regions",
+      content: globalData.regions.content,
+      hasNext: globalData.regions.hasNext,
+    },
+    {
+      category: "houseTypes",
+      content: globalData.houseTypes.content,
+      hasNext: globalData.houseTypes.hasNext,
+    },
+  ];
+};

--- a/src/features/home/ui/result/homeResultSectionHeader.tsx
+++ b/src/features/home/ui/result/homeResultSectionHeader.tsx
@@ -1,4 +1,5 @@
-import { SEARCH_CATEGORY_CONFIG, SearchCategory } from "@/src/widgets/homeSection";
+import { SearchCategory } from "@/src/entities/home/model/type";
+import { SEARCH_CATEGORY_CONFIG } from "../../hooks/hooks";
 
 interface HomeResultSectionHeaderProps {
   category: SearchCategory;
@@ -6,6 +7,7 @@ interface HomeResultSectionHeaderProps {
 }
 
 export const HomeResultSectionHeader = ({ category, count }: HomeResultSectionHeaderProps) => {
+  if (!category) return null;
   const config = SEARCH_CATEGORY_CONFIG[category];
 
   return (

--- a/src/features/home/ui/result/homeResultSectionItem.tsx
+++ b/src/features/home/ui/result/homeResultSectionItem.tsx
@@ -1,10 +1,10 @@
 import { cn } from "@/lib/utils";
 
-import { SearchItem } from "@/src/widgets/homeSection";
 import { HomeBgBookMark } from "./components/HomeBgBookMark";
+import { GlobalSearchItem } from "@/src/entities/home/model/type";
 
 interface HomeResultSectionItemsProps {
-  items: SearchItem[];
+  items: GlobalSearchItem[];
   limit?: number;
 }
 

--- a/src/features/home/ui/search/homeSearchPopuler.tsx
+++ b/src/features/home/ui/search/homeSearchPopuler.tsx
@@ -1,19 +1,17 @@
 "use client";
 import { cn } from "@/lib/utils";
-import { useGlobalPopular } from "@/src/entities/home/hooks/homeHooks";
-import { useSearchState } from "@/src/shared/hooks/store";
+import { useGlobal } from "@/src/entities/home/hooks/homeHooks";
+import { PopularResponse } from "@/src/entities/home/model/type";
 import { TagButton } from "@/src/shared/ui/button/tagButton";
 import { useRouter } from "next/navigation";
 
 export const HomeSearchPopuler = () => {
   const router = useRouter();
-  const { data } = useGlobalPopular();
-  const { searchQuery } = useSearchState();
-  if (searchQuery.length === 0) return;
+  const { data } = useGlobal<PopularResponse[]>({ params: "popular", q: "" });
 
   const handleSearchTag = (keyword: string) => {
     if (!keyword) return;
-    router.push(`/listings/search?query=${keyword}`);
+    router.push(`/home/search/result?q=${encodeURIComponent(keyword)}`);
   };
 
   return (

--- a/src/features/home/ui/search/homeSearchRecent.tsx
+++ b/src/features/home/ui/search/homeSearchRecent.tsx
@@ -6,7 +6,7 @@ import { TagButton } from "@/src/shared/ui/button/tagButton";
 import { useRouter } from "next/navigation";
 
 export const HomeSearchRecent = () => {
-  const { searchQuery, removeSearchQuery, setSearchQuery } = useSearchState();
+  const { searchQuery, removeSearchQuery } = useSearchState();
 
   const router = useRouter();
   if (searchQuery.length === 0) return;
@@ -17,8 +17,7 @@ export const HomeSearchRecent = () => {
 
   const handleSearchTag = (keyword: string) => {
     if (!keyword) return;
-    router.push(`/listings/search?query=${keyword}`);
-    setSearchQuery(keyword);
+    router.push(`/home/search/result?q=${encodeURIComponent(keyword)}`);
   };
 
   return (

--- a/src/features/home/ui/search/searchBar.tsx
+++ b/src/features/home/ui/search/searchBar.tsx
@@ -1,13 +1,16 @@
 "use client";
 import { SearchBarLabel } from "@/src/shared/ui/searchBarLabel";
 import { useRouter } from "next/navigation";
+import { useSearchState } from "@/src/shared/hooks/store";
 
 export const SearchBar = () => {
   const router = useRouter();
+  const { setSearchQuery } = useSearchState();
 
   const handleSearch = async (keyword: string) => {
     if (!keyword) return;
-    router.push(`/home/search/result?query=${keyword}`);
+    setSearchQuery(keyword);
+    router.push(`/home/search/result?q=${encodeURIComponent(keyword)}`);
   };
 
   return (

--- a/src/widgets/homeSection/homeResultSection/homeResultSection.tsx
+++ b/src/widgets/homeSection/homeResultSection/homeResultSection.tsx
@@ -1,231 +1,37 @@
-import { GlobalBuilding } from "@/src/assets/icons/home/globalBuilding";
-import { GlobalNoticeIncon } from "@/src/assets/icons/home/globalDoc";
-import { GlobalHouse } from "@/src/assets/icons/home/globalHouse";
-import { GlobalMapPin } from "@/src/assets/icons/home/globalMappin";
-import { GlobalPerson } from "@/src/assets/icons/home/globalPerson";
+"use client";
+import { useGlobal } from "@/src/entities/home/hooks/homeHooks";
+import { GlobalListType } from "@/src/entities/home/model/type";
 import { HomeResultSectionHeader } from "@/src/features/home";
+import { useHomeGlobalSearch } from "@/src/features/home/hooks/hooks";
 import { HomeResultSectionItems } from "@/src/features/home/ui/result/homeResultSectionItem";
 import { HomeResultSectionMore } from "@/src/features/home/ui/result/homeResultSectionMore";
-import { ReactNode } from "react";
+import { PageTransition } from "@/src/shared/ui/animation";
 
-export type SearchCategory = "NOTICE" | "COMPLEX" | "TARGET_GROUP" | "REGION" | "HOUSE_TYPE";
-
-export interface SearchItem {
-  id: string;
-  title: string;
-  agency: string;
-  housingType: string;
-  supplyType: string;
-  announceDate: string;
-  applyStart: string;
-  applyEnd: string;
-  targetGroups: string[];
-  liked: boolean;
-}
-
-export interface SearchResponse {
-  category: SearchCategory;
-  page: number;
-  content: SearchItem[];
-  hasNext: boolean;
-}
-export const NOTICE_SEARCH_MOCK: SearchResponse = {
-  category: "NOTICE",
-  page: 1,
-  content: [
-    {
-      id: "N001",
-      title: "광주역세권 청년혁신타운 통합공공임대주택 입주자 모집공고",
-      agency: "경기주택도시공사",
-      housingType: "오피스텔",
-      supplyType: "통합공공임대",
-      announceDate: "2025-12-23",
-      applyStart: "2026-01-06",
-      applyEnd: "2026-01-09",
-      targetGroups: ["청년", "무주택자"],
-      liked: false,
-    },
-    {
-      id: "N002",
-      title: "광주역세권 청년혁신타운 통합공공임대주택 입주자 모집공고",
-      agency: "경기주택도시공사",
-      housingType: "오피스텔",
-      supplyType: "통합공공임대",
-      announceDate: "2025-12-23",
-      applyStart: "2026-01-06",
-      applyEnd: "2026-01-09",
-      targetGroups: ["청년", "무주택자"],
-      liked: false,
-    },
-    {
-      id: "N003",
-      title: "광주역세권 청년혁신타운 통합공공임대주택 입주자 모집공고",
-      agency: "경기주택도시공사",
-      housingType: "오피스텔",
-      supplyType: "통합공공임대",
-      announceDate: "2025-12-23",
-      applyStart: "2026-01-06",
-      applyEnd: "2026-01-09",
-      targetGroups: ["청년", "무주택자"],
-      liked: false,
-    },
-    {
-      id: "N004",
-      title: "광주역세권 청년혁신타운 통합공공임대주택 입주자 모집공고",
-      agency: "경기주택도시공사",
-      housingType: "오피스텔",
-      supplyType: "통합공공임대",
-      announceDate: "2025-12-23",
-      applyStart: "2026-01-06",
-      applyEnd: "2026-01-09",
-      targetGroups: ["청년", "무주택자"],
-      liked: false,
-    },
-    {
-      id: "N005",
-      title: "광주역세권 청년혁신타운 통합공공임대주택 입주자 모집공고",
-      agency: "경기주택도시공사",
-      housingType: "오피스텔",
-      supplyType: "통합공공임대",
-      announceDate: "2025-12-23",
-      applyStart: "2026-01-06",
-      applyEnd: "2026-01-09",
-      targetGroups: ["청년", "무주택자"],
-      liked: false,
-    },
-    {
-      id: "N006",
-      title: "광주역세권 청년혁신타운 통합공공임대주택 입주자 모집공고",
-      agency: "경기주택도시공사",
-      housingType: "오피스텔",
-      supplyType: "통합공공임대",
-      announceDate: "2025-12-23",
-      applyStart: "2026-01-06",
-      applyEnd: "2026-01-09",
-      targetGroups: ["청년", "무주택자"],
-      liked: false,
-    },
-  ],
-  hasNext: false,
-};
-
-export const COMPLEX_SEARCH_MOCK: SearchResponse = {
-  category: "COMPLEX",
-  page: 1,
-  content: [
-    {
-      id: "C001",
-      title: "광주역세권 청년혁신타운",
-      agency: "광주도시공사",
-      housingType: "공공임대",
-      supplyType: "청년주택",
-      announceDate: "2025-11-10",
-      applyStart: "2025-12-01",
-      applyEnd: "2025-12-15",
-      targetGroups: ["청년"],
-      liked: false,
-    },
-  ],
-  hasNext: false,
-};
-
-export const TARGET_GROUP_SEARCH_MOCK: SearchResponse = {
-  category: "TARGET_GROUP",
-  page: 1,
-  content: [
-    {
-      id: "TG001",
-      title: "청년 대상 공공임대주택",
-      agency: "국토교통부",
-      housingType: "행복주택",
-      supplyType: "공공임대",
-      announceDate: "2025-10-01",
-      applyStart: "2025-10-10",
-      applyEnd: "2025-10-20",
-      targetGroups: ["청년"],
-      liked: false,
-    },
-  ],
-  hasNext: false,
-};
-
-export const REGION_SEARCH_MOCK: SearchResponse = {
-  category: "REGION",
-  page: 1,
-  content: [
-    {
-      id: "R001",
-      title: "서울 강남구 공공임대주택 공고",
-      agency: "서울주택도시공사",
-      housingType: "아파트",
-      supplyType: "국민임대",
-      announceDate: "2025-09-15",
-      applyStart: "2025-09-25",
-      applyEnd: "2025-10-05",
-      targetGroups: ["무주택자"],
-      liked: false,
-    },
-  ],
-  hasNext: false,
-};
-
-export const HOUSE_TYPE_SEARCH_MOCK: SearchResponse = {
-  category: "HOUSE_TYPE",
-  page: 1,
-  content: [
-    {
-      id: "H001",
-      title: "오피스텔 공공임대주택 입주자 모집",
-      agency: "인천도시공사",
-      housingType: "오피스텔",
-      supplyType: "공공임대",
-      announceDate: "2025-08-20",
-      applyStart: "2025-09-01",
-      applyEnd: "2025-09-10",
-      targetGroups: ["청년", "신혼부부"],
-      liked: false,
-    },
-  ],
-  hasNext: false,
-};
-
-export const SEARCH_CATEGORY_CONFIG: Record<SearchCategory, { label: string; icon: ReactNode }> = {
-  NOTICE: { label: "공고명", icon: <GlobalNoticeIncon /> },
-  COMPLEX: { label: "단지명", icon: <GlobalBuilding /> },
-  TARGET_GROUP: { label: "모집대상", icon: <GlobalPerson /> },
-  REGION: { label: "지역", icon: <GlobalMapPin /> },
-  HOUSE_TYPE: { label: "주택유형", icon: <GlobalHouse /> },
-};
-
-export const useHomeGlobalSearch = (): SearchResponse[] => {
-  return [
-    NOTICE_SEARCH_MOCK,
-    COMPLEX_SEARCH_MOCK,
-    TARGET_GROUP_SEARCH_MOCK,
-    REGION_SEARCH_MOCK,
-    HOUSE_TYPE_SEARCH_MOCK,
-  ];
-};
-export const HomeResultSection = () => {
-  const data = useHomeGlobalSearch();
+export const HomeResultSection = ({ q }: { q: string }) => {
+  const { data: globalData } = useGlobal<GlobalListType>({ params: "overview", q: q });
+  const data = useHomeGlobalSearch(globalData);
 
   return (
-    <section className="flex flex-col gap-5 bg-greyscale-grey-25 p-5">
-      {data.map(section => {
-        return (
-          <div key={section.category}>
-            <span>
-              <HomeResultSectionHeader category={section.category} count={section.content.length} />
-            </span>
-            <span className="flex flex-col rounded-xl border">
-              <HomeResultSectionItems items={section.content} limit={5} />
+    <PageTransition>
+      <section className="flex flex-col gap-5 bg-greyscale-grey-25 p-5">
+        {data.map(section => {
+          return (
+            <div key={section.category}>
+              <span>
+                <HomeResultSectionHeader
+                  category={section.category}
+                  count={section.content.length}
+                />
+              </span>
+              <span className="flex flex-col rounded-xl border">
+                <HomeResultSectionItems items={section.content} limit={5} />
 
-              {/* More */}
-              <HomeResultSectionMore total={section.content.length} limit={5} />
-            </span>
-          </div>
-        );
-      })}
-    </section>
+                <HomeResultSectionMore total={section.content.length} limit={5} />
+              </span>
+            </div>
+          );
+        })}
+      </section>
+    </PageTransition>
   );
 };

--- a/src/widgets/homeSection/homeSearchSection/homeSearchSection.tsx
+++ b/src/widgets/homeSection/homeSearchSection/homeSearchSection.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { LeftButton } from "@/src/assets/icons/button";
 import { SearchBar } from "@/src/features/home";
-import { SearchBarLabel } from "@/src/shared/ui/searchBarLabel";
 import { useRouter } from "next/navigation";
 
 export const HomeSerachSection = () => {


### PR DESCRIPTION
## #️⃣ Issue Number

#314 

<br/>
<br/>

## 📝 요약(Summary) (선택)

#### 변경
- page.tsx: 검색 결과 페이지가 ResultLifecycle를 사용하도록 변경. searchParams에서 q/query를 허용하고 await로 읽어 q를 전달.
- homeHooks.ts: 글로벌 서치 훅 useGlobal 정리. /popular는 limit, /overview는 q 파라미터로 호출하고 enabled 조건을 분기.
- type.ts: 글로벌 서치 타입 추가·정리. SearchCategory, GlobalList, GlobalListType, GlobalSearchSection 등 정의.
- homeResultSectionHeader.tsx: SEARCH_CATEGORY_CONFIG 기반으로 아이콘/라벨/카운트 표시.
- homeResultSectionItem.tsx: 글로벌 검색 아이템 리스트 렌더링(타이틀, 공급유형 뱃지) 구성 정리.
- homeSearchPopuler.tsx: 인기검색어 API 연동(useGlobal('popular')) 및 태그 클릭 시 ?q=로 라우팅하도록 수정.
- homeSearchRecent.tsx: 최근검색어 스토어 사용해 삭제/클릭 처리, 클릭 시 ?q=로 라우팅하도록 수정.
- searchBar.tsx: 검색 즉시 최근검색어 저장(setSearchQuery) 후 ?q=로 라우팅하도록 변경.
- homeResultSection.tsx: q를 받아 useGlobal('overview')로 데이터 패치 후 useHomeGlobalSearch로 섹션화, PageTransition 감싸기.
- homeSearchSection.tsx: 동작 동일, 포맷/경계만 정리.

#### 추가
- resultLifecycle.tsx: 클라이언트 래퍼. 언마운트 시점에 q를 최근검색어로 저장하고 HomeResultSection 렌더.
- hooks.tsx: SEARCH_CATEGORY_CONFIG와 useHomeGlobalSearch 추가. 글로벌 서치 응답을 섹션 배열로 변환.

<br/>
<br/>

