### PR TITLE
fix:바텀 시트 포지션 정리 / 글로벌 렌더링에 종속 되지 않고  시트가 뷰포트 기준으로 포지션이 잡힘

### DIFF
--- a/src/features/listings/ui/listingsFullSheet/listingsFullSheet.tsx
+++ b/src/features/listings/ui/listingsFullSheet/listingsFullSheet.tsx
@@ -7,8 +7,10 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { getIndicatorLeft, getIndicatorWidth } from "../../hooks/listingsHooks";
 import { Checkbox } from "@/src/shared/lib/headlessUi/checkBox/checkbox";
 import { ListingFilterPartialSheetHooks } from "./hooks";
-import { ReactNode, useRef } from "react";
+import { ReactNode, RefObject, useRef } from "react";
+import { createPortal } from "react-dom";
 import { useScrollLock } from "@/src/shared/hooks/useScrollLock";
+import { usePortalTarget } from "@/src/shared/hooks/usePortalTarget";
 
 export const ListingFilterPartialSheet = () => {
   const { open, scrollRef, isAtBottom, displayTotal, handleScroll, handleCloseSheet } =
@@ -235,20 +237,20 @@ const FilterSheetContainer = ({
 }) => {
   const open = useFilterSheetStore(s => s.open);
   const anchorRef = useRef<HTMLSpanElement>(null);
+  const portalRoot = usePortalTarget("mobile-overlay-root");
   useScrollLock({ locked: open, anchorRef });
 
-  return (
+  const content = (
     <>
-      <span ref={anchorRef} className="hidden" />
       <motion.div
-        className="fixed inset-y-0 left-0 right-0 z-40 mx-auto w-full max-w-[375px] bg-black/40"
+        className="pointer-events-auto absolute inset-0 z-40 bg-black/40"
         onClick={onDismiss}
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
       />
       <motion.div
-        className="fixed bottom-0 left-0 right-0 z-50 mx-auto flex h-[85vh] w-full max-w-[375px] flex-col rounded-t-2xl bg-white shadow-xl"
+        className="pointer-events-auto absolute bottom-0 left-0 right-0 z-50 flex h-[85vh] flex-col rounded-t-2xl bg-white shadow-xl"
         initial={{ y: "100%" }}
         animate={{ y: 0 }}
         exit={{ y: "100%" }}
@@ -256,6 +258,13 @@ const FilterSheetContainer = ({
       >
         {children}
       </motion.div>
+    </>
+  );
+
+  return (
+    <>
+      <span ref={anchorRef} className="hidden" />
+      {portalRoot ? createPortal(content, portalRoot) : content}
     </>
   );
 };
@@ -283,8 +292,8 @@ const FilterSheetContent = ({
   onScroll,
   isAtBottom,
 }: {
-  children: React.ReactNode;
-  scrollRef: React.RefObject<HTMLDivElement | null>;
+  children: ReactNode;
+  scrollRef: RefObject<HTMLDivElement | null>;
   onScroll: () => void;
   isAtBottom: boolean;
 }) => {


### PR DESCRIPTION
## #️⃣ Issue Number

#391 

<br/>
<br/>

## 📝 어떤 상황에서 발생한 버그인가요?

- Given: 사용자가 공고리스트 접근
- When: 필터 버튼 클릭시 시트 제공
- Then: 시트 제공시 포지션 기준이 뷰포트 기준으로 잡힘


## ✅ 버그 수정 결과

- 시트가 글로벌 렌더(375 프레임) 내부에서 시작해서 올라옴
- 더 이상 화면 바깥(뷰포트 전체) 기준으로 시작하지 않음

<br/>
<br/>
