### PR TITLE
fix:공고탐색 리스트 / 스크롤 버그

### DIFF
--- a/src/features/listings/hooks/useListingsContentListHooks.ts
+++ b/src/features/listings/hooks/useListingsContentListHooks.ts
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { InfiniteData } from "@tanstack/react-query";
+import { ListingListPage } from "@/src/entities/listings/model/type";
+
+type ListingsFetchingProps = {
+  fetchNextPage: () => Promise<unknown>;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  root?: Element | null;
+};
+
+export const useListingsContentListHooks = (data: InfiniteData<ListingListPage> | undefined) => {
+  const items = data?.pages.flatMap(page => page.content) ?? [];
+  const [isBottoms, setIsBottoms] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [observerRoot, setObserverRoot] = useState<Element | null>(null);
+  const ready = !!items;
+
+  const handleScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 5;
+    setIsBottoms(atBottom);
+  }, []);
+
+  const setScrollContainerRef = useCallback((node: HTMLDivElement | null) => {
+    scrollRef.current = node;
+    setObserverRoot(node);
+  }, []);
+
+  useEffect(() => {
+    handleScroll();
+  }, [data, handleScroll]);
+
+  return {
+    handleScroll,
+    items,
+    isBottoms,
+    observerRoot,
+    ready,
+    setScrollContainerRef,
+    scrollRef,
+  };
+};
+
+export const useListingsContentsObserveHooks = ({
+  fetchNextPage,
+  hasNextPage,
+  isFetchingNextPage,
+  root,
+}: ListingsFetchingProps) => {
+  const observerRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (!observerRef.current) return;
+    const observer = new IntersectionObserver(
+      entries => {
+        const entry = entries[0];
+        if (entry.isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage();
+        }
+      },
+      {
+        root: root ?? null,
+        rootMargin: "0px 0px 120px 0px",
+        threshold: 0,
+      }
+    );
+    observer.observe(observerRef.current);
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage, root]);
+
+  return {
+    observerRef,
+  };
+};

--- a/src/features/listings/ui/listingsContents/listingsContents.tsx
+++ b/src/features/listings/ui/listingsContents/listingsContents.tsx
@@ -21,7 +21,7 @@ export const ListingsContent = ({ viewSet = true }: { viewSet?: boolean }) => {
 
   return (
     <>
-      <div className="flex h-full flex-col">
+      <div className="flex h-full min-h-0 flex-col">
         {!viewSet ? null : <ListingsContentHeader totalCount={totalCount} />}
         {totalCount === 0 ? (
           <div className="flex h-full flex-col items-center justify-center pb-[88px]">


### PR DESCRIPTION
## #️⃣ Issue Number

#415 

<br/>
<br/>

## 📝 요약(Summary) (선택)

•맥북 해상도에서 /listings 무한스크롤이 멈추던 현상이 완화
•리스트 스크롤 루트와 observer 기준을 맞춰 트리거 누락 가능성
•UI 단 스크롤 useEffect를 훅으로 이동해 구조를 단순화
•pb-[88px] 보정 없이도 동작하도록 무한스크롤 조건을 안정



<br/>
<br/>

