### PR TITLE
feat:바텀 시트 포지션 정리 / 해당 컴포넌트 공통 훅으로 분리

### DIFF
--- a/src/features/home/model/homeStore.ts
+++ b/src/features/home/model/homeStore.ts
@@ -35,7 +35,7 @@ type HomeMaxSheet = {
 };
 
 export const useHomeMaxTime = create<HomeMaxSheet>(set => ({
-  maxTime: 30,
+  maxTime: 60,
   setMaxTime: time => set({ maxTime: time }),
   reset: () => set({ maxTime: 30 }),
 }));

--- a/src/features/home/ui/components/maxTime.tsx
+++ b/src/features/home/ui/components/maxTime.tsx
@@ -22,6 +22,7 @@ export const MaxTimeSliderBox = () => {
           <Slider
             min={0}
             max={120}
+            step={10}
             labelSuffix="분"
             value={[maxTime]}
             onValueChange={onSliderValueChange}

--- a/src/features/listings/ui/listingsCardDetail/components/DetailSectionFilter/DetailFilterSheet.tsx
+++ b/src/features/listings/ui/listingsCardDetail/components/DetailSectionFilter/DetailFilterSheet.tsx
@@ -2,7 +2,9 @@
 
 import { AnimatePresence, motion } from "framer-motion";
 import { useSearchParams } from "next/navigation";
+import { useRef } from "react";
 import { useDetailFilterSheetStore } from "@/src/features/listings/model";
+import { useScrollLock } from "@/src/shared/hooks/useScrollLock";
 import { DetailFilterTab } from "./DetailFilterTab";
 import { parseDetailSection } from "@/src/features/listings/model";
 import { DistanceFilter } from "./DistanceFilter";
@@ -14,12 +16,16 @@ export const DetailFilterSheet = () => {
   const open = useDetailFilterSheetStore(s => s.open);
   const closeSheet = useDetailFilterSheetStore(s => s.closeSheet);
   const searchParams = useSearchParams();
+  const anchorRef = useRef<HTMLSpanElement>(null);
   const section = parseDetailSection(searchParams);
+  useScrollLock({ locked: open, anchorRef });
 
   return (
-    <AnimatePresence>
-      {open && (
-        <>
+    <>
+      <span ref={anchorRef} className="hidden" />
+      <AnimatePresence>
+        {open && (
+          <>
           <motion.div
             className="fixed inset-0 bg-black/40"
             onClick={closeSheet}
@@ -61,8 +67,9 @@ export const DetailFilterSheet = () => {
               </motion.div>
             </div>
           </motion.div>
-        </>
-      )}
-    </AnimatePresence>
+          </>
+        )}
+      </AnimatePresence>
+    </>
   );
 };

--- a/src/features/listings/ui/listingsCardDetail/infra/components/roomTypeDetail.tsx
+++ b/src/features/listings/ui/listingsCardDetail/infra/components/roomTypeDetail.tsx
@@ -1,15 +1,16 @@
-"use cilent";
-import { useState, useEffect } from "react";
+"use client";
+
+import { useEffect, useState } from "react";
+import { CompareDefaultImage } from "@/src/assets/images/compare/compare";
 import { useListingRoomTypeDetail } from "@/src/entities/listings/hooks/useListingDetailHooks";
-import { SmallSpinner } from "@/src/shared/ui/spinner/small/smallSpinner";
-import { formatNumber } from "@/src/shared/lib/numberFormat";
+import { ListingUnitType } from "@/src/entities/listings/model/type";
 import { toPyeong } from "@/src/features/listings/model";
+import { LikeType } from "@/src/features/listings/hooks/listingsHooks";
+import { formatNumber } from "@/src/shared/lib/numberFormat";
+import { TagButton } from "@/src/shared/ui/button/tagButton";
+import { SmallSpinner } from "@/src/shared/ui/spinner/small/smallSpinner";
 import { DepositSection } from "./components/roomType/depositSection";
 import { TypeInfoSection } from "./components/roomType/typeInfoSection";
-import { ListingUnitType } from "@/src/entities/listings/model/type";
-import { TagButton } from "@/src/shared/ui/button/tagButton";
-import { LikeType } from "@/src/features/listings/hooks/listingsHooks";
-import { CompareDefaultImage } from "@/src/assets/images/compare/compare";
 
 export const RoomTypeDetail = ({ listingId }: { listingId: string }) => {
   const { data, isFetching } = useListingRoomTypeDetail<ListingUnitType>({
@@ -17,11 +18,10 @@ export const RoomTypeDetail = ({ listingId }: { listingId: string }) => {
     queryK: "useListingRoomTypeDetail",
     url: "unit",
   });
+
   const [currentIndex, setCurrentIndex] = useState(0);
   const items = data ?? [];
   const current = items[currentIndex];
-  const typeId = current?.typeId;
-  const liked = current?.liked;
 
   const goPrev = () => {
     setCurrentIndex(p => (p - 1 + items.length) % Math.max(items.length, 1));
@@ -31,15 +31,16 @@ export const RoomTypeDetail = ({ listingId }: { listingId: string }) => {
     setCurrentIndex(p => (p + 1) % Math.max(items.length, 1));
   };
 
-  const isLast = currentIndex + 1 < items.length;
+  const hasNext = currentIndex + 1 < items.length;
 
   useEffect(() => {
     setCurrentIndex(0);
   }, [listingId]);
 
   if (isFetching && !items.length) {
-    return <SmallSpinner title="방 타입 불러오는 중.." />;
+    return <SmallSpinner title="방 타입 불러오는 중..." />;
   }
+
   if (!items.length) {
     return (
       <div className="p-6 text-center text-sm text-text-secondary">
@@ -49,7 +50,7 @@ export const RoomTypeDetail = ({ listingId }: { listingId: string }) => {
   }
 
   return (
-    <section className="flex h-full min-h-0 flex-col overflow-y-auto">
+    <section className="flex h-full flex-col">
       <div className="relative flex flex-col justify-center bg-greyscale-grey-25">
         <div className="flex justify-between pl-3 pr-3 pt-3">
           <span className="flex gap-1">
@@ -64,31 +65,34 @@ export const RoomTypeDetail = ({ listingId }: { listingId: string }) => {
               </TagButton>
             ))}
           </span>
+
           <span className="flex items-center justify-center">
             <LikeType
-              id={typeId}
-              liked={liked}
+              id={current?.typeId}
+              liked={current?.liked}
               type="ROOM"
               resetQuery={["useListingRoomTypeDetail"]}
             />
           </span>
         </div>
+
         <div className="relative flex h-60 w-full items-center justify-center">
           <div className="relative aspect-[4/1.5] w-full overflow-hidden">
             {current?.thumbnail ? (
               <img src={current.thumbnail} className="h-full w-full object-cover" />
             ) : (
               <div className="absolute inset-0 flex flex-col items-center justify-center">
-                <CompareDefaultImage className="object-contain opacity-60 h-30" />
-                <p className="text-xs text-greyscale-grey-400">도면 이미지를 준비하고 있어요</p>
+                <CompareDefaultImage className="h-30 object-contain opacity-60" />
+                <p className="text-xs text-greyscale-grey-400">이미지 준비 중입니다.</p>
               </div>
             )}
           </div>
+
           {items.length > 1 && (
             <TypeInfoSection
               onPrev={goPrev}
               onNext={goNext}
-              isLast={isLast}
+              isLast={hasNext}
               currentIndex={currentIndex}
             />
           )}

--- a/src/features/listings/ui/listingsCardDetail/infra/infraSheet.tsx
+++ b/src/features/listings/ui/listingsCardDetail/infra/infraSheet.tsx
@@ -1,5 +1,9 @@
 import { motion, AnimatePresence } from "framer-motion";
+import { useRef } from "react";
+import { createPortal } from "react-dom";
 import { CloseButton } from "@/src/assets/icons/button";
+import { usePortalTarget } from "@/src/shared/hooks/usePortalTarget";
+import { useScrollLock } from "@/src/shared/hooks/useScrollLock";
 import {
   InfraSheetProps,
   RenderContentProps,
@@ -31,17 +35,20 @@ const RenderContent = ({ section, listingId }: RenderContentProps) => {
 };
 
 export const InfraSheet = ({ onClose, sheetState }: InfraSheetProps) => {
+  const anchorRef = useRef<HTMLSpanElement>(null);
+  const portalRoot = usePortalTarget("mobile-overlay-root");
   const roomType: RoomTitleDesType | null = sheetState.open
     ? ROOM_TYPE_TITLE_DES[sheetState.section]
     : null;
+  useScrollLock({ locked: sheetState.open, anchorRef });
 
-  return (
+  const content = (
     <AnimatePresence mode="wait">
       {sheetState.open && (
         <>
           <motion.div
             key="overlay"
-            className="fixed inset-0 bg-black/40"
+            className="pointer-events-auto absolute inset-0 bg-black/40"
             onClick={e => {
               e.stopPropagation();
               onClose();
@@ -53,7 +60,7 @@ export const InfraSheet = ({ onClose, sheetState }: InfraSheetProps) => {
 
           <motion.div
             key="sheet"
-            className="fixed bottom-0 left-0 right-0 z-50 flex h-[80vh] flex-col rounded-t-2xl bg-white shadow-xl"
+            className="pointer-events-auto absolute bottom-0 left-0 right-0 z-50 flex h-[80vh] flex-col rounded-t-2xl bg-white shadow-xl"
             initial={{ y: "100%" }}
             animate={{ y: 0 }}
             exit={{ y: "100%" }}
@@ -74,7 +81,7 @@ export const InfraSheet = ({ onClose, sheetState }: InfraSheetProps) => {
                 </div>
               </header>
             </section>
-            <div className="flex-1 overflow-hidden">
+            <div className="min-h-0 flex-1 overflow-hidden">
               {sheetState.open && (
                 <RenderContent section={sheetState.section} listingId={sheetState.listingId} />
               )}
@@ -83,5 +90,12 @@ export const InfraSheet = ({ onClose, sheetState }: InfraSheetProps) => {
         </>
       )}
     </AnimatePresence>
+  );
+
+  return (
+    <>
+      <span ref={anchorRef} className="hidden" />
+      {portalRoot ? createPortal(content, portalRoot) : content}
+    </>
   );
 };

--- a/src/features/listings/ui/listingsFullSheet/listingsFullSheet.tsx
+++ b/src/features/listings/ui/listingsFullSheet/listingsFullSheet.tsx
@@ -238,7 +238,7 @@ const FilterSheetContainer = ({
   return (
     <>
       <motion.div
-        className="fixed inset-0 z-40 bg-black/40"
+        className="absolute inset-0 z-40 bg-black/40"
         onClick={onDismiss}
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
@@ -246,7 +246,7 @@ const FilterSheetContainer = ({
       />
 
       <motion.div
-        className="fixed bottom-0 left-0 right-0 z-50 flex h-[95vh] flex-col rounded-t-2xl bg-white shadow-xl"
+        className="absolute bottom-0 left-0 right-0 z-50 flex flex-col rounded-t-2xl bg-white shadow-xl"
         initial={{ y: "100%" }}
         animate={{ y: 0 }}
         exit={{ y: "100%" }}

--- a/src/shared/hooks/usePortalTarget/index.ts
+++ b/src/shared/hooks/usePortalTarget/index.ts
@@ -1,0 +1,1 @@
+export * from "./usePortalTarget";

--- a/src/shared/hooks/usePortalTarget/usePortalTarget.ts
+++ b/src/shared/hooks/usePortalTarget/usePortalTarget.ts
@@ -1,0 +1,13 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export const usePortalTarget = (targetId: string) => {
+  const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    setPortalTarget(document.getElementById(targetId));
+  }, [targetId]);
+
+  return portalTarget;
+};

--- a/src/shared/hooks/useScrollLock/index.ts
+++ b/src/shared/hooks/useScrollLock/index.ts
@@ -1,0 +1,1 @@
+export * from "./useScrollLock";

--- a/src/shared/hooks/useScrollLock/useScrollLock.ts
+++ b/src/shared/hooks/useScrollLock/useScrollLock.ts
@@ -1,0 +1,76 @@
+"use client";
+
+import { RefObject, useEffect } from "react";
+
+interface UseScrollLockOptions {
+  locked: boolean;
+  anchorRef?: RefObject<HTMLElement | null>;
+  lockDocument?: boolean;
+}
+
+const findScrollableAncestor = (element: HTMLElement | null) => {
+  let current = element?.parentElement ?? null;
+
+  while (current) {
+    const styles = window.getComputedStyle(current);
+    const overflowY = styles.overflowY;
+    const overflow = styles.overflow;
+
+    if (
+      overflowY === "auto" ||
+      overflowY === "scroll" ||
+      overflow === "auto" ||
+      overflow === "scroll"
+    ) {
+      return current;
+    }
+
+    current = current.parentElement;
+  }
+
+  return null;
+};
+
+export const useScrollLock = ({
+  locked,
+  anchorRef,
+  lockDocument = true,
+}: UseScrollLockOptions) => {
+  useEffect(() => {
+    if (!locked) {
+      return;
+    }
+
+    const anchor = anchorRef?.current ?? null;
+    const scrollContainer = findScrollableAncestor(anchor);
+    const html = document.documentElement;
+    const body = document.body;
+
+    const prevContainerOverflow = scrollContainer?.style.overflow ?? "";
+    const prevContainerOverflowY = scrollContainer?.style.overflowY ?? "";
+    const prevHtmlOverflow = html.style.overflow;
+    const prevBodyOverflow = body.style.overflow;
+
+    if (scrollContainer) {
+      scrollContainer.style.overflow = "hidden";
+      scrollContainer.style.overflowY = "hidden";
+    }
+
+    if (lockDocument) {
+      html.style.overflow = "hidden";
+      body.style.overflow = "hidden";
+    }
+
+    return () => {
+      if (scrollContainer) {
+        scrollContainer.style.overflow = prevContainerOverflow;
+        scrollContainer.style.overflowY = prevContainerOverflowY;
+      }
+
+      if (lockDocument) {
+        html.style.overflow = prevHtmlOverflow;
+        body.style.overflow = prevBodyOverflow;
+      }
+    };
+  }, [anchorRef, lockDocument, locked]);
+};

--- a/src/shared/ui/globalRender/globalRender.tsx
+++ b/src/shared/ui/globalRender/globalRender.tsx
@@ -71,6 +71,11 @@ export const HomeLandingRender = ({ children, bottom }: Props) => {
             </div>
 
             <div className={cn("shrink-0", !hasBottom && "hidden")}>{bottom}</div>
+
+            <div
+              id="mobile-overlay-root"
+              className="pointer-events-none absolute inset-0 z-0 overflow-hidden sm:rounded-xl md:rounded-2xl lg:rounded-2xl"
+            />
           </div>
 
           <div className="pointer-events-none absolute bottom-0 left-[75px] z-0 w-[520px] -translate-x-1/2">


### PR DESCRIPTION
## #️⃣ Issue Number

#387 

<br/>
<br/>

## 📝 요약(Summary) (선택)

#### homeFullSheet.tsx
HomeSheet를 absolute 시트 구조로 유지하면서, createPortal + usePortalTarget("mobile-overlay-root") 패턴으로 바꿨습니다.
useScrollLock({ locked: open, anchorRef })를 붙여 시트 열릴 때 배경 스크롤 잠금도 유지되게 정리했습니다.
#### infraSheet.tsx
InfraSheet도 HomeSheet와 동일하게 createPortal + usePortalTarget("mobile-overlay-root")로 렌더 위치를 분리했습니다.
absolute 포지션 유지, useScrollLock 적용, overlay/sheet에 pointer-events-auto를 명시했습니다.
#### useScrollLock.ts
공통 스크롤 잠금 훅 추가했습니다.
locked가 true일 때 스크롤 가능한 조상과 html/body overflow를 잠그고, 해제 시 이전 상태로 복구하도록 구현했습니다.
#### useScrollLock/index.ts
useScrollLock 배럴 export 추가했습니다.
#### usePortalTarget.ts
document.getElementById(targetId) 조회 로직을 공통 훅으로 분리했습니다.
const portalRoot = usePortalTarget("mobile-overlay-root") 형태로 재사용 가능하게 만들었습니다.
#### usePortalTarget/index.ts
usePortalTarget 배럴 export 추가했습니다.
#### roomTypeDetail.tsx
"use client" 오타 수정, 일부 깨진 태그/문구 정리, 레이아웃 안정화를 위해 min-h-0 포함 형태로 정리했습니다.
#### globalRender.tsx
모바일 프레임 내부에 mobile-overlay-root를 추가하려고 작업했는데, 중간에 인코딩/문자 깨짐 이력이 있어 이 파일은 내일 시작 전에 상태 점검이 필요합니다.


<br/>
<br/>
