### PR TITLE
feat: 자격진단 API 연동 완료

### DIFF
--- a/app/eligibility/page.tsx
+++ b/app/eligibility/page.tsx
@@ -1,23 +1,66 @@
 "use client";
 
-import { Suspense, useEffect } from "react";
+import { Suspense, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import { EligibilitySection } from "@/src/widgets/eligibilitySection";
 import { useEligibilityStore } from "@/src/features/eligibility/model/eligibilityStore";
+import { useDiagnosisResultStore } from "@/src/features/eligibility/model/diagnosisResultStore";
+import { getDiagnosisLatest } from "@/src/features/eligibility/api/diagnosisApi";
+import type { DiagnosisResultData } from "@/src/features/eligibility/api/diagnosisTypes";
+import { Modal } from "@/src/shared/ui/modal/default/modal";
 import { Spinner } from "@/src/shared/ui/spinner/default";
 
 export default function EligibilityPage() {
+  const router = useRouter();
   const reset = useEligibilityStore(state => state.reset);
+  const setDiagnosisResult = useDiagnosisResultStore(s => s.setResult);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   useEffect(() => {
-    // 자격진단 페이지 진입 시 store 초기화
-    reset();
-  }, [reset]);
+    let mounted = true;
+
+    const checkLatest = async () => {
+      try {
+        const response = await getDiagnosisLatest<DiagnosisResultData>();
+        if (!mounted) return;
+        const data = response?.data;
+        if (data != null && typeof data === "object" && "eligible" in data) {
+          setDiagnosisResult(data as DiagnosisResultData);
+          setIsModalOpen(true);
+        } else {
+          reset();
+        }
+      } catch {
+        if (mounted) reset();
+      }
+    };
+
+    checkLatest();
+    return () => {
+      mounted = false;
+    };
+  }, [reset, setDiagnosisResult]);
+
+  const handleModalButtonClick = (index: number) => {
+    setIsModalOpen(false);
+    if (index === 0) {
+      setDiagnosisResult(null);
+      reset();
+    } else {
+      router.push("/eligibility/result/final");
+    }
+  };
 
   return (
     <main className="flex h-full flex-col">
       <Suspense fallback={<Spinner title="로딩 중" description="페이지를 불러오는 중입니다." />}>
         <EligibilitySection />
       </Suspense>
+      <Modal
+        type="eligibilityPreviousDiagnosis"
+        open={isModalOpen}
+        onButtonClick={handleModalButtonClick}
+      />
     </main>
   );
 }

--- a/app/eligibility/result/final/page.tsx
+++ b/app/eligibility/result/final/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { EligibilityFinalResultSection } from "@/src/widgets/eligibilitySection";
+
+export default function EligibilityFinalResultPage() {
+  return (
+    <main className="flex h-full flex-col">
+      <EligibilityFinalResultSection />
+    </main>
+  );
+}

--- a/src/features/eligibility/api/diagnosisApi.ts
+++ b/src/features/eligibility/api/diagnosisApi.ts
@@ -1,0 +1,20 @@
+import { http, API_BASE_URL_V2 } from "@/src/shared/api/http";
+import {
+  DIAGNOSIS_ENDPOINT,
+  DIAGNOSIS_LATEST_ENDPOINT,
+} from "@/src/shared/api/endpoints";
+import type { IResponse } from "@/src/shared/types/response";
+import type { DiagnosisResultData } from "./diagnosisTypes";
+import type { DiagnosisPostRequest } from "./diagnosisTypes";
+
+const v2Options = { baseURL: API_BASE_URL_V2 };
+
+/** GET /v2/diagnosis/latest - 청약 진단 최신 결과 조회 */
+export function getDiagnosisLatest<T = DiagnosisResultData>() {
+  return http.get<IResponse<T>>(DIAGNOSIS_LATEST_ENDPOINT, undefined, v2Options);
+}
+
+/** POST /v2/diagnosis - 청약 진단 제출 */
+export function postDiagnosis<T = DiagnosisResultData, D = DiagnosisPostRequest>(data: D) {
+  return http.post<IResponse<T>, D>(DIAGNOSIS_ENDPOINT, data, v2Options);
+}

--- a/src/features/eligibility/api/diagnosisTypes.ts
+++ b/src/features/eligibility/api/diagnosisTypes.ts
@@ -1,0 +1,121 @@
+/** POST /v2/diagnosis 요청 body - API DTO Enum 타입 */
+
+export const DIAGNOSIS_GENDER = ["남성", "여성", "미정"] as const;
+export type DiagnosisGender = (typeof DIAGNOSIS_GENDER)[number];
+
+export const DIAGNOSIS_ACCOUNT_YEARS = [
+  "6개월 미만",
+  "6개월 이상 ~ 1년 미만",
+  "1년 이상 ~ 2년 미만",
+  "2년 이상",
+] as const;
+export type DiagnosisAccountYears = (typeof DIAGNOSIS_ACCOUNT_YEARS)[number];
+
+export const DIAGNOSIS_ACCOUNT_DEPOSIT = [
+  "0회 ~ 5회",
+  "6회 ~ 11회",
+  "12회 ~ 23회",
+  "24회 ~ 35회",
+  "36회 ~ 48회",
+  "49회 ~ 59회",
+  "60회 이상",
+] as const;
+export type DiagnosisAccountDeposit = (typeof DIAGNOSIS_ACCOUNT_DEPOSIT)[number];
+
+export const DIAGNOSIS_ACCOUNT = ["600만원 이하", "600만원 이상"] as const;
+export type DiagnosisAccount = (typeof DIAGNOSIS_ACCOUNT)[number];
+
+export const DIAGNOSIS_EDUCATION_STATUS = [
+  "대학교 재학 중이거나 다음 학기에 입학 예정",
+  "대학교 휴학 중이며 다음 학기 복학 예정",
+  "대학교 혹은 고등학교 졸업/중퇴 후 2년 이내",
+  "졸업/중퇴 후 2년이 지났지만 대학원에 재학 중",
+  "해당 사항 없음",
+] as const;
+export type DiagnosisEducationStatus = (typeof DIAGNOSIS_EDUCATION_STATUS)[number];
+
+export const DIAGNOSIS_INCOME_LEVEL = [
+  "1구간",
+  "2구간",
+  "3구간",
+  "4구간",
+  "5구간",
+  "6구간",
+  "기타",
+] as const;
+export type DiagnosisIncomeLevel = (typeof DIAGNOSIS_INCOME_LEVEL)[number];
+
+export const DIAGNOSIS_HOUSING_STATUS = [
+  "나는 무주택자지만 우리 가구원중 주택 소유자가 있어요",
+  "우리집 가구원 모두 주택을 소유하고 있지 않아요",
+  "주택을 소유하고 있어요",
+] as const;
+export type DiagnosisHousingStatus = (typeof DIAGNOSIS_HOUSING_STATUS)[number];
+
+export const DIAGNOSIS_SPECIAL_CATEGORY = [
+  "주거급여 수급자",
+  "생계/의료급여 수급자",
+  "한부모 가정",
+  "보호대상 한부모 가정",
+  "친인척 위탁가정",
+  "대리양육가정",
+  "철거민",
+  "국가 유공자 본인/가구",
+  "위안부 피해자 본인/가구",
+  "북한이탈주민 본인",
+  "장애인 등록자/장애인 가구",
+  "영구임대 퇴거자",
+  "장기복무 제대군인",
+  "주거 취약계층/긴급 주거지원 대상자",
+  "위탁가정/보육원 시설종료2년이내, 종료예정자",
+  "귀한 국군포로 본인",
+  "교통사고 유자녀 가정",
+  "산단근로자",
+  "보증 거절자",
+  "나 또는 배우자가 노부모를 1년 이상 부양",
+  "그룹홈 거주",
+  "조손가족",
+] as const;
+export type DiagnosisSpecialCategory = (typeof DIAGNOSIS_SPECIAL_CATEGORY)[number];
+
+/** POST /v2/diagnosis 요청 body */
+export interface DiagnosisPostRequest {
+  gender: DiagnosisGender;
+  birthday: string;
+  monthPay: number;
+  hasAccount: boolean;
+  accountYears: DiagnosisAccountYears;
+  accountDeposit: DiagnosisAccountDeposit;
+  account: DiagnosisAccount;
+  maritalStatus: boolean;
+  marriageYears: number;
+  unbornChildrenCount: number;
+  under6ChildrenCount: number;
+  over7MinorChildrenCount: number;
+  educationStatus: DiagnosisEducationStatus;
+  hasCar: boolean;
+  carValue: number;
+  isHouseholdHead: boolean;
+  isSingle: boolean;
+  fetusCount: number;
+  minorCount: number;
+  adultCount: number;
+  incomeLevel: DiagnosisIncomeLevel;
+  housingStatus: DiagnosisHousingStatus;
+  housingYears: number;
+  propertyAsset: number;
+  carAsset: number;
+  financialAsset: number;
+  hasSpecialCategory: DiagnosisSpecialCategory[];
+}
+
+/** POST /v2/diagnosis 응답 data (공통 제외). GET /diagnosis/latest 응답에 소득분위·지원대상이 포함 */
+export interface DiagnosisResultData {
+  eligible: boolean;
+  decisionMessage: string;
+  recommended: string[];
+  /** 내 소득분위 (예: "1분위")*/
+  incomeLevel?: string;
+  /** 나의 지원 가능 대상 */
+  targetGroups?: string[];
+}

