### PR TITLE
feat:핀하우스 home / 글로벌 서치 /  더보기  로직 추가

### DIFF
--- a/src/features/home/ui/result/homeResultSectionMore.tsx
+++ b/src/features/home/ui/result/homeResultSectionMore.tsx
@@ -3,15 +3,25 @@ import { DownButton } from "@/src/assets/icons/button";
 interface HomeResultSectionMoreProps {
   total: number;
   limit: number;
+  expanded: boolean;
+  onToggle: () => void;
 }
 
-export const HomeResultSectionMore = ({ total, limit }: HomeResultSectionMoreProps) => {
+export const HomeResultSectionMore = ({
+  total,
+  limit,
+  expanded,
+  onToggle,
+}: HomeResultSectionMoreProps) => {
   if (total <= limit) return null;
 
   return (
-    <button className="flex w-full items-center justify-center rounded-b-xl bg-white p-3 text-center text-xs text-gray-400">
-      <p>더보기</p>
-      <span>
+    <button
+      onClick={onToggle}
+      className="flex w-full items-center justify-center gap-1 rounded-b-xl bg-white p-3 text-xs text-gray-400"
+    >
+      <p>{expanded ? "접기" : "더보기"}</p>
+      <span className={`transition-transform ${expanded ? "rotate-180" : ""}`}>
         <DownButton width={15} height={15} />
       </span>
     </button>

--- a/src/widgets/homeSection/homeResultSection/components/homeResultSectionBlock.tsx
+++ b/src/widgets/homeSection/homeResultSection/components/homeResultSectionBlock.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { SearchCategory } from "@/src/entities/home/model/type";
+import { HomeResultSectionHeader } from "@/src/features/home";
+import { HomeResultSectionItems } from "@/src/features/home/ui/result/homeResultSectionItem";
+import { HomeResultSectionMore } from "@/src/features/home/ui/result/homeResultSectionMore";
+import { useState } from "react";
+
+export const HomeResultSectionBlock = ({
+  category,
+  items,
+  limit,
+  q,
+}: {
+  category: SearchCategory;
+  items: any[];
+  limit: number;
+  q: string;
+}) => {
+  const [expanded, setExpanded] = useState(false);
+
+  const visibleItems = expanded ? items : items.slice(0, limit);
+
+  return (
+    <div>
+      <HomeResultSectionHeader category={category} count={items.length} />
+
+      <span className="flex flex-col rounded-xl border">
+        <HomeResultSectionItems items={visibleItems} limit={limit} q={q} />
+
+        <HomeResultSectionMore
+          total={items.length}
+          limit={limit}
+          expanded={expanded}
+          onToggle={() => setExpanded(v => !v)}
+        />
+      </span>
+    </div>
+  );
+};

--- a/src/widgets/homeSection/homeResultSection/homeResultSection.tsx
+++ b/src/widgets/homeSection/homeResultSection/homeResultSection.tsx
@@ -1,11 +1,9 @@
 "use client";
 import { useGlobal } from "@/src/entities/home/hooks/homeHooks";
 import { GlobalListType } from "@/src/entities/home/model/type";
-import { HomeResultSectionHeader } from "@/src/features/home";
 import { useHomeGlobalSearch } from "@/src/features/home/hooks/hooks";
-import { HomeResultSectionItems } from "@/src/features/home/ui/result/homeResultSectionItem";
-import { HomeResultSectionMore } from "@/src/features/home/ui/result/homeResultSectionMore";
 import { PageTransition } from "@/src/shared/ui/animation";
+import { HomeResultSectionBlock } from "./components/homeResultSectionBlock";
 
 export const HomeResultSection = ({ q }: { q: string }) => {
   const { data: globalData } = useGlobal<GlobalListType>({ params: "overview", q: q });
@@ -14,23 +12,15 @@ export const HomeResultSection = ({ q }: { q: string }) => {
   return (
     <PageTransition>
       <section className="flex h-screen flex-col gap-5 bg-greyscale-grey-25 p-5">
-        {data.map(section => {
-          return (
-            <div key={section.category}>
-              <span>
-                <HomeResultSectionHeader
-                  category={section.category}
-                  count={section.content.length}
-                />
-              </span>
-              <span className="flex flex-col rounded-xl border">
-                <HomeResultSectionItems items={section.content} limit={5} q={q} />
-
-                <HomeResultSectionMore total={section.content.length} limit={5} />
-              </span>
-            </div>
-          );
-        })}
+        {data.map(section => (
+          <HomeResultSectionBlock
+            key={section.category}
+            category={section.category}
+            items={section.content}
+            limit={5}
+            q={q}
+          />
+        ))}
       </section>
     </PageTransition>
   );


### PR DESCRIPTION
## #️⃣ Issue Number

#318 

<br/>
<br/>

## 📝 요약(Summary) (선택)

- 유저가 원하는 항목의 데이터의 길이가 5개 이상일시
- 더보기 탭 클릭시 추가로 5개식 데이터를 제공 한다.
- API 연결은 하지 않고 로직만 추가한다.

#### 추가
- HomeResultSectionBlock
- 섹션 단위 래퍼 신설. category/items/limit/q props 수신, 섹션별 expanded 상태 관리.
- expanded에 따라 아이템 slice 처리, 헤더/아이템/더보기(접기) 버튼을 일체로 렌더.
- HomeResultSectionItems에 q 전달해 제목 하이라이트 적용.

#### 변경
- HomeResultSectionMore
- props 확장: expanded, onToggle 추가.
- 버튼 클릭으로 펼치기/접기 토글, 라벨 “더보기/접기” 전환, 아이콘 회전 애니메이션 추가.
- total <= limit 시 렌더 생략 동일 유지.

#### HomeResultSection
- 섹션 렌더 구조를 HomeResultSectionBlock 사용으로 위임(헤더/아이템/더보기 조립 로직 제거).
- data.map에서 블록에 category/items/limit/q 전달해 일관 처리.
- 기존 useGlobal + useHomeGlobalSearch, PageTransition 사용은 유지.

<br/>
<br/>

