### PR TITLE
fix:바텀 시트 포지션 정리 / 글로벌 렌더링에 종속 되지 않고  시트가 뷰포트 기준으로 포지션이 잡힘

### DIFF
--- a/src/features/listings/ui/listingsCardDetail/components/DetailSectionFilter/DetailFilterSheet.tsx
+++ b/src/features/listings/ui/listingsCardDetail/components/DetailSectionFilter/DetailFilterSheet.tsx
@@ -3,8 +3,10 @@
 import { AnimatePresence, motion } from "framer-motion";
 import { useSearchParams } from "next/navigation";
 import { useRef } from "react";
+import { createPortal } from "react-dom";
 import { useDetailFilterSheetStore } from "@/src/features/listings/model";
 import { useScrollLock } from "@/src/shared/hooks/useScrollLock";
+import { usePortalTarget } from "@/src/shared/hooks/usePortalTarget";
 import { DetailFilterTab } from "./DetailFilterTab";
 import { parseDetailSection } from "@/src/features/listings/model";
 import { DistanceFilter } from "./DistanceFilter";
@@ -17,28 +19,31 @@ export const DetailFilterSheet = () => {
   const closeSheet = useDetailFilterSheetStore(s => s.closeSheet);
   const searchParams = useSearchParams();
   const anchorRef = useRef<HTMLSpanElement>(null);
+  const portalRoot = usePortalTarget("mobile-overlay-root");
   const section = parseDetailSection(searchParams);
   useScrollLock({ locked: open, anchorRef });
 
-  return (
-    <>
-      <span ref={anchorRef} className="hidden" />
-      <AnimatePresence>
-        {open && (
-          <>
+  const content = (
+    <AnimatePresence>
+      {open && (
+        <>
           <motion.div
-            className="fixed inset-0 bg-black/40"
-            onClick={closeSheet}
+            className="pointer-events-auto absolute inset-0 bg-black/40"
+            onClick={e => {
+              e.stopPropagation();
+              closeSheet();
+            }}
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
           />
 
           <motion.div
-            className="fixed bottom-0 left-0 right-0 flex h-[85vh] flex-col rounded-t-2xl bg-white shadow-xl"
+            className="pointer-events-auto absolute bottom-0 left-0 right-0 flex h-[80vh] flex-col rounded-t-2xl bg-white shadow-xl"
             initial={{ y: "100%" }}
             animate={{ y: 0 }}
             exit={{ y: "100%" }}
+            onClick={e => e.stopPropagation()}
             transition={{ type: "spring", stiffness: 260, damping: 30 }}
           >
             <div className="mx-auto mb-3 mt-2 h-1.5 w-12 rounded-full bg-gray-300" />
@@ -67,9 +72,15 @@ export const DetailFilterSheet = () => {
               </motion.div>
             </div>
           </motion.div>
-          </>
-        )}
-      </AnimatePresence>
+        </>
+      )}
+    </AnimatePresence>
+  );
+
+  return (
+    <>
+      <span ref={anchorRef} className="hidden" />
+      {portalRoot ? createPortal(content, portalRoot) : content}
     </>
   );
 };

--- a/src/features/listings/ui/listingsFullSheet/listingsFullSheet.tsx
+++ b/src/features/listings/ui/listingsFullSheet/listingsFullSheet.tsx
@@ -244,7 +244,10 @@ const FilterSheetContainer = ({
     <>
       <motion.div
         className="pointer-events-auto absolute inset-0 z-40 bg-black/40"
-        onClick={onDismiss}
+        onClick={e => {
+          e.stopPropagation();
+          onDismiss();
+        }}
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
@@ -254,6 +257,7 @@ const FilterSheetContainer = ({
         initial={{ y: "100%" }}
         animate={{ y: 0 }}
         exit={{ y: "100%" }}
+        onClick={e => e.stopPropagation()}
         transition={{ type: "spring", stiffness: 260, damping: 30 }}
       >
         {children}


### PR DESCRIPTION
## #️⃣ Issue Number

#391 

<br/>
<br/>

## 📝 어떤 상황에서 발생한 버그인가요?

- Given: 사용자가 공고리스트 접근 / 공고 상세단지 접근
- When: 상세 필터 버튼 클릭시 시트 제공
- Then: 시트 제공시 포지션 기준이 뷰포트 기준으로 잡힘


## ✅ 버그 수정 결과

-  DetailFilterSheet가 뷰포트 기준이 아니라 글로벌 렌더(375 프레임) 내부 기준
-  infraSheet와 동일한 렌더/동작 패턴으로 통일
-  시트 열릴 때 배경 스크롤 잠금은 계속 동작