--- a/src/features/eligibility/api/mapEligibilityToDiagnosisRequest.ts
+++ b/src/features/eligibility/api/mapEligibilityToDiagnosisRequest.ts
@@ -1,0 +1,220 @@
+import type { EligibilityData } from "../model/eligibilityStore";
+import type { DiagnosisPostRequest, DiagnosisSpecialCategory } from "./diagnosisTypes";
+import {
+  DIAGNOSIS_ACCOUNT_YEARS,
+  DIAGNOSIS_ACCOUNT_DEPOSIT,
+  DIAGNOSIS_ACCOUNT,
+  DIAGNOSIS_EDUCATION_STATUS,
+  DIAGNOSIS_HOUSING_STATUS,
+  DIAGNOSIS_INCOME_LEVEL,
+} from "./diagnosisTypes";
+
+/** Store housingSubscriptionPeriod key → API accountYears */
+const ACCOUNT_YEARS_MAP: Record<string, (typeof DIAGNOSIS_ACCOUNT_YEARS)[number]> = {
+  "1": "6개월 미만",
+  "2": "6개월 이상 ~ 1년 미만",
+  "3": "1년 이상 ~ 2년 미만",
+  "4": "2년 이상",
+};
+
+/** Store housingSubscriptionPaymentCount key → API accountDeposit */
+const ACCOUNT_DEPOSIT_MAP: Record<string, (typeof DIAGNOSIS_ACCOUNT_DEPOSIT)[number]> = {
+  "1": "0회 ~ 5회",
+  "2": "6회 ~ 11회",
+  "3": "12회 ~ 23회",
+  "4": "24회 ~ 35회",
+  "5": "36회 ~ 48회",
+  "6": "49회 ~ 59회",
+  "7": "60회 이상",
+};
+
+/** Store totalPaymentAmount id → API account (600만원) */
+const ACCOUNT_MAP: Record<string, (typeof DIAGNOSIS_ACCOUNT)[number]> = {
+  "1": "600만원 이상",
+  "2": "600만원 이하",
+};
+
+/** Store householdHousingOwnershipStatus → API housingStatus */
+const HOUSING_STATUS_MAP: Record<string, (typeof DIAGNOSIS_HOUSING_STATUS)[number]> = {
+  "1": "나는 무주택자지만 우리 가구원중 주택 소유자가 있어요",
+  "2": "우리집 가구원 모두 주택을 소유하고 있지 않아요",
+  "3": "주택을 소유하고 있어요",
+};
+
+/** Store youngSingleStudentStatus id → API educationStatus */
+const EDUCATION_STATUS_MAP: Record<string, (typeof DIAGNOSIS_EDUCATION_STATUS)[number]> = {
+  "1": "해당 사항 없음",
+  "2": "대학교 재학 중이거나 다음 학기에 입학 예정",
+  "3": "대학교 휴학 중이며 다음 학기 복학 예정",
+  "4": "대학교 혹은 고등학교 졸업/중퇴 후 2년 이내",
+  "5": "졸업/중퇴 후 2년이 지났지만 대학원에 재학 중",
+};
+
+function toNum(s: string | null | undefined): number {
+  if (s == null || s === "") return 0;
+  const n = Number(s);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function formatBirthday(date: Date | null): string {
+  if (!date) return "";
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * 스토어 monthlyIncome → 원 단위.
+ * (UI에서 만원으로 넣으면 150, 원으로 넣으면 1500000 저장되는 경우 모두 처리)
+ */
+function monthlyIncomeToWon(monthlyIncome: string | null): number {
+  const n = toNum(monthlyIncome);
+  if (n <= 0) return 0;
+  return n <= 10000 ? n * 10000 : n;
+}
+
+/** 월소득(만원 기준 비교) + 수급자 여부 → API incomeLevel */
+function toIncomeLevel(
+  monthlyIncome: string | null,
+  benefitTypes: string[]
+): (typeof DIAGNOSIS_INCOME_LEVEL)[number] {
+  if (benefitTypes?.length) return "1구간";
+  const won = monthlyIncomeToWon(monthlyIncome);
+  const manwon = won / 10000;
+  if (manwon <= 0) return "1구간";
+  if (manwon <= 150) return "1구간";
+  if (manwon <= 250) return "2구간";
+  if (manwon <= 350) return "3구간";
+  if (manwon <= 450) return "4구간";
+  if (manwon <= 550) return "5구간";
+  if (manwon <= 650) return "6구간";
+  return "기타";
+}
+
+/** benefitTypes store id → API hasSpecialCategory */
+const BENEFIT_TO_SPECIAL: Record<string, DiagnosisSpecialCategory> = {
+  "1": "주거급여 수급자",
+  "2": "생계/의료급여 수급자",
+};
+
+/** familyTypes store id → API hasSpecialCategory */
+const FAMILY_TO_SPECIAL: Record<string, DiagnosisSpecialCategory> = {
+  "1": "친인척 위탁가정",
+  "2": "대리양육가정",
+  "3": "한부모 가정",
+  "4": "보호대상 한부모 가정",
+};
+
+/** specialEligibilityTypes store id → API hasSpecialCategory */
+const SPECIAL_ELIGIBILITY_TO_API: Record<string, DiagnosisSpecialCategory> = {
+  "1": "국가 유공자 본인/가구",
+  "2": "위안부 피해자 본인/가구",
+  "3": "북한이탈주민 본인",
+  "4": "장애인 등록자/장애인 가구",
+  "5": "교통사고 유자녀 가정",
+  "6": "영구임대 퇴거자",
+  "7": "영구임대 퇴거자",
+  "8": "주거 취약계층/긴급 주거지원 대상자",
+  "9": "산단근로자",
+  "10": "보증 거절자",
+};
+
+/** marriedHouseholdFamilyTypes store id → API hasSpecialCategory */
+const MARRIED_HOUSEHOLD_FAMILY_TO_SPECIAL: Record<string, DiagnosisSpecialCategory> = {
+  "1": "나 또는 배우자가 노부모를 1년 이상 부양",
+  "2": "조손가족",
+};
+
+/** Store 라벨(또는 id) → API hasSpecialCategory (라벨로 저장된 경우 대응) */
+const SPECIAL_LABEL_TO_API: Record<string, DiagnosisSpecialCategory> = {
+  "국가 유공자 본인/가구": "국가 유공자 본인/가구",
+  "위안부 피해자 본인/가구": "위안부 피해자 본인/가구",
+  "북한이탈주민 본인": "북한이탈주민 본인",
+  "장애인 등록자/장애인 가구": "장애인 등록자/장애인 가구",
+  "교통사고 유자녀 가정": "교통사고 유자녀 가정",
+  "부도 공공임대 퇴거자": "영구임대 퇴거자",
+  "영구임대 퇴거자": "영구임대 퇴거자",
+  "주거 취약계층/긴급 주거지원 대상자": "주거 취약계층/긴급 주거지원 대상자",
+  "산단 근로자": "산단근로자",
+  산단근로자: "산단근로자",
+  보증거절자: "보증 거절자",
+  "보증 거절자": "보증 거절자",
+};
+
+function mapHasSpecialCategory(data: EligibilityData): DiagnosisSpecialCategory[] {
+  const set = new Set<DiagnosisSpecialCategory>();
+
+  (data.benefitTypes ?? []).forEach(id => {
+    const api = BENEFIT_TO_SPECIAL[id];
+    if (api) set.add(api);
+  });
+  (data.familyTypes ?? []).forEach(id => {
+    const api = FAMILY_TO_SPECIAL[id];
+    if (api) set.add(api);
+  });
+  (data.specialEligibilityTypes ?? []).forEach(val => {
+    const api = SPECIAL_ELIGIBILITY_TO_API[val] ?? SPECIAL_LABEL_TO_API[val];
+    if (api) set.add(api);
+  });
+  (data.marriedHouseholdFamilyTypes ?? []).forEach(id => {
+    const api = MARRIED_HOUSEHOLD_FAMILY_TO_SPECIAL[id];
+    if (api) set.add(api);
+  });
+
+  return Array.from(set);
+}
+
+/**
+ * EligibilityData(store) → POST /v2/diagnosis 요청 body 로 변환 (API DTO Enum 준수)
+ */
+export function mapEligibilityToDiagnosisRequest(data: EligibilityData): DiagnosisPostRequest {
+  const hasAccount = data.hasHousingSubscriptionSavings === "1";
+  const maritalStatus = data.isNewlyMarried === true;
+  const isSingle = !maritalStatus && data.marriageStatus !== "1";
+
+  const spouse = data.spouseChildrenInfo ?? data.marriedHouseholdChildrenInfo;
+  const unbornChildrenCount = spouse?.expectedBirth ?? 0;
+  const under6ChildrenCount = data.childrenInfo?.under6 ?? spouse?.under6 ?? 0;
+  const over7MinorChildrenCount = data.childrenInfo?.over7 ?? spouse?.over7 ?? 0;
+  const minorCount = under6ChildrenCount + over7MinorChildrenCount;
+  const adultCount = maritalStatus ? 2 : 1;
+
+  const housingStatus =
+    HOUSING_STATUS_MAP[data.householdHousingOwnershipStatus ?? ""] ??
+    "우리집 가구원 모두 주택을 소유하고 있지 않아요";
+
+  const monthPay = monthlyIncomeToWon(data.monthlyIncome);
+
+  const gender = data.gender === "1" ? "남성" : data.gender === "2" ? "여성" : "미정";
+
+  return {
+    gender,
+    birthday: formatBirthday(data.birthDate),
+    monthPay,
+    hasAccount,
+    accountYears: ACCOUNT_YEARS_MAP[data.housingSubscriptionPeriod ?? ""] ?? "2년 이상",
+    accountDeposit: ACCOUNT_DEPOSIT_MAP[data.housingSubscriptionPaymentCount ?? ""] ?? "0회 ~ 5회",
+    account: ACCOUNT_MAP[data.totalPaymentAmount ?? ""] ?? "600만원 이하",
+    maritalStatus,
+    marriageYears: toNum(data.marriagePeriod),
+    unbornChildrenCount,
+    under6ChildrenCount,
+    over7MinorChildrenCount,
+    educationStatus: EDUCATION_STATUS_MAP[data.youngSingleStudentStatus ?? ""] ?? "해당 사항 없음",
+    hasCar: data.hasCar === "1",
+    carValue: toNum(data.carAssetValue ?? data.householdCarAssetValue),
+    isHouseholdHead: data.householdRole === "1",
+    isSingle,
+    fetusCount: unbornChildrenCount,
+    minorCount,
+    adultCount,
+    incomeLevel: toIncomeLevel(data.monthlyIncome, data.benefitTypes ?? []),
+    housingStatus,
+    housingYears: toNum(data.housingDisposalYears),
+    propertyAsset: toNum(data.landAssetValue ?? data.householdLandAssetValue),
+    carAsset: toNum(data.carAssetValue ?? data.householdCarAssetValue),
+    financialAsset: toNum(data.financialAssetValue ?? data.householdFinancialAssetValue),
+    hasSpecialCategory: mapHasSpecialCategory(data),
+  };
+}

--- a/src/features/eligibility/hooks/useDiagnosisLatest.ts
+++ b/src/features/eligibility/hooks/useDiagnosisLatest.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { getDiagnosisLatest } from "../api/diagnosisApi";
+import type { DiagnosisResultData } from "../api/diagnosisTypes";
+
+const QUERY_KEY = ["diagnosis", "latest"];
+
+/** 마이페이지 등에서 자격진단 최신 결과 조회 (GET /v2/diagnosis/latest) */
+export function useDiagnosisLatest() {
+  const query = useQuery({
+    queryKey: QUERY_KEY,
+    queryFn: async () => {
+      const res = await getDiagnosisLatest<DiagnosisResultData>();
+      return (res?.data ?? null) as DiagnosisResultData | null;
+    },
+    retry: false,
+  });
+
+  return {
+    data: query.data ?? null,
+    isLoading: query.isLoading,
+    isError: query.isError,
+    refetch: query.refetch,
+  };
+}

--- a/src/features/eligibility/hooks/useDiagnosisResult.ts
+++ b/src/features/eligibility/hooks/useDiagnosisResult.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useEligibilityStore } from "../model/eligibilityStore";
+import { postDiagnosis } from "../api/diagnosisApi";
+import { mapEligibilityToDiagnosisRequest } from "../api/mapEligibilityToDiagnosisRequest";
+import type { DiagnosisResultData } from "../api/diagnosisTypes";
+
+export function useDiagnosisResult() {
+  const data = useEligibilityStore();
+  const [result, setResult] = useState<DiagnosisResultData | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const submit = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const body = mapEligibilityToDiagnosisRequest(data);
+      const response = await postDiagnosis<DiagnosisResultData, typeof body>(body);
+      const resultData = response.data as DiagnosisResultData | undefined;
+      if (resultData != null) {
+        setResult(resultData);
+        return resultData;
+      }
+      setResult(null);
+      return null;
+    } catch (err) {
+      const e = err instanceof Error ? err : new Error(String(err));
+      setError(e);
+      setResult(null);
+      throw e;
+    } finally {
+      setIsLoading(false);
+    }
+  }, [data]);
+
+  return { result, isLoading, error, submit };
+}

