### PR TITLE
공통 헤더 만들기 ( 리펙토링 같이 진행 )

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 !.yarn/releases
 !.yarn/versions
 
+
 # testing
 /coverage
 
@@ -29,7 +30,6 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
-
 # env files (can opt-in for committing if needed)
 .env*
 
@@ -43,3 +43,4 @@ next-env.d.ts
 
 *storybook.log
 storybook-static
+.idea

--- a/app/home/search/layout.tsx
+++ b/app/home/search/layout.tsx
@@ -1,9 +1,9 @@
-import { HomeSerachSection } from "@/src/widgets/homeSection";
+import { HomeSearchSection } from "@/src/widgets/homeSection";
 
 export default function SearchLayout({ children }: { children: React.ReactNode }) {
   return (
     <div>
-      <HomeSerachSection />
+      <HomeSearchSection />
       {children}
     </div>
   );

--- a/app/home/search/page.tsx
+++ b/app/home/search/page.tsx
@@ -1,4 +1,4 @@
-import { HomeSearchTag, HomeSerachSection } from "@/src/widgets/homeSection";
+import { HomeSearchTag } from "@/src/widgets/homeSection";
 
 export default function SearchHomePage() {
   return <HomeSearchTag />;

--- a/src/features/listings/ui/listingsHeaders/listingsSearchForm.tsx
+++ b/src/features/listings/ui/listingsHeaders/listingsSearchForm.tsx
@@ -4,25 +4,12 @@
 import { useRouter } from "next/navigation";
 import { LeftButton } from "@/src/assets/icons/button";
 import { useRouteStore } from "@/src/features/home/model/homeStore";
+import { DefaultHeader } from "@/src/shared/ui/header";
 
 export const SearchForm = () => {
-  const router = useRouter();
-  const { prevPath, reset } = useRouteStore();
-  const handleRouter = () => {
-    const nextPath = prevPath ?? "/listings";
-    reset();
-    router.push(nextPath);
-  };
-
   return (
     <div className="items-cente relative flex p-5">
-      <LeftButton
-        onClick={handleRouter}
-        className="h-6 w-6 cursor-pointer text-greyscale-grey-200"
-      />
-      <p className="font-suit absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 font-bold">
-        검색
-      </p>
+      <DefaultHeader title={"검색"} path={"/listings"} />
     </div>
   );
 };

--- a/src/shared/ui/header/header/defaultHeader/defaultHeader.tsx
+++ b/src/shared/ui/header/header/defaultHeader/defaultHeader.tsx
@@ -1,0 +1,31 @@
+"use client";
+import { useRouter } from "next/navigation";
+import { LeftButton } from "@/src/assets/icons/button";
+import { useRouteStore } from "@/src/features/home/model/homeStore";
+import { useDefaultHeader } from "@/src/shared/ui/header/header/defaultHeader/useDefaultHeader";
+
+type DefaultHeaderProps = {
+  title: string;
+  path: string;
+};
+
+export const DefaultHeader = ({ title, path }: DefaultHeaderProps) => {
+  const { prevPath, reset } = useRouteStore();
+  const { handleRouter } = useDefaultHeader({
+    path,
+    prevPath,
+    reset,
+  });
+
+  return (
+    <>
+      <LeftButton
+        onClick={handleRouter}
+        className="h-7 w-7 cursor-pointer text-greyscale-grey-200"
+      />
+      <p className="font-suit absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 font-bold">
+        {title}
+      </p>
+    </>
+  );
+};

--- a/src/shared/ui/header/header/defaultHeader/useDefaultHeader.ts
+++ b/src/shared/ui/header/header/defaultHeader/useDefaultHeader.ts
@@ -1,0 +1,18 @@
+import { useRouter } from "next/navigation";
+
+type DefaultHeaderProps = {
+  path: string;
+  prevPath: string | null;
+  reset: () => void;
+};
+
+export const useDefaultHeader = ({ path, prevPath, reset }: DefaultHeaderProps) => {
+  const router = useRouter();
+
+  const handleRouter = () => {
+    const nextPath = prevPath ?? path;
+    reset();
+    router.push(nextPath);
+  };
+  return { handleRouter };
+};

--- a/src/shared/ui/header/header/searchHeader/searchHeader.tsx
+++ b/src/shared/ui/header/header/searchHeader/searchHeader.tsx
@@ -1,0 +1,55 @@
+"use client";
+import { SearchBarLabel } from "@/src/shared/ui/searchBarLabel";
+import { LeftButton } from "@/src/assets/icons/button";
+import { useSearchHeader } from "@/src/shared/ui/header/header/searchHeader/useSearchHeader";
+
+/**
+ * @resultPath resultPath 검색 결과 페이지의 기본 경로 (검색 시 쿼리스트링이 붙습니다)
+ * @clearPath 검색어를 지웠을 때 이동할 경로.
+ * @queryKey 읽고/쓸 쿼리스트링 키 (예: "keyword").
+ * @mainUrl 메인/기준 페이지로 이동할 URL.
+ */
+type SearchConfig = {
+  resultPath: string;
+  clearPath: string;
+  queryKey: string;
+  mainUrl: string;
+};
+
+/**
+ * @placeHolder  검색 입력창에 표시할 플레이스홀더 텍스트
+ * @searchQuery  검색 제출 시 부가 처리 (스토어 업데이트를 위한 콜백)
+ */
+type SearchHeaderProps = {
+  searchConfig: SearchConfig;
+  placeHolder: string;
+  searchQuery: (q: string) => void;
+};
+
+export const SearchHeader = ({ placeHolder, searchQuery, searchConfig }: SearchHeaderProps) => {
+  const { resultPath, clearPath, queryKey, mainUrl } = searchConfig;
+  const { keyword, search, clear, goMain } = useSearchHeader({
+    resultPath,
+    clearPath,
+    queryKey,
+    mainUrl,
+    onSearch: searchQuery,
+  });
+
+  return (
+    <>
+      <LeftButton onClick={goMain} className="h-8 w-8 cursor-pointer text-greyscale-grey-400" />
+
+      <SearchBarLabel
+        direction="vertical"
+        placeholder={placeHolder}
+        className="rounded-3xl"
+        variant="capsule"
+        value={keyword}
+        onEnter={search}
+        onClear={clear}
+        xBtnDef="default"
+      />
+    </>
+  );
+};

--- a/src/shared/ui/header/header/searchHeader/useSearchHeader.ts
+++ b/src/shared/ui/header/header/searchHeader/useSearchHeader.ts
@@ -1,0 +1,47 @@
+// shared/hooks/useSearchHeader.ts
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+
+type UseSearchHeaderProps = {
+  resultPath: string;
+  clearPath: string;
+  queryKey: string;
+  mainUrl: string;
+  onSearch: (keyword: string) => void;
+};
+
+export const useSearchHeader = ({
+  resultPath,
+  clearPath,
+  queryKey,
+  mainUrl,
+  onSearch,
+}: UseSearchHeaderProps) => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const keyword = searchParams.get(queryKey) ?? "";
+
+  const search = (value: string) => {
+    if (!value) return;
+
+    onSearch(value);
+    router.push(`${resultPath}?${queryKey}=${encodeURIComponent(value)}`);
+  };
+
+  const clear = () => {
+    router.push(clearPath);
+  };
+
+  const goMain = () => {
+    router.push(mainUrl);
+  };
+
+  return {
+    keyword,
+    search,
+    clear,
+    goMain,
+  };
+};

--- a/src/shared/ui/header/index.ts
+++ b/src/shared/ui/header/index.ts
@@ -1,0 +1,1 @@
+export * from "@/src/shared/ui/header/header/defaultHeader/defaultHeader";

--- a/src/widgets/homeSection/homeSearchSection/homeSearchSection.tsx
+++ b/src/widgets/homeSection/homeSearchSection/homeSearchSection.tsx
@@ -2,21 +2,25 @@
 import { LeftButton } from "@/src/assets/icons/button";
 import { SearchBar } from "@/src/features/home";
 import { useRouter } from "next/navigation";
+import { SearchHeader } from "@/src/shared/ui/header/header/searchHeader/searchHeader";
+import { useSearchState } from "@/src/shared/hooks/store";
 
-export const HomeSerachSection = () => {
-  const router = useRouter();
-
-  const handleRouter = () => {
-    router.push("/home");
-  };
+export const HomeSearchSection = () => {
+  const { setSearchQuery } = useSearchState();
 
   return (
     <div className="items-cente flex items-center gap-2 rounded-none border-b px-5 pb-2 pt-5">
-      <LeftButton
-        onClick={handleRouter}
-        className="h-8 w-8 cursor-pointer text-greyscale-grey-400"
+      <SearchHeader
+        placeHolder="공고·지역·단지를 검색해보세요"
+        searchQuery={setSearchQuery}
+        searchConfig={{
+          resultPath: "/home/search/result",
+          clearPath: "/home/search",
+          queryKey: "q",
+          mainUrl: "/home",
+        }}
       />
-      <SearchBar />
     </div>
   );
 };
+1;


### PR DESCRIPTION
## #️⃣ Issue Number

#334 

<br/>
<br/>

## 📝 요약(Summary) (선택)

- Style : 공통 헤더 만들기
- Refactor : 공통에서 사용되는 함수들은 customHooks 작성후 교체

## 상세 내용
추가
• useDefaultHeader.ts: 뒤로가기/이동 로직을 분리한 훅 추가
• useSearchHeader.ts: 검색 키워드/라우팅/초기화/메인 이동 로직을 분리한 훅 추가
• index.ts: DefaultHeader export 추가

변경
• layout.tsx: HomeSerachSection 오타 수정 → HomeSearchSection
• page.tsx: HomeSerachSection import 제거, HomeSearchTag만 사용
• listingsSearchForm.tsx: 기존 뒤로가기/타이틀 로직 제거, DefaultHeader로 대체
• defaultHeader.tsx: 컴포넌트명 DeafultHeader → DefaultHeader, 라우팅 로직 훅으로 분리
• searchHeader.tsx: 검색/라우팅 로직 훅으로 분리, LeftButton 추가, props 구조 searchConfig로 변경
• homeSearchSection.tsx: 컴포넌트명 수정, LeftButton+SearchBar → SearchHeader로 교체, 마지막에 1; 라인 추가

<br/>
<br/>
