### PR TITLE
feat:핀하우스home/글로벌서치/더보기항목작업

### DIFF
--- a/src/entities/home/api/__test__/home.test.ts
+++ b/src/entities/home/api/__test__/home.test.ts
@@ -210,7 +210,7 @@ describe("핀포인트 home 글로벌 서치 인기검색어", () => {
       data: Mock,
     });
 
-    const result = await getNoticeByPinPoint<IResponse<PopularResponse>>({
+    const result = await getNoticeByPinPoint<IResponse<GlobalSearchItem[]>>({
       url,
       params: param,
     });

--- a/src/entities/home/hooks/homeHooks.ts
+++ b/src/entities/home/hooks/homeHooks.ts
@@ -1,6 +1,7 @@
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { getNoticeByPinPoint } from "../interface/homeInterface";
 import {
+  GlobalSearchItem,
   NoticeContent,
   NoticeCount,
   PopularResponse,
@@ -64,7 +65,7 @@ export const useGlobal = <T>({ params, q }: { params: string; q: string }) => {
   });
 };
 
-export const useGlobalPageNation = <T>({
+export const useGlobalPageNation = <TItem>({
   q,
   category,
   enabled,
@@ -76,13 +77,13 @@ export const useGlobalPageNation = <T>({
   const url = `${HOME_SEARCH_POPULAR_ENDPOINT}/category`;
   const apiCategory: ApiCategory | null = category ? CATEGORY_MAP[category] : null;
 
-  return useInfiniteQuery({
-    queryKey: ["globalInfinity", enabled],
-    enabled: enabled && Boolean(category),
-    initialPageParam: 2,
+  return useInfiniteQuery<SliceResponse<TItem>, Error>({
+    queryKey: ["globalInfinity", apiCategory],
+    enabled: Boolean(category),
+    initialPageParam: 1,
     queryFn: ({ pageParam }) =>
-      getNoticeByPinPoint<SliceResponse<NoticeContent>>({
-        url: url,
+      getNoticeByPinPoint<SliceResponse<TItem>>({
+        url,
         params: {
           type: apiCategory,
           q,

--- a/src/entities/home/model/type.ts
+++ b/src/entities/home/model/type.ts
@@ -15,6 +15,7 @@ export interface SliceResponse<T> {
   pages: number;
   totalCount: number;
   totalElements: number;
+  category?: string;
 }
 
 export interface NoticeByPinPointParams {
@@ -77,4 +78,8 @@ export interface GlobalSearchSection {
   category: SearchCategory;
   content: GlobalSearchItem[];
   hasNext: boolean;
+}
+
+export interface GlobalSearchCategoryItem {
+  content: GlobalSearchItem[];
 }

--- a/src/features/home/hooks/hooks.tsx
+++ b/src/features/home/hooks/hooks.tsx
@@ -53,9 +53,9 @@ export const useHomeGlobalSearch = (globalData?: GlobalListType): GlobalSearchSe
 export const CATEGORY_MAP = {
   notices: "NOTICE",
   complexes: "COMPLEX",
-  targetGroups: "TARGETGROUP",
+  targetGroups: "TARGET_GROUP",
   regions: "REGION",
-  houseTypes: "HOUSETYPE",
+  houseTypes: "HOUSE_TYPE",
 } as const;
 
 export type SearchCategoryMap = keyof typeof CATEGORY_MAP;

--- a/src/features/home/ui/result/__mocks__/homeResultMocks.ts
+++ b/src/features/home/ui/result/__mocks__/homeResultMocks.ts
@@ -1,0 +1,23 @@
+import { GlobalSearchItem } from "@/src/entities/home/model/type";
+
+const makeItem = (index: number): GlobalSearchItem => ({
+  id: `mock-${index + 1}`,
+  title: `테스트 공고 ${index + 1}`,
+  agency: "LH",
+  housingType: "아파트",
+  supplyType: "공공임대",
+  announceDate: "2026-01-20",
+  applyStart: "2026-01-21",
+  applyEnd: "2026-02-01",
+  targetGroups: ["청년", "신혼부부"],
+  liked: false,
+});
+
+export const makeHomeResultItems = (count: number) =>
+  Array.from({ length: count }, (_, index) => makeItem(index));
+
+// Example datasets for "더보기" 테스트
+export const homeResultItemsLessThanFive = makeHomeResultItems(4);
+export const homeResultItemsExactlyFive = makeHomeResultItems(5);
+export const homeResultItemsMoreThanFive = makeHomeResultItems(9);
+export const homeResultItemsMoreThanTen = makeHomeResultItems(12);

--- a/src/features/home/ui/result/homeResultSectionMore.tsx
+++ b/src/features/home/ui/result/homeResultSectionMore.tsx
@@ -1,32 +1,38 @@
 import { DownButton } from "@/src/assets/icons/button";
+import { SearchCategory } from "@/src/entities/home/model/type";
 
 interface HomeResultSectionMoreProps {
-  total: number;
-  limit: number;
   expanded: boolean;
-  onToggle: (category: string) => void;
-  category: string;
+  onToggle: (category: SearchCategory) => void;
+  category: SearchCategory;
+  hasNextPage?: boolean; // undefined 가능
 }
 
 export const HomeResultSectionMore = ({
-  total,
-  limit,
   category,
   expanded,
   onToggle,
+  hasNextPage,
 }: HomeResultSectionMoreProps) => {
-  // 필요하면 다시 활성화
-  // if (total <= limit) return null;
+  // // 아직 펼쳐지지 않았다면 버튼 자체를 숨김
+  // if (!expanded) return null;
 
   return (
     <button
+      type="button"
       onClick={() => onToggle(category)}
       className="flex w-full items-center justify-center gap-1 rounded-b-xl bg-white p-3 text-xs text-gray-400"
     >
-      <p>{expanded ? "접기" : "더보기"}</p>
-      <span className={`transition-transform ${expanded ? "rotate-180" : ""}`}>
-        <DownButton width={15} height={15} />
-      </span>
+      {hasNextPage ? (
+        <>
+          <p>{"더보기"}</p>
+          <span className="rotate-180 transition-transform">
+            <DownButton width={15} height={15} />
+          </span>
+        </>
+      ) : (
+        <p>{"데이터가 없습니다."}</p>
+      )}
     </button>
   );
 };

--- a/src/widgets/homeSection/homeResultSection/homeResultSection.tsx
+++ b/src/widgets/homeSection/homeResultSection/homeResultSection.tsx
@@ -46,12 +46,7 @@ export const HomeResultSection = ({ q }: { q: string }) => {
     >
       {data.map(section => (
         <motion.div key={section.category} variants={itemVariants}>
-          <HomeResultSectionBlock
-            category={section.category}
-            items={section.content}
-            limit={5}
-            q={q}
-          />
+          <HomeResultSectionBlock category={section.category} items={section.content} q={q} />
         </motion.div>
       ))}
     </motion.section>


### PR DESCRIPTION
<!--- Pull Request title = 커밋 메시지와 동일/ 해당 이슈를 close 하지 않을 경우, footer #이슈 번호 제외  -->

## #️⃣ Issue Number

#330 

<br/>
<br/>

## 📝 요약(Summary) (선택)

- 유저가 해당 항목의 더보기 클릭시 추가로 데이터를 조회하여 기존의 항목 데이터와 적산하여 제공

#### 추가
- homeResultMocks.ts : 홈 결과 섹션 테스트용 mock 데이터 생성 유틸/샘플 배열 추가
#### 변경
- home.test.ts : getNoticeByPinPoint 응답 타입을 GlobalSearchItem[]로 변경
- homeHooks.ts : useGlobalPageNation 제네릭/쿼리키/초기 페이지 파라미터 조정, SliceResponse<TItem>로 통일
- type.ts : SliceResponse에 category? 추가, GlobalSearchCategoryItem 타입 추가
- hooks.tsx : CATEGORY_MAP 값 수정(TARGET_GROUP, HOUSE_TYPE)
- homeResultSectionMore.tsx : props 구조 변경, hasNextPage 기준으로 “더보기/데이터 없음” 표시
- homeResultSectionBlock.tsx : 더보기 동작 로직 변경, useGlobalPageNation 데이터 기반 렌더/더보기 처리
- homeResultSection.tsx : HomeResultSectionBlock props 변경 반영

<br/>
<br/>
