### PR TITLE
style: 핀하우스 공고리스트 / 공고상세 / 방타입 style 변경

### DIFF
--- a/src/features/listings/ui/listingsCardDetail/infra/components/roomTypeDetail.tsx
+++ b/src/features/listings/ui/listingsCardDetail/infra/components/roomTypeDetail.tsx
@@ -78,8 +78,8 @@ export const RoomTypeDetail = ({ listingId }: { listingId: string }) => {
             {current?.thumbnail ? (
               <img src={current.thumbnail} className="h-full w-full object-cover" />
             ) : (
-              <div className="absolute inset-0 flex flex-col items-center justify-center gap-2">
-                <CompareDefaultImage className="object-contain opacity-60" />
+              <div className="absolute inset-0 flex flex-col items-center justify-center">
+                <CompareDefaultImage className="object-contain opacity-60 h-30" />
                 <p className="text-xs text-greyscale-grey-400">도면 이미지를 준비하고 있어요</p>
               </div>
             )}


### PR DESCRIPTION
## #️⃣ Issue Number

#371 

<br/>
<br/>

## 📝 요약(Summary) (선택)

#### roomTypeDetail.tsx
• 기본 이미지 영역: gap-2 제거, 이미지에 h-30 클래스 추가
• CompareDefaultImage 클래스가 object-contain opacity-60 → object-contain opacity-60 h-30로 변경

<br/>
<br/>
