### PR TITLE
chore:도커 빌드 환경 /  Dockerfile에 secret 주입 경로를 반영

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,5 +34,7 @@ jobs:
           build-args: |
             NEXT_PUBLIC_API_URL=${{ secrets.NEXT_PUBLIC_API_URL }}
             NEXT_PUBLIC_OAUTH2=${{ secrets.NEXT_PUBLIC_OAUTH2 }}
+          secrets: |
+            npmrc=${{ secrets.NPM_TOKEN }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Docker-pinhouse-file
+++ b/Docker-pinhouse-file
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.7
+
 # =========================
 # 1️⃣ Base
 # =========================
@@ -9,7 +11,7 @@ WORKDIR /pinhouse-fe
 # =========================
 FROM base AS deps
 COPY package.json package-lock.json ./
-RUN npm ci
+RUN --mount=type=secret,id=npmrc,target=/root/.npmrc npm ci
 
 # =========================
 # 3️⃣ Build


### PR DESCRIPTION
## #️⃣ Issue Number

#431 

<br/>
<br/>

## 📝 요약(Summary) (선택)

1. 워크플로우에 BuildKit secret 전달 추가
• 파일: .github/workflows/ci.yml
• 추가한 설정:
◦ secrets:
◦ npmrc=${{ secrets.NPM_TOKEN}}

2. Dockerfile에서 secret mount로 .npmrc 사용
• 파일: Docker-pinhouse-file
• 변경:
◦ 상단에 # syntax=docker/dockerfile:1.7 추가
◦ RUN npm ci -> RUN --mount=type=secret,id=npmrc,target=/root/.npmrc npm ci

<br/>
<br/>

