### PR TITLE
fix:핀하우스 home / 글로벌 검색 결과 / 카테고리별 데이터 조회 버그

### DIFF
--- a/src/assets/icons/button/upButton.tsx
+++ b/src/assets/icons/button/upButton.tsx
@@ -2,7 +2,14 @@ import { SVGProps } from "react";
 
 export const UpButton = (props: SVGProps<SVGSVGElement>) => {
   return (
-    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
       <g clipPath="url(#clip0_9421_754)">
         <path
           d="M6 15L12 9L18 15"

--- a/src/entities/home/hooks/homeHooks.ts
+++ b/src/entities/home/hooks/homeHooks.ts
@@ -57,9 +57,7 @@ export const useNoticeCount = () => {
 
 export const useGlobal = <T>({ params, q }: { params: string; q: string }) => {
   const url = `${HOME_SEARCH_POPULAR_ENDPOINT}/${params}`;
-
   const param = params === "popular" ? { limit: 10 } : { q: q };
-
   return useQuery({
     queryKey: ["global-search", params, q],
     retry: false,
@@ -82,8 +80,8 @@ export const useGlobalPageNation = <TItem>({
 
   return useInfiniteQuery<SliceResponse<TItem>, Error>({
     queryKey: ["globalInfinity", apiCategory],
-    enabled: Boolean(category),
-    initialPageParam: 1,
+    enabled: enabled,
+    initialPageParam: 2,
     retry: false,
     queryFn: ({ pageParam }) =>
       getNoticeByPinPoint<SliceResponse<TItem>>({
@@ -94,9 +92,7 @@ export const useGlobalPageNation = <TItem>({
           page: Number(pageParam),
         },
       }),
-    getNextPageParam: lastPage => {
-      return lastPage.hasNext ? lastPage.pages + 1 : undefined;
-    },
+    getNextPageParam: (lastPage, allPages) => (lastPage.hasNext ? allPages.length + 2 : undefined),
   });
 };
 

--- a/src/features/home/ui/result/homeResultSectionItem.tsx
+++ b/src/features/home/ui/result/homeResultSectionItem.tsx
@@ -13,9 +13,9 @@ interface HomeResultSectionItemsProps {
 export const HomeResultSectionItems = ({ items, limit = 5, q }: HomeResultSectionItemsProps) => {
   return (
     <ul className="rounded-xl bg-white px-3">
-      {items.slice(0, limit).map(item => (
+      {items.slice(0, limit).map((item, index) => (
         <li
-          key={item.id}
+          key={item.id + index}
           className={cn(
             "flex items-center justify-between gap-2 p-3",
             items.length === 1 ? "border-none" : "border-b"

--- a/src/features/home/ui/result/homeResultSectionMore.tsx
+++ b/src/features/home/ui/result/homeResultSectionMore.tsx
@@ -1,33 +1,34 @@
-import { DownButton } from "@/src/assets/icons/button";
+import { DownButton, UpButton } from "@/src/assets/icons/button";
 import { SearchCategory } from "@/src/entities/home/model/type";
 
 interface HomeResultSectionMoreProps {
-  expanded: boolean;
   onToggle: (category: SearchCategory) => void;
   category: SearchCategory;
-  hasNextPage?: boolean; // undefined 가능
+  canLoadMore?: boolean; // undefined 가능
+  isFetchingNextPage: boolean;
+  nextPage: boolean;
 }
 
 export const HomeResultSectionMore = ({
   category,
-  expanded,
-  onToggle,
-  hasNextPage,
-}: HomeResultSectionMoreProps) => {
-  // // 아직 펼쳐지지 않았다면 버튼 자체를 숨김
-  // if (!expanded) return null;
 
+  onToggle,
+  canLoadMore,
+  isFetchingNextPage,
+  nextPage,
+}: HomeResultSectionMoreProps) => {
   return (
     <button
       type="button"
       onClick={() => onToggle(category)}
+      disabled={!canLoadMore || isFetchingNextPage}
       className="flex w-full items-center justify-center gap-1 rounded-b-xl bg-white p-3 text-xs text-gray-400"
     >
-      {hasNextPage ? (
+      {canLoadMore ? (
         <>
           <p>{"더보기"}</p>
           <span className="rotate-180 transition-transform">
-            <DownButton width={15} height={15} />
+            {nextPage ? <UpButton width={15} height={15} /> : <DownButton width={15} height={15} />}
           </span>
         </>
       ) : (

--- a/src/widgets/homeSection/homeResultSection/components/homeResultSectionBlock.tsx
+++ b/src/widgets/homeSection/homeResultSection/components/homeResultSectionBlock.tsx
@@ -15,22 +15,23 @@ type Props = {
   category: SearchCategory;
   items: GlobalSearchItem[]; // 최초 미리보기 (최대 5개)
   q: string;
+  nextPage: boolean;
 };
 
-export const HomeResultSectionBlock = ({ category, items, q }: Props) => {
+export const HomeResultSectionBlock = ({ category, items, q, nextPage }: Props) => {
   /**
    * 현재 펼쳐진 카테고리
    * - null: 아무 것도 펼쳐지지 않음
    * - category 값: 해당 카테고리 펼쳐짐
    */
-  const [expandedCategory, setExpandedCategory] = useState<SearchCategory | null>(null);
 
+  const [expandedCategory, setExpandedCategory] = useState<SearchCategory | null>(null);
   const isExpanded = expandedCategory === category;
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useGlobalPageNation<GlobalSearchItem>({
       q,
-      category,
+      category: expandedCategory,
       enabled: isExpanded,
     });
 
@@ -39,39 +40,37 @@ export const HomeResultSectionBlock = ({ category, items, q }: Props) => {
     return data.pages.flatMap(page => (Array.isArray(page.content) ? page.content : []));
   }, [data]);
 
-  const visibleItems: GlobalSearchItem[] = isExpanded ? serverItems : items;
+  const visibleItems: GlobalSearchItem[] = isExpanded ? [...items, ...serverItems] : items;
 
   /**
    * 더보기 노출 기준
    * - 펼쳐진 이후에만 판단
    * - 서버 기준(hasNextPage)만 신뢰
    */
-  const hasMore = isExpanded && Boolean(hasNextPage);
 
+  const canLoadMore = isExpanded ? Boolean(hasNextPage) : nextPage;
   const handleToggle = async (clickedCategory: SearchCategory) => {
-    // 최초 펼침
     if (!isExpanded) {
       setExpandedCategory(clickedCategory);
       return;
     }
-
     if (hasNextPage && !isFetchingNextPage) {
       await fetchNextPage();
     }
   };
-
   return (
     <div>
       <HomeResultSectionHeader category={category} count={visibleItems.length} />
 
       <span className="flex flex-col rounded-xl border">
-        <HomeResultSectionItems items={visibleItems} q={q} />
+        <HomeResultSectionItems items={visibleItems} q={q} limit={visibleItems.length} />
 
         <HomeResultSectionMore
           category={category}
-          expanded={isExpanded}
-          hasNextPage={hasNextPage}
+          canLoadMore={canLoadMore}
           onToggle={handleToggle}
+          nextPage={hasNextPage}
+          isFetchingNextPage={isFetchingNextPage}
         />
       </span>
     </div>

--- a/src/widgets/homeSection/homeResultSection/homeResultSection.tsx
+++ b/src/widgets/homeSection/homeResultSection/homeResultSection.tsx
@@ -46,7 +46,12 @@ export const HomeResultSection = ({ q }: { q: string }) => {
     >
       {data.map(section => (
         <motion.div key={section.category} variants={itemVariants}>
-          <HomeResultSectionBlock category={section.category} items={section.content} q={q} />
+          <HomeResultSectionBlock
+            category={section.category}
+            items={section.content}
+            q={q}
+            nextPage={section.hasNext}
+          />
         </motion.div>
       ))}
     </motion.section>


### PR DESCRIPTION
<!--- Pull Request title = 커밋 메시지와 동일/ 해당 이슈를 close 하지 않을 경우, footer #이슈 번호 제외  -->

## #️⃣ Issue Number

#426 

<br/>
<br/>

## 📝 요약(Summary) (선택)

1. useGlobalPageNation 페이지 NaN 이슈 수정
• 원인: getNextPageParam에서 응답 pages 필드 의존 시 undefined + 1로 NaN 발생 가능.
• 조치: allPages.length + 2 기반으로 다음 페이지 계산하도록 변경.
• 결과: 첫 요청 page=2 이후 3,4... 순차 증가, payload.page=NaN 재발 방지.
2. 더보기 버튼 상태 판단 로직 개선
• 원인: 초기 nextPage 값과 확장 후 hasNextPage 값이 혼용되어 버튼 상태가 불안정.
• 조치: canLoadMore = isExpanded ? hasNextPage : nextPage 파생값 도입, 버튼 disabled 조건 정리.
• 결과: 초기/확장 이후 모두 일관된 “더보기 가능 여부” 동작.
3. 확장 시 데이터 누적 표시 반영
• 원인: 확장 후 serverItems만 보여서 초기 items가 사라짐.
• 조치: visibleItems를 isExpanded ? [...items, ...serverItems] : items로 변경.
• 결과: 최초 목록 유지 + 추가 조회 목록 누적 표시.
4. React key 중복 경고 대응
• 원인: 합쳐진 리스트에서 동일 id가 중복되어 key 충돌.
• 조치: 렌더 key를 item.id + index로 변경.
• 결과: Encountered two children with the same key 경고 해소.

<br/>
<br/>

