### PR TITLE
fix:핀하우스 Home / 자격진단 및 마이페이지

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -25,6 +25,16 @@ const nextConfig: NextConfig = {
         hostname: "t1.kakaocdn.net",
         pathname: "/**",
       },
+      {
+        protocol: "https",
+        hostname: "k.kakaocdn.net",
+        pathname: "/**",
+      },
+      {
+        protocol: "http",
+        hostname: "k.kakaocdn.net",
+        pathname: "/**",
+      },
     ],
   },
   webpack(config: Configuration) {

--- a/src/features/home/index.ts
+++ b/src/features/home/index.ts
@@ -1,5 +1,5 @@
 export * from "./ui/homeContentsCard";
-export * from "./ui/homeActionCardList";
+export * from "./ui/homeAction/homeActionCardList";
 export * from "./ui/homeContentsCard";
 export * from "./ui/homeHeader";
 export * from "./ui/homeHero";

--- a/src/features/home/ui/homeAction/homeActionCardList.tsx
+++ b/src/features/home/ui/homeAction/homeActionCardList.tsx
@@ -1,0 +1,15 @@
+"use client";
+import { useHomeActionCard } from "@/src/features/home/ui/homeUseHooks/homeUseHooks";
+import { PinpointStandard } from "@/src/features/home/ui/homeAction/pinpointStandard";
+import { QualificationDiagnosis } from "@/src/features/home/ui/homeAction/qualificationdiagnosis";
+
+export const ActionCardList = () => {
+  const { onListingsPageMove, onEligibilityPageMove } = useHomeActionCard();
+
+  return (
+    <div className="mb-4 flex gap-4">
+      <PinpointStandard onListingsPageMove={onListingsPageMove} />
+      <QualificationDiagnosis onEligibilityPageMove={onEligibilityPageMove} />
+    </div>
+  );
+};

--- a/src/features/home/ui/homeAction/pinpointStandard.tsx
+++ b/src/features/home/ui/homeAction/pinpointStandard.tsx
@@ -1,0 +1,35 @@
+import { ArrowUpRight } from "@/src/assets/icons/button/arrowUpRight";
+import { useNoticeCount } from "@/src/entities/home/hooks/homeHooks";
+import { useOAuthStore } from "@/src/features/login/model";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { SliceResponse } from "@/src/entities/home/model/type";
+import { ListingItem } from "@/src/entities/listings/model/type";
+import { getNoticeByPinPoint } from "@/src/entities/home/interface/homeInterface";
+import { HOME_RECOMMENDED_ENDPOINT } from "@/src/shared/api";
+
+type PinpointStandardProps = {
+  onListingsPageMove: () => void;
+};
+
+export const PinpointStandard = ({ onListingsPageMove }: PinpointStandardProps) => {
+  const { data } = useNoticeCount();
+  const count = data?.count;
+  console.log(count);
+  return (
+    <div
+      className="flex min-h-[88px] flex-1 cursor-pointer flex-col justify-between rounded-lg bg-primary-blue-300 px-4 py-3"
+      onClick={onListingsPageMove}
+    >
+      <div className="flex items-center justify-between text-white">
+        <p className="text-sm font-bold leading-tight opacity-[0.7] hover:cursor-pointer">
+          핀포인트 기준
+        </p>
+        <div className="flex items-center justify-center">
+          <ArrowUpRight />
+        </div>
+      </div>
+
+      <p className="text-xl font-bold leading-tight text-white">{count}건</p>
+    </div>
+  );
+};

--- a/src/features/home/ui/homeAction/qualificationdiagnosis.tsx
+++ b/src/features/home/ui/homeAction/qualificationdiagnosis.tsx
@@ -1,0 +1,38 @@
+import { ArrowUpRight } from "@/src/assets/icons/button/arrowUpRight";
+import { useRecommendedNotice } from "@/src/entities/home/hooks/homeHooks";
+
+type QualificationDiagnosisProps = {
+  onEligibilityPageMove: () => void;
+};
+export const QualificationDiagnosis = ({ onEligibilityPageMove }: QualificationDiagnosisProps) => {
+  const { data: recommend } = useRecommendedNotice();
+  const count = recommend?.pages[0]?.totalCount;
+
+  return (
+    <div
+      className="flex min-h-[88px] flex-1 cursor-pointer flex-col justify-between rounded-lg px-4 py-3"
+      style={{ background: "#FFBA18" }}
+      onClick={onEligibilityPageMove}
+    >
+      <div className="flex items-center justify-between text-white">
+        <p className="text-sm font-bold leading-tight opacity-[0.7] hover:cursor-pointer">
+          자격진단 기준
+        </p>
+
+        <div className="flex items-center justify-center">
+          <ArrowUpRight />
+        </div>
+      </div>
+
+      <div className="flex gap-2 text-xl leading-tight">
+        <p className="font-bold text-white">{count ? count : "0"}건</p>
+        <span
+          className="flex items-center rounded-xl bg-greyscale-grey-25 p-1 text-xs font-bold"
+          style={{ color: "#FFBA18" }}
+        >
+          <p>0% 완료</p>
+        </span>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
<!--- Pull Request title = 커밋 메시지와 동일/ 해당 이슈를 close 하지 않을 경우, footer #이슈 번호 제외  -->

## #️⃣ Issue Number

#407 

<br/>
<br/>

## 📝 요약(Summary) (선택)

next.config.ts
next/image 허용 도메인에 k.kakaocdn.net(http, https) 추가.
목적: next-image-unconfigured-host 에러 해결.
#### homeHooks.ts
useRecommendedNotice에 세션 키(home-recommended-fetched:*) 로직 추가해서 최초 1회 조회 제어.
queryKey에 userName 포함, enabled/staleTime/gcTime 설정 추가.
조회 성공 시 sessionStorage.setItem(..., "query") 저장.
#### index.ts
ActionCardList export 경로를 homeAction/homeActionCardList로 변경.
#### homeActionCardList.tsx
기존 인라인 카드 UI 제거하고 PinpointStandard, QualificationDiagnosis 컴포넌트 조합 구조로 리팩터링.
#### pinpointStandard.tsx
신규 카드 컴포넌트 생성. useNoticeCount로 핀포인트 기준 건수 표시.
현재 불필요 import와 console.log(count)가 남아있음(정리 필요).
#### qualificationdiagnosis.tsx
신규 카드 컴포넌트 생성. useRecommendedNotice 결과의 totalCount 표시.

<br/>
<br/>

