### PR TITLE
style:핀하우스 home / 공고리스트 / 공고상세 css 정리

### DIFF
--- a/app/listings/page.tsx
+++ b/app/listings/page.tsx
@@ -1,10 +1,17 @@
+import { HomeScreenLogo } from "@/src/assets/icons/home/homeScreenLogo";
 import { ListingsSection } from "@/src/widgets/listingsSection";
 import { Suspense } from "react";
 
 export default function Listings() {
   return (
     <main className="flex h-full flex-col">
-      <Suspense fallback={null}>
+      <Suspense
+        fallback={
+          <div className="flex min-h-screen w-full -translate-y-20 items-center justify-center">
+            <HomeScreenLogo width={60} height={50} />
+          </div>
+        }
+      >
         <ListingsSection />
       </Suspense>
     </main>

--- a/src/entities/listings/hooks/useListingDetailHooks.ts
+++ b/src/entities/listings/hooks/useListingDetailHooks.ts
@@ -56,7 +56,8 @@ export const useListingDetailBasic = (id: string) => {
       debouncedMaxDeposit,
       debouncedMaxMonthPay,
     ],
-    enabled: !!id,
+    placeholderData: prevData => prevData,
+    enabled: typeof id === "string" && id.length > 0,
     staleTime: 1000 * 60 * 5,
     retry: false,
 

--- a/src/features/home/ui/homeUrgentNoticeList.tsx
+++ b/src/features/home/ui/homeUrgentNoticeList.tsx
@@ -25,8 +25,9 @@ export const UrgentNoticeList = () => {
   };
 
   return (
-    <section className={cn("flex flex-col", contents.length >= 2 ? "pb-[55px]" : "")}>
-      <div className="flex items-center justify-between">
+    // <section className={cn("flex flex-col", contents.length >= 2 ? "pb-[55px]" : "")}>
+    <section className={cn("flex flex-col")}>
+      <div className="flex items-center justify-between pt-4">
         <div>
           <p className="mb-3 text-lg font-bold text-greyscale-grey-900">
             {isError || dataCount ? "공고 리스트" : "마감임박 공고"}

--- a/src/features/listings/ui/listingsContents/listingsBookMark.tsx
+++ b/src/features/listings/ui/listingsContents/listingsBookMark.tsx
@@ -24,7 +24,6 @@ export const ListingBgBookMark = ({
   text: string;
   border: string;
 }) => {
-  console.log(bg, text, border);
   return (
     <Toggle
       aria-label="Toggle bookmark"

--- a/src/features/listings/ui/listingsContents/listingsContents.tsx
+++ b/src/features/listings/ui/listingsContents/listingsContents.tsx
@@ -1,5 +1,4 @@
 "use client";
-
 import { useListingListInfiniteQuery } from "@/src/entities/listings/hooks/useListingHooks";
 import { ListingsContentHeader } from "./listingsContentsHeader";
 import { ListingContentsList } from "./listingsContentsList";
@@ -12,7 +11,7 @@ export const ListingsContent = ({ viewSet = true }: { viewSet?: boolean }) => {
 
   const totalCount = isLoading || !isSuccess ? null : (data?.pages[0]?.totalCount ?? 0);
 
-  if (isLoading) {
+  if (!data) {
     return (
       <div className="flex h-full items-center justify-center pb-[88px]">
         <Spinner title="공고 탐색중..." description="잠시만 기다려주세요" />

--- a/src/features/listings/ui/listingsContents/listingsContentsList.tsx
+++ b/src/features/listings/ui/listingsContents/listingsContentsList.tsx
@@ -4,9 +4,8 @@ import { ListingContentsListProps } from "@/src/entities/listings/model/type";
 import { ListingNoSearchResult } from "../listingsNoSearchResult/listingNoSearchResult";
 import { Button } from "@/src/shared/lib/headlessUi";
 import { ListingContentsCard } from "./listingsContentCard";
-import { AnimatePresence, motion } from "framer-motion";
-import { usePathname, useSearchParams } from "next/navigation";
 import { Spinner } from "@/src/shared/ui/spinner/default";
+import { DataEnterTransition } from "@/src/shared/ui/animation/pageUpTransition";
 
 export const ListingContentsList = ({
   data,
@@ -18,11 +17,9 @@ export const ListingContentsList = ({
 }: ListingContentsListProps) => {
   const items = data?.pages.flatMap(page => page.content) ?? [];
   const observerRef = useRef<HTMLDivElement | null>(null);
-  const searchParams = useSearchParams();
-  const keyword = searchParams.get("query") ?? "";
-  const pathname = usePathname();
   const scrollRef = useRef<HTMLDivElement>(null);
   const [isBottoms, setIsBottoms] = useState(false);
+  const ready = !!items;
 
   const handleScroll = () => {
     const el = scrollRef.current;
@@ -62,22 +59,14 @@ export const ListingContentsList = ({
 
   return (
     <div
-      className={`flex h-full w-full flex-col overflow-y-auto ${isBottom ? `pb-[88px]` : "pb-0"} scrollbar-hide`}
+      // className={`flex h-full w-full flex-col overflow-y-auto ${isBottom ? `pb-[88px]` : "pb-0"} scrollbar-hide`}
+      className={`flex h-full w-full flex-col overflow-y-auto scrollbar-hide`}
       ref={scrollRef}
       onScroll={handleScroll}
     >
-      <AnimatePresence mode="wait">
-        <motion.div
-          key={pathname + keyword}
-          initial={{ x: 100, opacity: 0 }}
-          animate={{ x: 0, opacity: 1 }}
-          exit={{ x: -100, opacity: 0 }}
-          transition={{ duration: 0.2, ease: "easeInOut" }}
-          className="relative w-full"
-        >
-          <ListingContentsCard data={items} />
-        </motion.div>
-      </AnimatePresence>
+      <DataEnterTransition ready={ready}>
+        <ListingContentsCard data={items} />
+      </DataEnterTransition>
 
       {!isError && hasNextPage && <div ref={observerRef} className="h-10" />}
 

--- a/src/shared/ui/animation/pageUpTransition.tsx
+++ b/src/shared/ui/animation/pageUpTransition.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { motion, AnimatePresence } from "framer-motion";
+import { ReactNode } from "react";
+
+export const DataEnterTransition = ({
+  ready,
+  children,
+}: {
+  ready: boolean;
+  children: ReactNode;
+}) => {
+  return (
+    <AnimatePresence>
+      {ready && (
+        <motion.div
+          key="data-enter"
+          initial={{ y: 24, opacity: 0 }}
+          animate={{ y: 0, opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{
+            duration: 0.45,
+            ease: [0.22, 1, 0.36, 1],
+            opacity: {
+              duration: 0.55,
+              ease: "easeOut",
+            },
+          }}
+        >
+          {children}
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};

--- a/src/shared/ui/globalRender/globalRender.tsx
+++ b/src/shared/ui/globalRender/globalRender.tsx
@@ -19,22 +19,22 @@ export const HomeLandingRender = ({ children, bottom }: Props) => {
       {/* 최대 폭 컨테이너 */}
       <div className="mx-auto flex h-full max-w-[1350px] px-20 sm:justify-center md:px-20 lg:justify-between lg:px-20">
         {/* LEFT TEXT */}
-        <section className="desktop:block z-10 hidden max-w-[600px] pt-10 text-white lg:block">
+        <section className="z-10 hidden max-w-[600px] pt-10 text-white lg:block desktop:block">
           <div className="mb-48 flex items-center gap-2">
             <SecondaryLogoRender />
           </div>
 
           <h1 className="mb-6 leading-tight">
-            <span className="desktop:text-[55px] font-light lg:text-[30px]">
+            <span className="font-light lg:text-[30px] desktop:text-[55px]">
               모두의 꿈인 내 집 마련!
             </span>
             <br />
-            <span className="desktop:text-[55px] font-extrabold text-white lg:text-[30px]">
+            <span className="font-extrabold text-white lg:text-[30px] desktop:text-[55px]">
               나에게 맞는 추천 집은?
             </span>
           </h1>
           <div className="mb-10 h-1 w-[73px] border-2 border-white bg-white" />
-          <p className="desktop:text-[20px] relative mb-14 text-2xl leading-relaxed text-greyscale-grey-50 lg:text-[20px]">
+          <p className="relative mb-14 text-2xl leading-relaxed text-greyscale-grey-50 lg:text-[20px] desktop:text-[20px]">
             <span className="absolute left-[600px]">
               <HomeRectangleRender2 width={60} height={60} />
             </span>

--- a/src/widgets/homeSection/homeSection.tsx
+++ b/src/widgets/homeSection/homeSection.tsx
@@ -12,9 +12,11 @@ import { PageTransition } from "@/src/shared/ui/animation";
 
 export const HomeSection = () => {
   return (
-    <section className="relative min-h-screen w-full overflow-y-auto bg-greyscale-grey-25 text-greyscale-grey-900 scrollbar-hide">
+    // <section className="relative min-h-screen w-full overflow-y-auto bg-greyscale-grey-25 text-greyscale-grey-900 scrollbar-hide"></section>
+    <section className="relative min-h-screen w-full bg-greyscale-grey-25 text-greyscale-grey-900 scrollbar-hide">
       <PageTransition>
-        <div className="flex flex-col pb-6">
+        {/* <div className="flex flex-col pb-6"> */}
+        <div className="flex flex-col">
           <div className="px-4">
             <HomeHeader />
             <HomeHero />
@@ -26,7 +28,7 @@ export const HomeSection = () => {
           <div className="border-b-8 border-greyscale-grey-50 p-4">
             <PersonalShortcutList />
           </div>
-          <div className="px-5 py-3">
+          <div className="px-5">
             <UrgentNoticeList />
           </div>
         </div>


### PR DESCRIPTION
<!--- Pull Request title = 커밋 메시지와 동일/ 해당 이슈를 close 하지 않을 경우, footer #이슈 번호 제외  -->

## #️⃣ Issue Number

- 핀하우스 home / 공고리스트 / 공고상세 css 정리
- #322 

<br/>
<br/>

## 📝 요약(Summary) (선택)

- #### 변경
- useListingDetailBasic: enabled 조건 강화(빈 id 방지) + placeholderData로 이전 데이터 유지
- UrgentNoticeList: 섹션 패딩 조건 제거, 헤더 상단 패딩 추가
- ListingsCardTileDetails: 시트 open 핸들러 분리, isFetching 체크 제거(데이터 존재 기준), 하단 라운드/섹션 보더 조정, 시트는 open일 때만 렌더
- ListingBgBookMark: 디버그 console.log 제거
- ListingContentsList: 리스트 컨테이너 padding 조건 제거(고정 레이아웃)
- PageTransition: 하단 그라데이션 레이어 비활성화
- HomeLandingRender: 클래스 순서 정리(스타일 동작은 동일)
- HomeSection: 내부 스크롤 제거, 하단 패딩/섹션 패딩 조정
- ListingsCardDetailSection: 로딩 시 스피너, 데이터 준비 후 DataEnterTransition로 진입 애니메이션, open 상태에 따라 일부 섹션 숨김
#### 추가
- DataEnterTransition
- Home 진입시 핀하우스 로고 fullBack에 추가

<br/>
<br/>

