### PR TITLE
핀하우스 home/ 글로벌 검색 결과 / 카테고리별  로직 역활,책임 hooks 분리

### DIFF
--- a/src/features/home/ui/homeUseHooks/homeResultHooks/useHomeResultHooks.ts
+++ b/src/features/home/ui/homeUseHooks/homeResultHooks/useHomeResultHooks.ts
@@ -1,0 +1,70 @@
+import { useCallback, useMemo } from "react";
+import { useGlobalPageNation } from "@/src/entities/home/hooks/homeHooks";
+import { GlobalSearchItem, SearchCategory } from "@/src/entities/home/model/type";
+
+type UseHomeResultsDataProps = {
+  category: SearchCategory;
+  q: string;
+  items: GlobalSearchItem[];
+  isExpanded: boolean;
+};
+
+export const useHomeResultsData = ({ category, q, items, isExpanded }: UseHomeResultsDataProps) => {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useGlobalPageNation<GlobalSearchItem>({
+      q,
+      category,
+      enabled: isExpanded,
+    });
+
+  const serverItems = useMemo<GlobalSearchItem[]>(() => {
+    if (!data?.pages) return [];
+    return data.pages.flatMap(page => (Array.isArray(page.content) ? page.content : []));
+  }, [data]);
+
+  const visibleItems = useMemo(
+    () => (isExpanded ? [...items, ...serverItems] : items),
+    [isExpanded, items, serverItems]
+  );
+
+  return {
+    visibleItems,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  };
+};
+
+type UseHomeResultToggleProps = {
+  category: SearchCategory;
+  isExpanded: boolean;
+  setExpandedCategory: (category: SearchCategory | null) => void;
+  hasNextPage: boolean | undefined;
+  isFetchingNextPage: boolean;
+  fetchNextPage: () => Promise<unknown>;
+};
+
+export const useHomeResultToggle = ({
+  category,
+  isExpanded,
+  setExpandedCategory,
+  hasNextPage,
+  isFetchingNextPage,
+  fetchNextPage,
+}: UseHomeResultToggleProps) => {
+  const onToggle = useCallback(async () => {
+    if (!isExpanded) {
+      setExpandedCategory(category);
+      return;
+    }
+
+    if (hasNextPage && !isFetchingNextPage) {
+      await fetchNextPage();
+      return;
+    }
+
+    // setExpandedCategory(null);
+  }, [isExpanded, setExpandedCategory, category, hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  return { onToggle };
+};

--- a/src/features/home/ui/result/homeResultSectionMore.tsx
+++ b/src/features/home/ui/result/homeResultSectionMore.tsx
@@ -11,11 +11,10 @@ interface HomeResultSectionMoreProps {
 
 export const HomeResultSectionMore = ({
   category,
-
-  onToggle,
   canLoadMore,
-  isFetchingNextPage,
+  onToggle,
   nextPage,
+  isFetchingNextPage,
 }: HomeResultSectionMoreProps) => {
   return (
     <button


### PR DESCRIPTION
<!--- Pull Request title = 커밋 메시지와 동일/ 해당 이슈를 close 하지 않을 경우, footer #이슈 번호 제외  -->

## #️⃣ Issue Number

#428 

<br/>
<br/>

## 📝 요약(Summary) (선택)

코드 리팩토링은 HomeResultSectionBlock에 useState를 유지한 채(항목별 독립 확장), useHomeResultsData/useHomeResultToggle로 역할을 분리하고 HomeResultSectionMore의 onToggle 시그니처를 () => void로 맞추며 nextPage는 Boolean(hasNextPage)로 넘김

<br/>
<br/>
