### PR TITLE
chore: npm 인증 secret 전달 방식 불일치

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,6 @@ jobs:
             NEXT_PUBLIC_API_URL=${{ secrets.NEXT_PUBLIC_API_URL }}
             NEXT_PUBLIC_OAUTH2=${{ secrets.NEXT_PUBLIC_OAUTH2 }}
           secrets: |
-            npmrc=${{ secrets.NPM_TOKEN }}
+            NPM_TOKEN=${{ secrets.NPM_TOKEN }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Docker-pinhouse-file
+++ b/Docker-pinhouse-file
@@ -10,8 +10,9 @@ WORKDIR /pinhouse-fe
 # 2️⃣ Dependencies
 # =========================
 FROM base AS deps
-COPY package.json package-lock.json ./
-RUN --mount=type=secret,id=npmrc,target=/root/.npmrc npm ci
+COPY package.json package-lock.json .npmrc ./
+RUN --mount=type=secret,id=NPM_TOKEN \
+    NPM_TOKEN="$(cat /run/secrets/NPM_TOKEN)" npm ci
 
 # =========================
 # 3️⃣ Build


### PR DESCRIPTION
## #️⃣ Issue Number

#437 

<br/>
<br/>

## 📝 요약(Summary) (선택)

1. 기존 구성은 Dockerfile이 /root/.npmrc 파일 전체를 secret으로 기대했지만, CI에서는 토큰 문자열만 전달하고 있어 private npm 인증이 실패
2. GitHub에 등록된 secret 이름/구조(NPM_TOKEN)를 바꾸지 못하는 조건을 만족하면서, 현재 .npmrc의 ${NPM_TOKEN} 치환 방식으로 정상 인증되게 만들기 위해서

<br/>
<br/>
