### PR TITLE
fix:공고 리스트 / 공고 카드 섹션 / 시트 조정

### DIFF
--- a/src/features/home/ui/components/homeFullSheet.tsx
+++ b/src/features/home/ui/components/homeFullSheet.tsx
@@ -30,7 +30,7 @@ export const HomeSheet = () => {
       {open && (
         <>
           <motion.div
-            className="pointer-events-auto absolute inset-0 z-40 bg-black/40"
+            className="pointer-events-auto absolute inset-0 bg-black/40"
             onClick={replaceRouter}
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
@@ -38,7 +38,7 @@ export const HomeSheet = () => {
           />
 
           <motion.div
-            className="pointer-events-auto absolute bottom-0 left-0 right-0 z-50 flex h-[55vh] flex-col rounded-t-2xl bg-white p-5 shadow-xl"
+            className="pointer-events-auto absolute bottom-0 left-0 right-0 flex h-[55vh] flex-col rounded-t-2xl bg-white p-5 shadow-xl"
             initial={{ y: "100%" }}
             animate={{ y: 0 }}
             exit={{ y: "100%" }}
@@ -56,7 +56,7 @@ export const HomeSheet = () => {
                 animate={{ x: 0, opacity: 1 }}
                 exit={{ x: -100, opacity: 0 }}
                 transition={{ duration: 0.5, ease: "easeInOut" }}
-                className="flex h-full flex-col justify-between"
+                className="z-11 flex h-full flex-col justify-between"
               >
                 {mode?.key === "pinpoints" && <PinpointRowBox />}
                 {mode?.key === "maxTime" && <MaxTimeSliderBox />}

--- a/src/features/home/ui/homeUrgentNoticeList.tsx
+++ b/src/features/home/ui/homeUrgentNoticeList.tsx
@@ -34,7 +34,7 @@ export const UrgentNoticeList = () => {
           </p>
         </div>
         <div
-          className="min-w-auto flex items-center text-xs font-semibold text-greyscale-grey-400"
+          className="min-w-auto hover: flex items-center text-xs font-semibold text-greyscale-grey-400 hover:cursor-pointer"
           onClick={pageRouter}
         >
           <span>전체보기</span>

--- a/src/features/listings/hooks/listingsHooks.tsx
+++ b/src/features/listings/hooks/listingsHooks.tsx
@@ -37,9 +37,9 @@ const normalizeRentType = (rentType: string) => {
 };
 
 export const getListingIcon = (type: string, housingType: string, size = 78) => {
-  const Nyear = normalizeRentType(type);
+  const Near = normalizeRentType(type);
 
-  const IconComp = LISTING_ICON_MAP[Nyear]?.[housingType];
+  const IconComp = LISTING_ICON_MAP[Near]?.[housingType];
   if (!IconComp) return null;
 
   return <IconComp width={size} height={size} />;
@@ -160,14 +160,15 @@ export const HouseICons = (item: ListingNormalized) => {
 type HouseRentalProps = ListingNormalized & {
   query: "listingListInfinite" | "listingSearchInfinite" | "notice";
 };
-//  ListingNormalized
 
+//  ListingNormalized
 export const HouseRental = ({ query, ...item }: HouseRentalProps) => {
-  const rantalText = getListingsRental(item.type);
-  if (!rantalText) return null;
+  const Near = normalizeRentType(item.type);
+  const rentalText = getListingsRental(Near);
+  if (!rentalText) return null;
   return (
     <span className="flex w-full justify-between">
-      <ListingBgBookMark item={item.type} bg={rantalText.bg} text={rantalText.text} border="none" />
+      <ListingBgBookMark item={item.type} bg={rentalText.bg} text={rentalText.text} border="none" />
       <LikeType liked={item.liked} id={item.id} type={"NOTICE"} resetQuery={[query]} />
     </span>
   );

--- a/src/features/listings/ui/listingsContents/listingsBookMark.tsx
+++ b/src/features/listings/ui/listingsContents/listingsBookMark.tsx
@@ -6,12 +6,25 @@ export const ListingBookMark = ({ item, border }: { item: string; border: string
       aria-label="Toggle bookmark"
       size="sm"
       variant="outline"
-      className={`data-[state=on]:*:[svg]:fill-blue-500 data-[state=on]:*:[svg]:stroke-blue-500 ${border}`}
+      className={` ${border} data-[state=on]:*:[svg]:fill-blue-500 data-[state=on]:*:[svg]:stroke-blue-500 max-w-full overflow-hidden rounded-[4px]`}
     >
-      <p className="text-xs">{item}</p>
+      <p className="min-w-0 flex-1 truncate text-xs-12">{item}</p>
     </Toggle>
   );
 };
+
+// export const ListingBookMark = ({ item, border }: { item: string; border: string }) => {
+//   return (
+//     <Toggle
+//       aria-label="Toggle bookmark"
+//       size="sm"
+//       variant="outline"
+//       className={` ${border} data-[state=on]:*:[svg]:fill-blue-500 data-[state=on]:*:[svg]:stroke-blue-500 inline-flex w-fit max-w-none rounded-[4px]`}
+//     >
+//       <p className="whitespace-nowrap text-xs-12">{item}</p>
+//     </Toggle>
+//   );
+// };
 
 export const ListingBgBookMark = ({
   item,

--- a/src/features/listings/ui/listingsContents/listingsContentCard.tsx
+++ b/src/features/listings/ui/listingsContents/listingsContentCard.tsx
@@ -27,9 +27,9 @@ export const ListingContentsCard = <T extends ListingUnion>({ data }: { data: T[
             onClick={() => handleRouter(normalized.id)}
           >
             <div className="border-r-1 flex w-[35%] flex-col rounded-l-xl rounded-bl-xl bg-bgColor-mute pl-1 pt-2">
-              <div className="flex justify-start gap-1">
+              <div className="flex min-w-0 items-center gap-2">
                 <ListingBookMark item={normalized.type} border="border" />
-                <p className="truncate text-xs font-semibold text-greyscale-grey-800">
+                <p className="min-w-0 flex-1 truncate text-xs font-semibold text-greyscale-grey-800">
                   {normalized.supplier}
                 </p>
               </div>
@@ -38,26 +38,23 @@ export const ListingContentsCard = <T extends ListingUnion>({ data }: { data: T[
               </div>
             </div>
 
-            <div className="flex w-[65%] flex-col justify-start gap-2 rounded-br-xl rounded-tr-xl bg-white pb-3 pl-4 pr-4 pt-2">
-              <div
-                className="flex items-baseline gap-2"
-                onClick={e => {
-                  e.stopPropagation();
-                }}
-              >
+            <div className="flex w-[65%] flex-col gap-2 rounded-br-xl rounded-tr-xl bg-white py-3 pl-4 pr-[10px]">
+              <div onClick={e => e.stopPropagation()}>
                 <HouseRental
                   {...normalized}
                   query={path ? "listingSearchInfinite" : "listingListInfinite"}
                 />
               </div>
+
               <div className="max-w-full">
-                <p className="truncate text-sm font-semibold">
+                <p className="truncate text-sm font-semibold leading-tight">
                   <HighlightCenteredText text={normalized.name} keyword={keyword} />
                 </p>
               </div>
+
               <div className="max-w-full">
-                <p className="text-sm text-greyscale-grey-400">모집일정</p>
-                <p className="text-sm text-greyscale-grey-400">
+                <p className="text-sm leading-tight text-greyscale-grey-400">모집일정</p>
+                <p className="text-sm leading-tight text-greyscale-grey-400">
                   {formatApplyPeriod(normalized.applyPeriod)}
                 </p>
               </div>

--- a/src/features/listings/ui/listingsFullSheet/listingsFullSheet.tsx
+++ b/src/features/listings/ui/listingsFullSheet/listingsFullSheet.tsx
@@ -253,7 +253,7 @@ const FilterSheetContainer = ({
         exit={{ opacity: 0 }}
       />
       <motion.div
-        className="pointer-events-auto absolute bottom-0 left-0 right-0 z-50 flex h-[85vh] flex-col rounded-t-2xl bg-white shadow-xl"
+        className="pointer-events-auto absolute bottom-0 left-0 right-0 z-50 flex h-[85%] max-h-full flex-col rounded-t-2xl bg-white shadow-xl"
         initial={{ y: "100%" }}
         animate={{ y: 0 }}
         exit={{ y: "100%" }}
@@ -278,9 +278,13 @@ const FilterSheetHeader = ({ onClose }: { onClose: () => void }) => {
     <>
       <div className="mx-auto mb-3 mt-2 h-1.5 w-12 rounded-full bg-gray-300" />
 
-      <div className="flex items-center justify-between px-5 pb-2">
+      <div className="flex items-center justify-between px-5 pb-2 pt-1">
         <h2 className="text-sm font-bold">공고 필터</h2>
-        <button onClick={onClose} className="text-xl font-bold">
+        <button
+          onClick={onClose}
+          className="-mr-2 inline-flex h-10 w-10 items-center justify-center rounded-full"
+          aria-label="close filter sheet"
+        >
           <CloseButton />
         </button>
       </div>

--- a/src/shared/ui/globalRender/mobileFrameWithSheetPortal.tsx
+++ b/src/shared/ui/globalRender/mobileFrameWithSheetPortal.tsx
@@ -39,7 +39,7 @@ export function MobileFrameWithSheetPortal({
 
         <div
           id="mobile-overlay-root"
-          className="pointer-events-none absolute inset-0 z-0 overflow-hidden sm:rounded-xl md:rounded-2xl lg:rounded-2xl"
+          className="pointer-events-none absolute inset-0 z-20 overflow-hidden sm:rounded-xl md:rounded-2xl lg:rounded-2xl"
         />
 
         {/* 바텀시트가 이 컨테이너에만 렌더되도록 포탈 타깃 */}


### PR DESCRIPTION
## #️⃣ Issue Number

#403 

<br/>
<br/>

## 📝 요약(Summary) (선택)

1. homeFullSheet.tsx
• 수정 결과: HomeSheet 오버레이/시트의 레이어 우선순위를 mobile-overlay-root 기준으로 정리.
• 버그 효과: 홈 HomeCharacter가 딤 레이어 위로 뜨던 현상이 완화됨(오버레이 루트 z-index 변경과 함께 동작).
2. mobileFrameWithSheetPortal.tsx
• 수정 결과: mobile-overlay-root를 z-20으로 상향.
• 버그 효과: 공통 시트 오버레이가 홈의 z-10 요소(HomeCharacter)보다 위에서 렌더되어, 시트 열릴 때 배경 딤이 정상 적용됨.
3. listingsFullSheet.tsx
• 수정 결과: 시트 높이를 85vh -> 85%(+max-h-full)로 변경, 헤더 상단 여백 추가, 닫기 버튼 터치 영역 확장.
• 버그 효과: 해상도/뷰포트에 따라 X 버튼이 너무 위로 올라가거나 UI가 잘려 보이던 문제 완화, 닫기 버튼 클릭성 개선.
4. listingsContentCard.tsx
• 수정 결과: 카드 내부 텍스트/배지 영역에 min-w-0, truncate, 패딩/간격 조정 적용.
• 버그 효과: 좁은 폭에서 공급자명/타이틀/일정 줄바꿈 및 레이아웃 깨짐(잘림/겹침) 완화.
5. listingsBookMark.tsx
• 수정 결과: 북마크 라벨 컨테이너 폭 제한/overflow 처리 및 텍스트 truncate 적용.
• 버그 효과: 긴 라벨로 카드 레이아웃이 밀리거나 넘치는 현상 완화.
6. listingsHooks.tsx
• 수정 결과: HouseRental에서 임대 타입을 정규화 후 getListingsRental에 전달하도록 보정.
• 버그 효과: 타입 매핑 불일치로 배지/문구가 비정상 노출되던 케이스 완화.
7. homeUrgentNoticeList.tsx
• 수정 결과: 클릭 가능한 영역에 hover:cursor-pointer 추가.
• 버그 효과: 직접적인 기능 버그보다는 인터랙션 피드백 개선.
• 참고: 클래스 문자열에 hover: 단독 토큰이 있어 Tailwind 오타 가능성 있음(동작 영향은 낮지만 정리 권장).

<br/>
<br/>