### PR TITLE
[feat] - 청약 진단 결과를 기반으로 추천 공고를 조회 API 작성

### DIFF
--- a/src/features/home/ui/homeActionCardList.tsx
+++ b/src/features/home/ui/homeActionCardList.tsx
@@ -1,20 +1,16 @@
 "use client";
 import { ArrowUpRight } from "@/src/assets/icons/button/arrowUpRight";
-import { useNoticeCount } from "@/src/entities/home/hooks/homeHooks";
+import { useNoticeCount, useRecommendedNotice } from "@/src/entities/home/hooks/homeHooks";
 import { useRouter } from "next/navigation";
+import { useHomeActionCard } from "@/src/features/home/ui/homeUseHooks/homeUseHooks";
 
 export const ActionCardList = () => {
   const { data } = useNoticeCount();
-  const conut = data?.count;
-  const router = useRouter();
+  const { data: recommend } = useRecommendedNotice();
 
-  const onListingsPageMove = () => {
-    router.push("/listings");
-  };
+  const count = data?.count;
+  const { onListingsPageMove, onEligibilityPageMove } = useHomeActionCard();
 
-  const onEligibilityPageMove = () => {
-    router.push("/eligibility");
-  };
   return (
     <div className="mb-4 flex gap-4">
       <div
@@ -30,7 +26,7 @@ export const ActionCardList = () => {
           </div>
         </div>
 
-        <p className="text-xl font-bold leading-tight text-white">{conut}건</p>
+        <p className="text-xl font-bold leading-tight text-white">{count}건</p>
       </div>
 
       <div
@@ -49,7 +45,9 @@ export const ActionCardList = () => {
         </div>
 
         <div className="flex gap-2 text-xl leading-tight">
-          <p className="font-bold text-white">0건</p>
+          <p className="font-bold text-white">
+            {recommend?.pages?.length ? recommend?.pages?.length : "0"}건
+          </p>
           <span
             className="flex items-center rounded-xl bg-greyscale-grey-25 p-1 text-xs font-bold"
             style={{ color: "#FFBA18" }}

--- a/src/features/home/ui/homeUseHooks/homeUseHooks.ts
+++ b/src/features/home/ui/homeUseHooks/homeUseHooks.ts
@@ -20,6 +20,23 @@ export const useHomeUseHooks = () => {
   return {
     line1,
     line2,
-    onSelectSection
-  }
-}
+    onSelectSection,
+  };
+};
+
+export const useHomeActionCard = () => {
+  const router = useRouter();
+
+  const onListingsPageMove = () => {
+    router.push("/listings");
+  };
+
+  const onEligibilityPageMove = () => {
+    router.push("/eligibility");
+  };
+
+  return {
+    onListingsPageMove,
+    onEligibilityPageMove,
+  };
+};

--- a/src/shared/api/endpoints.ts
+++ b/src/shared/api/endpoints.ts
@@ -13,6 +13,7 @@ export const HTTP_METHODS = {
  */
 export const HOME_NOTICE_ENDPOINT = "/home/notice";
 export const HOME_SEARCH_POPULAR_ENDPOINT = "/home/search";
+export const HOME_RECOMMENDED_ENDPOINT = "/home/recommended-notices";
 
 /**
  * 공고 API 엔드포인트


### PR DESCRIPTION
## #️⃣ Issue Number

#380 

<br/>
<br/>

## 📝 요약(Summary) (선택)
• 공통 http 레이어에서 success:false일 때 AxiosResponse가 throw되는 케이스가 생겨서 isAxiosError만으로는 못 잡는 경우가 있음.
• 그래서 훅에서만 처리하려면, catch에서 AxiosError와 일반 Response 둘 다 메시지를 뽑는 분기가 필요함.
• “토스트 띄우되 에러 상태 유지”는 toast.error(message) 

<br/>
<br/>

## 📸스크린샷 (선택)2

<img width="398" height="66" alt="image" src="https://github.com/user-attachments/assets/c04ed8d1-069a-42ae-98d5-6180852e25e0" />
<br/>
<br/>