--- a/src/features/eligibility/model/diagnosisResultStore.ts
+++ b/src/features/eligibility/model/diagnosisResultStore.ts
@@ -1,0 +1,22 @@
+import { create } from "zustand";
+import type { DiagnosisResultData } from "../api/diagnosisTypes";
+
+export interface DiagnosisResultMeta {
+  incomeLevel?: string;
+}
+
+interface DiagnosisResultState {
+  result: DiagnosisResultData | null;
+  incomeLevel: string | null;
+  setResult: (result: DiagnosisResultData | null, meta?: DiagnosisResultMeta) => void;
+}
+
+export const useDiagnosisResultStore = create<DiagnosisResultState>(set => ({
+  result: null,
+  incomeLevel: null,
+  setResult: (result, meta) =>
+    set({
+      result,
+      incomeLevel: result ? (meta?.incomeLevel ?? null) : null,
+    }),
+}));

--- a/src/features/eligibility/ui/result/diagnosisResultBanner.tsx
+++ b/src/features/eligibility/ui/result/diagnosisResultBanner.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import ResultBannerImg from "@/src/assets/images/eligibility/resultBannerImg";
+import { cn } from "@/lib/utils";
+
+export interface DiagnosisResultBannerProps {
+  /** 사용자 이름 */
+  userName: string;
+  /** 소득 구간 (예: "4구간" → "4분위"로 표시) */
+  incomeLevel: string | null;
+  /** 추천 유형 요약 (예: ["청년 특별공급", "신혼부부 특별공급"] → "청년 특별공급, 신혼부부 특별공급 으로 신청이 가능합니다") */
+  applicationTypeSummary: string[];
+  className?: string;
+}
+
+/** 소득 구간 문자열을 분위 표시로 변환 (예: "4구간" → "4분위") */
+function toIncomeBunwi(incomeLevel: string | null): string {
+  if (!incomeLevel) return "0분위";
+  const match = incomeLevel.replace("구간", "").trim();
+  return /^\d+$/.test(match) ? `${match}분위` : incomeLevel;
+}
+
+export const DiagnosisResultBanner = ({
+  userName,
+  incomeLevel,
+  applicationTypeSummary,
+  className,
+}: DiagnosisResultBannerProps) => {
+  const bunwi = toIncomeBunwi(incomeLevel);
+  const summaryText =
+    applicationTypeSummary.length > 0
+      ? `${applicationTypeSummary.join(", ")} 으로 신청이 가능합니다`
+      : "추천 매물이 있습니다";
+
+  return (
+    <div
+      className={cn(
+        "flex gap-4 rounded-lg bg-white px-5 py-4 shadow-result-card",
+        className
+      )}
+      role="banner"
+    >
+      <div className="relative flex-shrink-0">
+        <ResultBannerImg />
+      </div>
+      <div className="flex min-w-0 flex-1 flex-col justify-center gap-1">
+        <p className="text-sm font-medium leading-[140%] tracking-[-0.02em] text-greyscale-grey-900">
+          <span className="underline decoration-greyscale-grey-300 underline-offset-2">
+            {userName}
+          </span>
+          님은 소득{" "}
+          <span className="underline decoration-greyscale-grey-300 underline-offset-2">
+            {bunwi}
+          </span>
+          이고,
+        </p>
+        <p className="text-sm font-medium leading-[140%] tracking-[-0.02em] text-greyscale-grey-900">
+          <span className="underline decoration-greyscale-grey-300 underline-offset-2">
+            {summaryText}
+          </span>
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/src/features/eligibility/ui/result/diagnosisResultConstants.ts
+++ b/src/features/eligibility/ui/result/diagnosisResultConstants.ts
@@ -1,0 +1,31 @@
+/** 진단결과 임대주택 유형별 설명 (API recommended 파싱용 라벨과 매칭) */
+export const HOUSING_TYPE_DESCRIPTIONS: Record<string, string> = {
+  통합공공임대:
+    "저소득층, 젊은 층 및 장애인·국가유공자 등 사회 취약 계층 등의 주거안정을 목적으로 공급하는 공공임대주택",
+  국민임대:
+    "저소득 무주택 세대의 주거 안정을 위해 국가와 지자체가 공급하는 국민임대주택",
+  행복주택:
+    "청년·신혼부부·노인 등 주거 취약계층을 위한 공공 주거지원 주택",
+  공공임대:
+    "국가·지자체 등이 건설하거나 매입하여 저소득층 등에 임대하는 공공임대주택",
+  영구임대:
+    "저소득 무주택자에게 평생 거주권을 부여하는 영구임대주택",
+  장기전세:
+    "전세금을 지원하여 장기간 거주할 수 있도록 하는 주택",
+  매입임대:
+    "국가·지자체가 기존 주택을 매입하여 저소득층 등에 임대하는 주택",
+  전세임대:
+    "전세 계약을 통해 저소득층 등에 임대하는 주택",
+};
+
+/** 진단결과 임대주택 유형별 태그 배경색 (tailwind 또는 임의 클래스) */
+export const HOUSING_TYPE_TAG_CLASS: Record<string, string> = {
+  통합공공임대: "bg-teal-100 text-teal-800",
+  국민임대: "bg-amber-100 text-amber-800",
+  행복주택: "bg-emerald-100 text-emerald-800",
+  공공임대: "bg-amber-100 text-amber-800",
+  영구임대: "bg-violet-100 text-violet-800",
+  장기전세: "bg-rose-100 text-rose-800",
+  매입임대: "bg-violet-100 text-violet-800",
+  전세임대: "bg-orange-100 text-orange-800",
+};

--- a/src/features/eligibility/ui/result/diagnosisResultItem.tsx
+++ b/src/features/eligibility/ui/result/diagnosisResultItem.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { HOUSING_TYPE_TAG_CLASS } from "./diagnosisResultConstants";
+
+export interface DiagnosisResultItemProps {
+  /** 임대주택 유형 (예: "통합공공임대") */
+  housingType: string;
+  /** 유형 설명 문단 */
+  description: string;
+  /** 신청 가능 유형 목록 (예: ["일반 공급", "청년 특별공급"]) */
+  applicationTypes: string[];
+  className?: string;
+}
+
+const DEFAULT_TAG_CLASS = "bg-greyscale-grey-100 text-greyscale-grey-700";
+
+export const DiagnosisResultItem = ({
+  housingType,
+  description,
+  applicationTypes,
+  className,
+}: DiagnosisResultItemProps) => {
+  const tagClass = HOUSING_TYPE_TAG_CLASS[housingType] ?? DEFAULT_TAG_CLASS;
+
+  return (
+    <article
+      className={cn(
+        "flex flex-col gap-3 rounded-lg bg-white px-5 py-4 shadow-result-card",
+        className
+      )}
+    >
+      <div className="flex flex-col gap-3">
+        <span
+          className={cn(
+            "w-fit rounded-full px-3 py-1 text-xs font-medium",
+            tagClass
+          )}
+        >
+          {housingType}
+        </span>
+        <p className="text-sm leading-[140%] tracking-[-0.02em] text-greyscale-grey-700">
+          {description}
+        </p>
+      </div>
+      <div className="h-px bg-greyscale-grey-100" aria-hidden />
+      <div className="flex flex-col gap-2">
+        <span className="text-xs font-medium text-greyscale-grey-500">
+          신청 가능 유형
+        </span>
+        <div className="flex flex-wrap gap-2">
+          {applicationTypes.map((type, index) => (
+            <span
+              key={`${type}-${index}`}
+              className="rounded-full bg-greyscale-grey-100 px-3 py-1 text-xs font-medium text-greyscale-grey-700"
+            >
+              {type}
+            </span>
+          ))}
+        </div>
+      </div>
+    </article>
+  );
+};

--- a/src/features/eligibility/ui/result/diagnosisResultList.tsx
+++ b/src/features/eligibility/ui/result/diagnosisResultList.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useMemo } from "react";
+import { DiagnosisResultItem } from "./diagnosisResultItem";
+import { HOUSING_TYPE_DESCRIPTIONS } from "./diagnosisResultConstants";
+
+export interface DiagnosisResultListProps {
+  /** API recommended 배열 (예: ["통합공공임대 : 청년 특별공급", "통합공공임대 : 신혼부부 특별공급"]) */
+  recommended: string[];
+  className?: string;
+}
+
+const SECTION_TITLE = "신청 가능한 임대주택";
+
+/** "통합공공임대 : 청년 특별공급" 형태를 { housingType, applicationType } 로 파싱 */
+function parseRecommendedItem(item: string): { housingType: string; applicationType: string } {
+  const sep = " : ";
+  const idx = item.indexOf(sep);
+  if (idx === -1) {
+    return { housingType: item.trim(), applicationType: "" };
+  }
+  return {
+    housingType: item.slice(0, idx).trim(),
+    applicationType: item.slice(idx + sep.length).trim(),
+  };
+}
+
+/** recommended 배열을 housingType 기준으로 묶어서, 유형별 신청 가능 유형 목록으로 변환 */
+function groupByHousingType(
+  recommended: string[]
+): Array<{ housingType: string; applicationTypes: string[] }> {
+  const map = new Map<string, Set<string>>();
+  for (const raw of recommended) {
+    const { housingType, applicationType } = parseRecommendedItem(raw);
+    if (!housingType) continue;
+    if (!map.has(housingType)) map.set(housingType, new Set());
+    if (applicationType) map.get(housingType)!.add(applicationType);
+  }
+  return Array.from(map.entries()).map(([housingType, set]) => ({
+    housingType,
+    applicationTypes: Array.from(set),
+  }));
+}
+
+export const DiagnosisResultList = ({
+  recommended,
+  className,
+}: DiagnosisResultListProps) => {
+  const items = useMemo(() => groupByHousingType(recommended), [recommended]);
+
+  if (items.length === 0) return null;
+
+  return (
+    <section className={className} aria-labelledby="diagnosis-result-list-title">
+      <h2
+        id="diagnosis-result-list-title"
+        className="mb-3 text-lg font-bold leading-[140%] tracking-[-0.02em] text-greyscale-grey-900"
+      >
+        {SECTION_TITLE}
+      </h2>
+      <ul className="flex flex-col gap-3" role="list">
+        {items.map(({ housingType, applicationTypes }) => (
+          <li key={housingType}>
+            <DiagnosisResultItem
+              housingType={housingType}
+              description={
+                HOUSING_TYPE_DESCRIPTIONS[housingType] ??
+                "해당 유형의 공공임대주택입니다."
+              }
+              applicationTypes={applicationTypes}
+            />
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+};

--- a/src/features/eligibility/ui/result/index.ts
+++ b/src/features/eligibility/ui/result/index.ts
@@ -2,3 +2,10 @@ export { EligibilityResultBanner } from "./eligibilityResultBanner";
 export type { EligibilityResultBannerProps } from "./eligibilityResultBanner";
 export { EligibilityResultList } from "./eligibilityResultList";
 export type { EligibilityResultListProps } from "./eligibilityResultList";
+
+export { DiagnosisResultBanner } from "./diagnosisResultBanner";
+export type { DiagnosisResultBannerProps } from "./diagnosisResultBanner";
+export { DiagnosisResultItem } from "./diagnosisResultItem";
+export type { DiagnosisResultItemProps } from "./diagnosisResultItem";
+export { DiagnosisResultList } from "./diagnosisResultList";
+export type { DiagnosisResultListProps } from "./diagnosisResultList";

--- a/src/features/home/ui/homeActionCardList.tsx
+++ b/src/features/home/ui/homeActionCardList.tsx
@@ -1,12 +1,13 @@
 "use client";
 import { ArrowUpRight } from "@/src/assets/icons/button/arrowUpRight";
 import { useNoticeCount, useRecommendedNotice } from "@/src/entities/home/hooks/homeHooks";
-import { useRouter } from "next/navigation";
 import { useHomeActionCard } from "@/src/features/home/ui/homeUseHooks/homeUseHooks";
+import { useDiagnosisResultStore } from "@/src/features/eligibility/model/diagnosisResultStore";
 
 export const ActionCardList = () => {
   const { data } = useNoticeCount();
   const { data: recommend } = useRecommendedNotice();
+  const hasDiagnosisResult = useDiagnosisResultStore(state => state.result != null);
 
   const count = data?.count;
   const { onListingsPageMove, onEligibilityPageMove } = useHomeActionCard();
@@ -46,13 +47,13 @@ export const ActionCardList = () => {
 
         <div className="flex gap-2 text-xl leading-tight">
           <p className="font-bold text-white">
-            {recommend?.pages?.length ? recommend?.pages?.length : "0"}건
+            {recommend?.pages?.[0]?.totalElements ?? 0}건
           </p>
           <span
             className="flex items-center rounded-xl bg-greyscale-grey-25 p-1 text-xs font-bold"
             style={{ color: "#FFBA18" }}
           >
-            <p>0% 완료</p>
+            <p>{hasDiagnosisResult ? "100% 완료" : "0% 완료"}</p>
           </span>
         </div>
       </div>

--- a/src/features/mypage/model/mypageConstants.ts
+++ b/src/features/mypage/model/mypageConstants.ts
@@ -35,6 +35,11 @@ export const MYPAGE_PIN_REPORT_DESCRIPTION_LINES = [
   "맞춤 보고서를 받아보세요",
 ] as const;
 export const MYPAGE_PIN_REPORT_BUTTON = "자격진단 하러가기";
+export const MYPAGE_PIN_REPORT_REDIAGNOSIS = "재진단";
+export const MYPAGE_PIN_REPORT_VIEW_DETAIL = "자세히 보기";
+export const MYPAGE_PIN_REPORT_INCOME_LABEL = "내 소득분위";
+export const MYPAGE_PIN_REPORT_TARGET_LABEL = "나의 지원 가능 대상";
+export const MYPAGE_PIN_REPORT_HOUSING_LABEL = "신청 가능한 임대주택";
 
 /** 설정 화면 (settings) */
 export const MYPAGE_SETTINGS_TITLE = "설정";

--- a/src/features/mypage/ui/pinReportSection.tsx
+++ b/src/features/mypage/ui/pinReportSection.tsx
@@ -1,21 +1,145 @@
 "use client";
 
+import { useMemo } from "react";
+import { ChevronRight, RefreshCw } from "lucide-react";
 import { Button } from "@/src/shared/lib/headlessUi";
 import {
   MYPAGE_PIN_REPORT_BUTTON,
   MYPAGE_PIN_REPORT_DESCRIPTION_LINES,
   MYPAGE_PIN_REPORT_TITLE,
+  MYPAGE_PIN_REPORT_REDIAGNOSIS,
+  MYPAGE_PIN_REPORT_VIEW_DETAIL,
+  MYPAGE_PIN_REPORT_INCOME_LABEL,
+  MYPAGE_PIN_REPORT_TARGET_LABEL,
+  MYPAGE_PIN_REPORT_HOUSING_LABEL,
 } from "@/src/features/mypage/model/mypageConstants";
+import type { DiagnosisResultData } from "@/src/features/eligibility/api/diagnosisTypes";
+import { useDiagnosisResultStore } from "@/src/features/eligibility/model/diagnosisResultStore";
 
 interface PinReportSectionProps {
+  /** 자격진단 최신 결과. 있으면 요약 카드, 없으면 '자격진단 하러가기' 빈 상태 표시 */
+  diagnosisResult: DiagnosisResultData | null;
   onDiagnosisClick?: () => void;
+  onRediagnosisClick?: () => void;
+  onViewDetailClick?: () => void;
 }
 
 const PIN_REPORT_HEADING_ID = "pin-report-heading";
+const TAG_CLASS =
+  "inline-flex items-center rounded-full bg-primary-blue-100 px-2.5 py-1 text-xs font-medium text-primary-blue-700";
+
+/** recommended 항목에서 housingType만 추출 (예: "통합공공임대 : 청년 특별공급" → "통합공공임대") */
+function getUniqueHousingTypes(recommended: string[]): string[] {
+  const set = new Set<string>();
+  const sep = " : ";
+  for (const raw of recommended) {
+    const idx = raw.indexOf(sep);
+    const housingType = (idx === -1 ? raw : raw.slice(0, idx)).trim();
+    if (housingType) set.add(housingType);
+  }
+  return Array.from(set);
+}
 
 export const PinReportSection = ({
+  diagnosisResult,
   onDiagnosisClick,
+  onRediagnosisClick,
+  onViewDetailClick,
 }: PinReportSectionProps) => {
+  const storeIncomeLevel = useDiagnosisResultStore(s => s.incomeLevel);
+
+  const hasResult = diagnosisResult != null && Array.isArray(diagnosisResult.recommended);
+  const incomeLevel =
+    diagnosisResult?.incomeLevel ?? storeIncomeLevel ?? null;
+  const targetGroups = diagnosisResult?.targetGroups ?? [];
+  const housingTypes = useMemo(
+    () =>
+      hasResult && diagnosisResult?.recommended?.length
+        ? getUniqueHousingTypes(diagnosisResult.recommended)
+        : [],
+    [hasResult, diagnosisResult?.recommended]
+  );
+
+  if (hasResult) {
+    return (
+      <section
+        aria-labelledby={PIN_REPORT_HEADING_ID}
+        className="flex flex-col rounded-lg bg-white"
+      >
+        <div className="flex items-center justify-between border-b border-greyscale-grey-50 px-4 py-4">
+          <h2
+            id={PIN_REPORT_HEADING_ID}
+            className="text-base font-bold leading-[140%] tracking-[-0.02em] text-greyscale-grey-900"
+          >
+            {MYPAGE_PIN_REPORT_TITLE}
+          </h2>
+          <button
+            type="button"
+            onClick={onRediagnosisClick}
+            className="flex items-center gap-1 text-sm font-medium text-greyscale-grey-500 hover:text-greyscale-grey-700"
+          >
+            <RefreshCw className="h-4 w-4" aria-hidden />
+            {MYPAGE_PIN_REPORT_REDIAGNOSIS}
+          </button>
+        </div>
+
+        <div className="flex flex-col gap-4 px-4 py-5">
+          {incomeLevel != null && incomeLevel !== "" && (
+            <div>
+              <h3 className="mb-2 text-sm font-bold leading-[140%] tracking-[-0.02em] text-greyscale-grey-900">
+                {MYPAGE_PIN_REPORT_INCOME_LABEL}
+              </h3>
+              <span className={TAG_CLASS}>{incomeLevel}</span>
+            </div>
+          )}
+
+          {targetGroups.length > 0 && (
+            <div>
+              <h3 className="mb-2 text-sm font-bold leading-[140%] tracking-[-0.02em] text-greyscale-grey-900">
+                {MYPAGE_PIN_REPORT_TARGET_LABEL}
+              </h3>
+              <div className="flex flex-wrap gap-2">
+                {targetGroups.map(label => (
+                  <span key={label} className={TAG_CLASS}>
+                    {label}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {housingTypes.length > 0 && (
+            <div>
+              <h3 className="mb-2 text-sm font-bold leading-[140%] tracking-[-0.02em] text-greyscale-grey-900">
+                {MYPAGE_PIN_REPORT_HOUSING_LABEL}
+              </h3>
+              <div className="flex flex-wrap gap-2">
+                {housingTypes.map(name => (
+                  <span key={name} className={TAG_CLASS}>
+                    {name}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {onViewDetailClick && (
+            <div className="flex justify-center pt-2">
+              <button
+                type="button"
+                onClick={onViewDetailClick}
+                className="flex items-center gap-1 text-sm font-bold text-primary-blue-600 hover:underline"
+              >
+                {MYPAGE_PIN_REPORT_VIEW_DETAIL}
+                <ChevronRight className="h-4 w-4" aria-hidden />
+              </button>
+            </div>
+          )}
+        </div>
+      </section>
+    );
+  }
+
   return (
     <section
       aria-labelledby={PIN_REPORT_HEADING_ID}

--- a/src/shared/api/endpoints.ts
+++ b/src/shared/api/endpoints.ts
@@ -93,8 +93,10 @@ export const COMPLEX_INFRA_ENDPOINT = "/complexes/infra";
  * 진단 API
  */
 
-// 청약 진단 API
+// 청약 진단 API (v2)
 export const DIAGNOSIS_ENDPOINT = "/diagnosis";
+// 청약 진단 최신 결과 조회 (v2)
+export const DIAGNOSIS_LATEST_ENDPOINT = "/diagnosis/latest";
 
 // 질문 설명 API
 export const DIAGNOSIS_INFO_ENDPOINT = "/diagnosis/info";

--- a/src/shared/api/http.ts
+++ b/src/shared/api/http.ts
@@ -46,6 +46,12 @@ const processQueue = (error: any, token: string | null = null) => {
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_URL;
 
+/** v1 base URL을 v2로 치환 (특정 API만 v2 사용 시 baseURL 옵션으로 전달) */
+export const API_BASE_URL_V2 =
+  typeof process.env.NEXT_PUBLIC_API_URL === "string"
+    ? process.env.NEXT_PUBLIC_API_URL.replace(/\/v1\/?$/, "/v2")
+    : "";
+
 const api: AxiosInstance = axios.create({
   baseURL: BASE_URL,
   withCredentials: true,

--- a/src/shared/lib/headlessUi/modal/dialog.tsx
+++ b/src/shared/lib/headlessUi/modal/dialog.tsx
@@ -32,32 +32,45 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 type DialogContentProps = React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
   overlayClassName?: string;
   showCloseButton?: boolean;
+  /** When set, portal and overlay/content are rendered inside this element with absolute positioning (e.g. mobile frame). */
+  container?: HTMLElement | null;
 };
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   DialogContentProps
->(({ className, children, overlayClassName, showCloseButton = true, ...props }, ref) => (
-  <DialogPortal>
-    <DialogOverlay className={overlayClassName} />
-    <DialogPrimitive.Content
-      ref={ref}
-      className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
-        className
-      )}
-      {...props}
-    >
-      {children}
-      {showCloseButton && (
-        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-          <X className="h-4 w-4" />
-          <span className="sr-only">Close</span>
-        </DialogPrimitive.Close>
-      )}
-    </DialogPrimitive.Content>
-  </DialogPortal>
-));
+>(({ className, children, overlayClassName, showCloseButton = true, container, ...props }, ref) => {
+  const isInsideContainer = Boolean(container);
+  const contentPositionClass = isInsideContainer
+    ? "absolute left-[50%] top-[50%] translate-x-[-50%] translate-y-[-50%]"
+    : "fixed left-[50%] top-[50%] translate-x-[-50%] translate-y-[-50%]";
+  const overlayMergedClassName = isInsideContainer
+    ? cn("!absolute inset-0", overlayClassName?.replace(/\bfixed\b/g, "absolute"))
+    : overlayClassName;
+
+  return (
+    <DialogPortal container={container ?? undefined}>
+      <DialogOverlay className={overlayMergedClassName} />
+      <DialogPrimitive.Content
+        ref={ref}
+        className={cn(
+          contentPositionClass,
+          "z-50 grid w-full max-w-lg gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+            <X className="h-4 w-4" />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+});
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
 const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (

--- a/src/shared/ui/errorState/ErrorState.tsx
+++ b/src/shared/ui/errorState/ErrorState.tsx
@@ -29,10 +29,7 @@ export const ErrorState = ({
 
   return (
     <div
-      className={
-        className ??
-        "flex h-full min-h-screen flex-col items-center justify-center px-5"
-      }
+      className={className ?? "flex h-full min-h-screen flex-col items-center justify-center px-5"}
     >
       <AnimatePresence mode="wait">
         <motion.div
@@ -64,7 +61,7 @@ export const ErrorState = ({
             className="mt-4 w-full max-w-[200px]"
             onClick={handleButtonClick}
           >
-            home으로 돌아가기
+            홈으로 돌아가기
           </Button>
         </motion.div>
       </AnimatePresence>

--- a/src/shared/ui/header/header/rightIconDefaultHeader/rightIconDefaultHeader.tsx
+++ b/src/shared/ui/header/header/rightIconDefaultHeader/rightIconDefaultHeader.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { CloseButton, LeftButton } from "@/src/assets/icons/button";
+
+type RightIconDefaultHeaderProps = {
+  title: string;
+  onRightClick: () => void;
+};
+
+export const RightIconDefaultHeader = ({ title, onRightClick }: RightIconDefaultHeaderProps) => {
+  return (
+    <div className="flex w-full flex-row-reverse items-center justify-start gap-2">
+      <p className="font-suit absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 font-bold">
+        {title}
+      </p>
+      <CloseButton
+        onClick={onRightClick}
+        className="h-7 w-7 cursor-pointer justify-end text-greyscale-grey-200"
+      />
+    </div>
+  );
+};

--- a/src/shared/ui/header/index.ts
+++ b/src/shared/ui/header/index.ts
@@ -1,1 +1,2 @@
 export * from "@/src/shared/ui/header/header/defaultHeader/defaultHeader";
+export * from "@/src/shared/ui/header/header/rightIconDefaultHeader/rightIconDefaultHeader";

--- a/src/shared/ui/modal/default/modal.tsx
+++ b/src/shared/ui/modal/default/modal.tsx
@@ -1,5 +1,9 @@
+"use client";
+
+import { useState, useLayoutEffect } from "react";
 import { cn } from "@/src/shared/lib/utils";
 import { Dialog, DialogContent, DialogTitle } from "@/src/shared/lib/headlessUi/modal/dialog";
+import { useMobileSheetPortal } from "@/src/shared/context/mobileSheetPortalContext";
 
 import { discription, modalContainerPreset, modalOverlayPreset } from "../preset";
 import { ModalProps } from "./type";
@@ -13,17 +17,32 @@ export const Modal = ({
   overlayClassName,
   onButtonClick,
   confirmButtonDisabled = false,
+  showCloseButton = false,
+  onClose,
 }: ModalProps) => {
+  const portalRef = useMobileSheetPortal();
+  const [container, setContainer] = useState<HTMLElement | null>(null);
+
+  useLayoutEffect(() => {
+    if (portalRef?.current) setContainer(portalRef.current);
+  }, [portalRef]);
+
   if (!open) return null;
 
   const modalScript = discription[type];
 
   return (
-    <Dialog open={open}>
+    <Dialog
+      open={open}
+      onOpenChange={value => {
+        if (!value) onClose?.();
+      }}
+    >
       <DialogContent
         className={cn(modalContainerPreset, className)}
         overlayClassName={cn(modalOverlayPreset, overlayClassName)}
-        showCloseButton={false}
+        showCloseButton={showCloseButton}
+        container={container}
       >
         <div className="flex flex-col gap-5">
           <DialogTitle className="text-md mt-1 whitespace-pre-line text-center font-bold">
@@ -31,20 +50,25 @@ export const Modal = ({
           </DialogTitle>
 
           <div className="flex items-center justify-center gap-2">
-            {modalScript?.btnlabel?.map((item, index) => (
-              <Button
-                key={item}
-                type="button"
-                variant={index === 0 ? "outline" : "solid"}
-                theme={index === 0 ? "black" : "mainBlue"}
-                size="sm"
-                className={cn("min-w-[140px] flex-1")}
-                disabled={index === 1 ? confirmButtonDisabled : undefined}
-                onClick={() => onButtonClick?.(index, item)}
-              >
-                {item}
-              </Button>
-            ))}
+            {modalScript?.btnlabel?.map((item, index) => {
+              const isSinglePrimary = (modalScript?.btnlabel?.length ?? 0) === 1;
+              const variant = isSinglePrimary ? "solid" : index === 0 ? "outline" : "solid";
+              const theme = isSinglePrimary ? "mainBlue" : index === 0 ? "black" : "mainBlue";
+              return (
+                <Button
+                  key={item}
+                  type="button"
+                  variant={variant}
+                  theme={theme}
+                  size="sm"
+                  className={cn("min-w-[130px] flex-1")}
+                  disabled={index === 1 ? confirmButtonDisabled : undefined}
+                  onClick={() => onButtonClick?.(index, item)}
+                >
+                  {item}
+                </Button>
+              );
+            })}
           </div>
         </div>
       </DialogContent>

--- a/src/shared/ui/modal/default/type.ts
+++ b/src/shared/ui/modal/default/type.ts
@@ -20,4 +20,8 @@ export interface ModalProps {
   onButtonClick?: (buttonIndex: number, buttonLabel: string) => void;
   /** 확인(두 번째) 버튼 비활성화 (예: 제출 중) */
   confirmButtonDisabled?: boolean;
+  /** 우측 상단 X 버튼 노출 여부. true일 때만 표시 */
+  showCloseButton?: boolean;
+  /** X 버튼 또는 외부 클릭으로 닫을 때 호출 (showCloseButton 사용 시 상태 정리용) */
+  onClose?: () => void;
 }

--- a/src/shared/ui/modal/preset.ts
+++ b/src/shared/ui/modal/preset.ts
@@ -5,7 +5,7 @@ export const modalOverlayPreset =
 
 export const modalContainerPreset = [
   "rounded-xl sm:rounded-xl bg-white p-6 shadow-lg transition-all",
-  "w-[90%] min-w-[322px] sm:w-[322px] md:w-[400px] lg:w-[500px]",
+  "w-[90%] min-w-[280px] sm:w-[300px] md:w-[320px]",
 ] as const;
 
 export const filterScript: ModalDescriptProps = {
@@ -33,10 +33,22 @@ export const withdrawConfirmScript: ModalDescriptProps = {
   btnlabel: ["취소", "탈퇴하기"],
 };
 
+export const eligibilityPreviousDiagnosisScript: ModalDescriptProps = {
+  descript: "이전에 진행한 진단 이력이 있어요!\n 새로 시작할까요?",
+  btnlabel: ["새로 시작하기", "결과보기"],
+};
+
+export const eligibilityDiagnosisGoScript: ModalDescriptProps = {
+  descript: "자격진단으로\n나에게 맞는 공고를 확인해볼까요?",
+  btnlabel: ["자격진단 하러가기"],
+};
+
 export const discription: ModalDescriptMap = {
   filterSearch: filterScript,
   quickSearchEnterCheck: quickSearchEnterCheckScript,
   quickSearchSaveCheck: quickSearchSaveCheckScript,
   quickSearchResetAlert: quickSearchResetAlertScript,
   withdrawConfirm: withdrawConfirmScript,
+  eligibilityPreviousDiagnosis: eligibilityPreviousDiagnosisScript,
+  eligibilityDiagnosisGo: eligibilityDiagnosisGoScript,
 };

--- a/src/widgets/eligibilitySection/index.ts
+++ b/src/widgets/eligibilitySection/index.ts
@@ -1,2 +1,3 @@
 export { EligibilitySection } from "./ui/eligibilitySection";
 export { EligibilityResultSection } from "./ui/eligibilityResultSection";
+export { EligibilityFinalResultSection } from "./ui/eligibilityFinalResultSection";

--- a/src/widgets/eligibilitySection/ui/eligibilityFinalResultSection.tsx
+++ b/src/widgets/eligibilitySection/ui/eligibilityFinalResultSection.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useMemo } from "react";
+import { useRouter } from "next/navigation";
+import { useDiagnosisResultStore } from "@/src/features/eligibility/model/diagnosisResultStore";
+import { DiagnosisResultBanner, DiagnosisResultList } from "@/src/features/eligibility/ui/result";
+import { RightIconDefaultHeader } from "@/src/shared/ui/header";
+import { ErrorState } from "@/src/shared/ui/errorState";
+import { useOAuthStore } from "@/src/features/login/model/authStore";
+import { PageTransition } from "@/src/shared/ui/animation/pageTransition";
+
+const FINAL_RESULT_PAGE_TITLE = "진단 결과";
+const INELIGIBLE_MESSAGE = "조건 미충족으로 인해 자격미달입니다.";
+const NULL_RESULT_MESSAGE = "결과가 없습니다.";
+
+/** "통합공공임대 : 청년 특별공급" 에서 신청 유형만 추출 (배너 요약용) */
+function getApplicationTypeSummary(recommended: string[], maxCount = 3): string[] {
+  const sep = " : ";
+  const set = new Set<string>();
+  for (const raw of recommended) {
+    const idx = raw.indexOf(sep);
+    const applicationType = idx === -1 ? raw.trim() : raw.slice(idx + sep.length).trim();
+    if (applicationType) set.add(applicationType);
+    if (set.size >= maxCount) break;
+  }
+  return Array.from(set);
+}
+
+export const EligibilityFinalResultSection = () => {
+  const router = useRouter();
+  const result = useDiagnosisResultStore(s => s.result);
+  const incomeLevel = useDiagnosisResultStore(s => s.incomeLevel);
+  const { userName } = useOAuthStore();
+
+  const applicationTypeSummary = useMemo(
+    () => (result?.recommended ? getApplicationTypeSummary(result.recommended) : []),
+    [result?.recommended]
+  );
+
+  const showErrorState = result === null || !result.eligible;
+
+  if (showErrorState) {
+    return (
+      <section className="flex h-full flex-col">
+        <PageTransition>
+          <header
+            className="relative flex items-center bg-white px-5 py-4"
+            aria-label={FINAL_RESULT_PAGE_TITLE}
+          >
+            <RightIconDefaultHeader
+              title={FINAL_RESULT_PAGE_TITLE}
+              onRightClick={() => router.push("/home")}
+            />
+          </header>
+          <div className="flex min-h-0 flex-1 flex-col items-center justify-center bg-greyscale-grey-25 px-5">
+            <ErrorState
+              text={result === null ? NULL_RESULT_MESSAGE : INELIGIBLE_MESSAGE}
+              className="flex h-full min-h-0 w-full flex-col items-center justify-center px-0"
+            />
+          </div>
+        </PageTransition>
+      </section>
+    );
+  }
+
+  return (
+    <section className="flex h-full flex-col">
+      <PageTransition>
+        <header
+          className="relative flex items-center bg-white px-5 py-4"
+          aria-label={FINAL_RESULT_PAGE_TITLE}
+        >
+          <RightIconDefaultHeader
+            title={FINAL_RESULT_PAGE_TITLE}
+            onRightClick={() => router.push("/home")}
+          />
+        </header>
+        <div className="flex flex-1 flex-col gap-4 bg-greyscale-grey-25 px-5 pb-5">
+          <DiagnosisResultBanner
+            userName={userName ?? "회원"}
+            incomeLevel={incomeLevel}
+            applicationTypeSummary={applicationTypeSummary}
+          />
+          {result.recommended.length > 0 && (
+            <DiagnosisResultList recommended={result.recommended} />
+          )}
+        </div>
+      </PageTransition>
+    </section>
+  );
+};

--- a/src/widgets/eligibilitySection/ui/eligibilityResultSection.tsx
+++ b/src/widgets/eligibilitySection/ui/eligibilityResultSection.tsx
@@ -2,6 +2,9 @@
 
 import { useRouter } from "next/navigation";
 import { useEligibilityStore } from "@/src/features/eligibility/model/eligibilityStore";
+import { useDiagnosisResult } from "@/src/features/eligibility/hooks/useDiagnosisResult";
+import { useDiagnosisResultStore } from "@/src/features/eligibility/model/diagnosisResultStore";
+import { mapEligibilityToDiagnosisRequest } from "@/src/features/eligibility/api/mapEligibilityToDiagnosisRequest";
 import {
   ELIGIBILITY_RESULT_BUTTON,
   ELIGIBILITY_RESULT_PAGE_TITLE,
@@ -10,39 +13,74 @@ import {
   EligibilityResultBanner,
   EligibilityResultList,
 } from "@/src/features/eligibility/ui/result";
+import EligibilityLoadingState from "@/src/features/eligibility/ui/common/eligibilityLoadingState";
 import { DefaultHeader } from "@/src/shared/ui/header";
 import { Button } from "@/src/shared/lib/headlessUi/button/button";
 import { useOAuthStore } from "@/src/features/login/model/authStore";
+import { toast } from "sonner";
+import { PageTransition } from "@/src/shared/ui/animation/pageTransition";
 
 export const EligibilityResultSection = () => {
   const router = useRouter();
   const data = useEligibilityStore();
   const { userName } = useOAuthStore();
+  const { submit, isLoading, error } = useDiagnosisResult();
+  const setDiagnosisResult = useDiagnosisResultStore(s => s.setResult);
+
+  const handleResultClick = async () => {
+    try {
+      const resultData = await submit();
+      if (resultData) {
+        const body = mapEligibilityToDiagnosisRequest(data);
+        setDiagnosisResult(resultData, { incomeLevel: body.incomeLevel });
+        router.push("/eligibility/result/final");
+      } else {
+        toast.error("진단 결과를 받지 못했어요. 다시 시도해 주세요.");
+      }
+    } catch {
+      toast.error("진단 요청에 실패했어요. 다시 시도해 주세요.");
+    }
+  };
 
   return (
     <section className="flex h-full flex-col">
-      <header
-        className="relative flex items-center bg-white px-5 py-4"
-        aria-label={ELIGIBILITY_RESULT_PAGE_TITLE}
-      >
-        <DefaultHeader title={ELIGIBILITY_RESULT_PAGE_TITLE} path="/eligibility" />
-      </header>
-      <div className="flex flex-1 flex-col gap-4 bg-greyscale-grey-25 px-5 pb-5">
-        <EligibilityResultBanner userName={userName} />
-        <EligibilityResultList data={data} />
-      </div>
-      <div className="bg-greyscale-grey-25 px-5">
-        <Button
-          type="button"
-          variant="capsule"
-          size="lg"
-          theme="mainBlue"
-          radius="xl"
-          onClick={() => router.push("/eligibility/report")}
+      <PageTransition>
+        <header
+          className="relative flex items-center bg-white px-5 py-4"
+          aria-label={ELIGIBILITY_RESULT_PAGE_TITLE}
         >
-          {ELIGIBILITY_RESULT_BUTTON}
-        </Button>
-      </div>
+          <DefaultHeader title={ELIGIBILITY_RESULT_PAGE_TITLE} path="/eligibility" />
+        </header>
+        {isLoading ? (
+          <div className="flex flex-1 flex-col">
+            <EligibilityLoadingState />
+          </div>
+        ) : (
+          <>
+            <div className="flex flex-1 flex-col gap-4 bg-greyscale-grey-25 px-5 pb-5">
+              <EligibilityResultBanner userName={userName} />
+              <EligibilityResultList data={data} />
+            </div>
+            <div className="bg-greyscale-grey-25 px-5">
+              <Button
+                type="button"
+                variant="capsule"
+                size="lg"
+                theme="mainBlue"
+                radius="xl"
+                onClick={handleResultClick}
+              >
+                {ELIGIBILITY_RESULT_BUTTON}
+              </Button>
+              {error && (
+                <p className="mt-2 text-sm text-red-500" role="alert">
+                  {error.message}
+                </p>
+              )}
+            </div>
+          </>
+        )}
+      </PageTransition>
     </section>
   );
 };

--- a/src/widgets/eligibilitySection/ui/eligibilitySection.tsx
+++ b/src/widgets/eligibilitySection/ui/eligibilitySection.tsx
@@ -32,22 +32,24 @@ export const EligibilitySection = () => {
 
   return (
     <section className="flex h-full w-full flex-col">
-      {/* Stepper */}
-      {ELIGIBILITY_STEPS.length > 0 && currentGroup && (
-        <div className="px-5 pt-5">
-          <EligibilityStepper steps={ELIGIBILITY_STEPS} currentStepId={groupId} />
-        </div>
-      )}
-
       <PageTransition>
-        {/* 단계별 폼 컴포넌트 */}
-        <EligibilityStepRenderer stepId={currentStepId} />
-      </PageTransition>
+        {/* Stepper */}
+        {ELIGIBILITY_STEPS.length > 0 && currentGroup && (
+          <div className="px-5 pt-5">
+            <EligibilityStepper steps={ELIGIBILITY_STEPS} currentStepId={groupId} />
+          </div>
+        )}
 
-      {/* 다음 버튼 */}
-      <div className="w-full flex-none px-5 pb-3">
-        <EligibilityNextButton />
-      </div>
+        <PageTransition>
+          {/* 단계별 폼 컴포넌트 */}
+          <EligibilityStepRenderer stepId={currentStepId} />
+        </PageTransition>
+
+        {/* 다음 버튼 */}
+        <div className="w-full flex-none px-5 pb-3">
+          <EligibilityNextButton />
+        </div>
+      </PageTransition>
     </section>
   );
 };

--- a/src/widgets/mypageSection/ui/PinpointsSection.tsx
+++ b/src/widgets/mypageSection/ui/PinpointsSection.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/src/features/mypage/model/mypageConstants";
 import { Button } from "@/src/shared/lib/headlessUi";
 import { DefaultHeader } from "@/src/shared/ui/header";
+import { PageTransition } from "@/src/shared/ui/animation/pageTransition";
 
 /**
  * 마이페이지 핀포인트 설정 화면 위젯
@@ -42,37 +43,40 @@ export const PinpointsSection = () => {
 
   return (
     <div>
-        <header className="relative flex items-center py-4 px-5" aria-label={MYPAGE_PINPOINTS_HEADER_TITLE}>
-            <DefaultHeader title={MYPAGE_PINPOINTS_HEADER_TITLE} path="/mypage" />
+      <PageTransition>
+        <header
+          className="relative flex items-center px-5 py-4"
+          aria-label={MYPAGE_PINPOINTS_HEADER_TITLE}
+        >
+          <DefaultHeader title={MYPAGE_PINPOINTS_HEADER_TITLE} path="/mypage" />
         </header>
         <div className="border-b border-greyscale-grey-25"></div>
-        <div className="mb-3 flex flex-1 flex-col items-center justify-start text-center px-5">
-            <div className="inline-flex sm:min-w-[200px] sm:max-w-[250px] md:min-w-[250px] md:max-w-[300px] lg:min-w-[280px] lg:max-w-[340px]">
+        <div className="mb-3 flex flex-1 flex-col items-center justify-start px-5 text-center">
+          <div className="inline-flex sm:min-w-[200px] sm:max-w-[250px] md:min-w-[250px] md:max-w-[300px] lg:min-w-[280px] lg:max-w-[340px]">
             <MapPin />
-            </div>
-            <h2 className="text-lg font-bold text-greyscale-grey-900">
-            {MYPAGE_LABEL_PINPOINTS}
-            </h2>
-            <p className="mt-1 whitespace-pre-line text-center text-sm text-greyscale-grey-500">
+          </div>
+          <h2 className="text-lg font-bold text-greyscale-grey-900">{MYPAGE_LABEL_PINPOINTS}</h2>
+          <p className="mt-1 whitespace-pre-line text-center text-sm text-greyscale-grey-500">
             {MYPAGE_PINPOINTS_DESCRIPTION}
-            </p>
-            <div className="mt-5 w-full">
+          </p>
+          <div className="mt-5 w-full">
             <AddressSearch />
-            </div>
+          </div>
         </div>
         {address ? (
-            <div className="px-5">
+          <div className="px-5">
             <Button
-            type="button"
-            size="md"
-            variant="solid"
-            disabled={isLoading}
-            onClick={handleAddPinpoint}
+              type="button"
+              size="md"
+              variant="solid"
+              disabled={isLoading}
+              onClick={handleAddPinpoint}
             >
-            {MYPAGE_PINPOINTS_ADD_BUTTON}
+              {MYPAGE_PINPOINTS_ADD_BUTTON}
             </Button>
-            </div>
+          </div>
         ) : null}
+      </PageTransition>
     </div>
   );
 };

--- a/src/widgets/mypageSection/ui/ProfileSection.tsx
+++ b/src/widgets/mypageSection/ui/ProfileSection.tsx
@@ -8,6 +8,7 @@ import {
   MYPAGE_PROFILE_LOADING_TITLE,
 } from "@/src/features/mypage/model/mypageConstants";
 import { ProfileForm } from "@/src/features/mypage/ui";
+import { PageTransition } from "@/src/shared/ui/animation/pageTransition";
 import { ErrorState } from "@/src/shared/ui/errorState";
 import { DefaultHeader } from "@/src/shared/ui/header";
 import { LoadingState } from "@/src/shared/ui/loadingState";
@@ -41,15 +42,18 @@ export const ProfileSection = () => {
 
   return (
     <div className="flex min-h-screen flex-col bg-white">
-        <header className="relative flex items-center py-4 px-5" aria-label={MYPAGE_PROFILE_HEADER_TITLE}>
-            <DefaultHeader title={MYPAGE_PROFILE_HEADER_TITLE} path="/mypage/settings" />
+      <PageTransition>
+        <header
+          className="relative flex items-center px-5 py-4"
+          aria-label={MYPAGE_PROFILE_HEADER_TITLE}
+        >
+          <DefaultHeader title={MYPAGE_PROFILE_HEADER_TITLE} path="/mypage/settings" />
         </header>
         <div className="border-b border-greyscale-grey-25"></div>
         <div className="px-5 py-6">
-            <ProfileForm
-            user={data}
-            />
+          <ProfileForm user={data} />
         </div>
+      </PageTransition>
     </div>
   );
 };

--- a/src/widgets/mypageSection/ui/SettingsSection.tsx
+++ b/src/widgets/mypageSection/ui/SettingsSection.tsx
@@ -7,10 +7,8 @@ import {
   MYPAGE_SETTINGS_TITLE,
   MYPAGE_SETTINGS_WITHDRAW,
 } from "@/src/features/mypage/model/mypageConstants";
-import {
-  MypageSettingsMenu,
-  type MypageSettingsMenuItem,
-} from "@/src/features/mypage/ui";
+import { MypageSettingsMenu, type MypageSettingsMenuItem } from "@/src/features/mypage/ui";
+import { PageTransition } from "@/src/shared/ui/animation/pageTransition";
 import { DefaultHeader } from "@/src/shared/ui/header";
 
 /**
@@ -26,13 +24,15 @@ export const SettingsSection = () => {
 
   return (
     <div className="flex min-h-screen flex-col bg-white">
-      <header className="relative flex items-center py-4 px-5" aria-label={MYPAGE_SETTINGS_TITLE}>
-        <DefaultHeader title={MYPAGE_SETTINGS_TITLE} path="/mypage" />
-      </header>
-      <div className="border-b border-greyscale-grey-25"></div>
-      <div className="px-5">
-        <MypageSettingsMenu items={menuItems} />
-      </div>
+      <PageTransition>
+        <header className="relative flex items-center px-5 py-4" aria-label={MYPAGE_SETTINGS_TITLE}>
+          <DefaultHeader title={MYPAGE_SETTINGS_TITLE} path="/mypage" />
+        </header>
+        <div className="border-b border-greyscale-grey-25"></div>
+        <div className="px-5">
+          <MypageSettingsMenu items={menuItems} />
+        </div>
+      </PageTransition>
     </div>
   );
 };

--- a/src/widgets/mypageSection/ui/WithdrawSection.tsx
+++ b/src/widgets/mypageSection/ui/WithdrawSection.tsx
@@ -2,11 +2,12 @@
 
 import { WithdrawBanner, WithdrawForm } from "@/src/features/mypage/ui";
 import {
-    MYPAGE_WITHDRAW_HEADER_TITLE,
+  MYPAGE_WITHDRAW_HEADER_TITLE,
   WITHDRAW_BANNER_DESCRIPTION,
   WITHDRAW_BANNER_TITLE,
 } from "@/src/features/mypage/model/mypageConstants";
 import { DefaultHeader } from "@/src/shared/ui/header";
+import { PageTransition } from "@/src/shared/ui/animation/pageTransition";
 
 /**
  * 마이페이지 회원 탈퇴 화면 위젯
@@ -14,19 +15,24 @@ import { DefaultHeader } from "@/src/shared/ui/header";
 export const WithdrawSection = () => {
   return (
     <div className="flex min-h-screen flex-col bg-white">
-        <header className="relative flex items-center py-4 px-5" aria-label={MYPAGE_WITHDRAW_HEADER_TITLE}>
-            <DefaultHeader title={MYPAGE_WITHDRAW_HEADER_TITLE} path="/mypage/settings" />
+      <PageTransition>
+        <header
+          className="relative flex items-center px-5 py-4"
+          aria-label={MYPAGE_WITHDRAW_HEADER_TITLE}
+        >
+          <DefaultHeader title={MYPAGE_WITHDRAW_HEADER_TITLE} path="/mypage/settings" />
         </header>
         <div className="border-b border-greyscale-grey-25"></div>
-      <WithdrawBanner
-        className="py-6 px-5"
-        title={WITHDRAW_BANNER_TITLE}
-        description={WITHDRAW_BANNER_DESCRIPTION}
-      />
-      <div className="mb-7 h-[9px] w-full border border-greyscale-grey-50 bg-greyscale-grey-25" />
-      <div className="px-5">
-        <WithdrawForm />
-      </div>
+        <WithdrawBanner
+          className="px-5 py-6"
+          title={WITHDRAW_BANNER_TITLE}
+          description={WITHDRAW_BANNER_DESCRIPTION}
+        />
+        <div className="mb-7 h-[9px] w-full border border-greyscale-grey-50 bg-greyscale-grey-25" />
+        <div className="px-5">
+          <WithdrawForm />
+        </div>
+      </PageTransition>
     </div>
   );
 };


### PR DESCRIPTION
- 모달: 모바일 프레임 내부 렌더 옵션, 300px대·버튼 140px, X 버튼 플래그
- 홈: 자격진단 기준 N건(totalElements), 100%/0% 완료 표시
- 마이페이지: 자격진단 하러가기 확인 모달, 핀 보고서 결과 유무별 카드/빈 상태
- 자격진단 입력 완료 - 로딩 - 결과 임시 화면 개발 완료
- 자격진단 V2/API 연동 완료
- 기존 자격진단 결과 있는 경우 modal 출력하도록 개발 완료

<!--- Pull Request title = 커밋 메시지와 동일/ 해당 이슈를 close 하지 않을 경우, footer #이슈 번호 제외  -->

## #️⃣ Issue Number

#256 