### PR TITLE
feat 바텀 시트 포지션 정리 / 해당 컴포넌트 공통 훅으로 분리

### DIFF
--- a/src/features/home/ui/homeQuickStatsList.tsx
+++ b/src/features/home/ui/homeQuickStatsList.tsx
@@ -2,16 +2,13 @@
 import { CaretDown } from "@/src/assets/icons/button/caretDown";
 import { HomeFiveoclock } from "@/src/assets/icons/home/HomeFiveoclock";
 import { HomePushPin } from "@/src/assets/icons/home/homePushpin";
-import { useHomeMaxTime, useHomeSheetStore } from "../model/homeStore";
-import { useRouter, useSearchParams } from "next/navigation";
-import { useOAuthStore } from "../../login/model";
-import { splitAddress, transTime } from "@/src/shared/lib/utils";
+import { useHomeMaxTime } from "../model/homeStore";
+import { transTime } from "@/src/shared/lib/utils";
 import { useHomeUseHooks } from "@/src/features/home/ui/homeUseHooks/homeUseHooks";
 
 export const QuickStatsList = () => {
-
   const { maxTime } = useHomeMaxTime();
-  const {line2, line1 , onSelectSection} = useHomeUseHooks();
+  const { line2, line1, onSelectSection } = useHomeUseHooks();
 
   return (
     <div className="relative grid grid-cols-2 grid-rows-[auto,1fr] rounded-2xl bg-white p-4">

--- a/src/features/listings/ui/listingsContents/listingsContents.tsx
+++ b/src/features/listings/ui/listingsContents/listingsContents.tsx
@@ -2,7 +2,7 @@
 import { useListingListInfiniteQuery } from "@/src/entities/listings/hooks/useListingHooks";
 import { ListingsContentHeader } from "./listingsContentsHeader";
 import { ListingContentsList } from "./listingsContentsList";
-import { ListingNoSearchResult } from "../listingsNoSearchResult/listingNoSearchResult";
+import { ListingNoSearchResult } from "@/src/features/listings";
 import { Spinner } from "@/src/shared/ui/spinner/default";
 
 export const ListingsContent = ({ viewSet = true }: { viewSet?: boolean }) => {

--- a/src/features/listings/ui/listingsFullSheet/listingsFullSheet.tsx
+++ b/src/features/listings/ui/listingsFullSheet/listingsFullSheet.tsx
@@ -1,12 +1,14 @@
 "use client";
 import { motion, AnimatePresence } from "framer-motion";
-import { useListingsFilterStore } from "../../model/listingsStore";
+import { useFilterSheetStore, useListingsFilterStore } from "../../model/listingsStore";
 import { FILTER_TABS, FilterTabKey, TAB_CONFIG } from "../../model";
 import { CloseButton } from "@/src/assets/icons/button";
 import { useRouter, useSearchParams } from "next/navigation";
 import { getIndicatorLeft, getIndicatorWidth } from "../../hooks/listingsHooks";
 import { Checkbox } from "@/src/shared/lib/headlessUi/checkBox/checkbox";
 import { ListingFilterPartialSheetHooks } from "./hooks";
+import { ReactNode, useRef } from "react";
+import { useScrollLock } from "@/src/shared/hooks/useScrollLock";
 
 export const ListingFilterPartialSheet = () => {
   const { open, scrollRef, isAtBottom, displayTotal, handleScroll, handleCloseSheet } =
@@ -125,7 +127,6 @@ const UseCheckBox = () => {
   const searchParams = useSearchParams();
   const currentTab = (searchParams.get("tab") as FilterTabKey) || "region";
   const tabConfig = currentTab ? TAB_CONFIG[currentTab] : null;
-
   const regionType = useListingsFilterStore(s => s.regionType);
   const rentalTypes = useListingsFilterStore(s => s.rentalTypes);
   const supplyTypes = useListingsFilterStore(s => s.supplyTypes);
@@ -154,12 +155,9 @@ const UseCheckBox = () => {
     rental: supplyTypes,
     housing: houseTypes,
   }[currentTab];
-
   const isAllSelected = selectedList.length === totalItems.length;
-
   const handleAllSelect = (e: boolean) => {
     const checked = e;
-
     // 기존 방식 유지: 기존 값 초기화
     if (currentTab === "region") resetRegionType();
     if (currentTab === "target") resetRentalTypes();
@@ -233,20 +231,24 @@ const FilterSheetContainer = ({
   children,
 }: {
   onDismiss: () => void;
-  children: React.ReactNode;
+  children: ReactNode;
 }) => {
+  const open = useFilterSheetStore(s => s.open);
+  const anchorRef = useRef<HTMLSpanElement>(null);
+  useScrollLock({ locked: open, anchorRef });
+
   return (
     <>
+      <span ref={anchorRef} className="hidden" />
       <motion.div
-        className="absolute inset-0 z-40 bg-black/40"
+        className="fixed inset-y-0 left-0 right-0 z-40 mx-auto w-full max-w-[375px] bg-black/40"
         onClick={onDismiss}
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
       />
-
       <motion.div
-        className="absolute bottom-0 left-0 right-0 z-50 flex flex-col rounded-t-2xl bg-white shadow-xl"
+        className="fixed bottom-0 left-0 right-0 z-50 mx-auto flex h-[85vh] w-full max-w-[375px] flex-col rounded-t-2xl bg-white shadow-xl"
         initial={{ y: "100%" }}
         animate={{ y: 0 }}
         exit={{ y: "100%" }}

--- a/src/shared/ui/bottomNavigation/frameBottomNavigation.tsx
+++ b/src/shared/ui/bottomNavigation/frameBottomNavigation.tsx
@@ -37,16 +37,7 @@ export const FrameBottomNav = () => {
     detailPageRegex.test(pathname) ||
     compareDetailPageRegex.test(pathname) ||
     (pathname === "/listings" && hasListingsTab);
-  // const searchParams = useSearchParams();
-  // const tab = searchParams.get("tab");
-  // const shouldHide =
-  //   hiddenRoutes.some(route => pathname.startsWith(route)) ||
-  //   hiddenExactRoutes.includes(pathname) ||
-  //   pathname.startsWith("/home/search") ||
-  //   (pathname === "/listings" && tab !== null) ||
-  //   detailPageRegex.test(pathname) ||
-  //   compareDetailPageRegex.test(pathname) ||
-  //   (pathname === "/home" && searchParams.has("mode"));
+
   if (shouldHide) return null;
 
   return (


### PR DESCRIPTION
## #️⃣ Issue Number

#389 

<br/>
<br/>

## 📝 요약(Summary) (선택)

#### FilterSheetContainer 내부
◦ open 상태 구독 추가:
▪ const open = useFilterSheetStore(s => s.open);
◦ 스크롤락 추가:
▪ const anchorRef = useRef<HTMLSpanElement>(null);
▪ useScrollLock({ locked: open, anchorRef });
◦ 앵커 추가
▪ <span ref={anchorRef} className="hidden" />
◦ 오버레이 클래스 변경:
▪ fixed inset-y-0 left-0 right-0 z-40 mx-auto w-full max-w-[375px] bg-black/40
◦ 바텀시트 클래스 변경:
▪ fixed bottom-0 left-0 right-0 z-50 mx-auto flex h-[85vh] w-full max-w-[375px] flex-col rounded-t-2xl bg-white shadow-xl

<br/>
<br/>

## 📸스크린샷 (선택)2

<img width="381" height="1214" alt="스크린샷 2026-02-13 091554" src="https://github.com/user-attachments/assets/9f18069b-0f98-47e0-85b9-197d2ddac7cf" />
<br/>
<br/>

