### PR TITLE
fix:핀하우스 Home/ 공고리스트 무한스크롤 버그 / home 에서 공고리스트 라우터시 정렬 버그

### DIFF
--- a/src/entities/home/hooks/homeHooks.ts
+++ b/src/entities/home/hooks/homeHooks.ts
@@ -16,7 +16,7 @@ import { toast } from "sonner";
 
 export const useNoticeInfinite = () => {
   const pinpointId = useOAuthStore(state => state.pinPointId);
-
+  console.log(pinpointId);
   return useInfiniteQuery({
     queryKey: ["notice", pinpointId],
     enabled: !!pinpointId,

--- a/src/entities/listings/model/type.ts
+++ b/src/entities/listings/model/type.ts
@@ -152,6 +152,7 @@ export interface ListingContentsListProps {
   isFetchingNextPage: boolean;
   isError: boolean;
   isBottom?: boolean;
+  enableInfiniteScroll?: boolean;
 }
 /**
  * 총공고 카운트

--- a/src/features/home/ui/homeUrgentNoticeList.tsx
+++ b/src/features/home/ui/homeUrgentNoticeList.tsx
@@ -1,31 +1,19 @@
 "use client";
 import { cn } from "@/lib/utils";
 import { LeftButton } from "@/src/assets/icons/button";
-import { useNoticeInfinite } from "@/src/entities/home/hooks/homeHooks";
 import { HomeContentsCard } from "@/src/features/home";
 import { ListingNoSearchResult, ListingsContent } from "@/src/features/listings";
 import { Button } from "@/src/shared/lib/headlessUi";
-import { useRouteStore } from "../model/homeStore";
-import { useRouter } from "next/navigation";
-import { useListingsFilterStore } from "../../listings/model";
+import {
+  useUrgentNoticeListHooks,
+  useUrgentNoticeListRouterHooks,
+} from "@/src/features/home/ui/homeUseHooks";
 
 export const UrgentNoticeList = () => {
-  const { data, isFetchingNextPage, isError, fetchNextPage } = useNoticeInfinite();
-  const contents = data?.pages?.flatMap(page => page.content) ?? [];
-  const dataCount = contents.length === 0;
-  const region = data?.pages?.flatMap(page => page.region) ?? [];
-  const { setSortType } = useListingsFilterStore();
-  const router = useRouter();
-  const { setPrevPath } = useRouteStore();
-
-  const pageRouter = () => {
-    setPrevPath("/home");
-    setSortType("마감임박순");
-    router.push("/listings");
-  };
-
+  const { data, contents, dataCount, isFetchingNextPage, isError, fetchNextPage } =
+    useUrgentNoticeListHooks();
+  const { pageRouter } = useUrgentNoticeListRouterHooks();
   return (
-    // <section className={cn("flex flex-col", contents.length >= 2 ? "pb-[55px]" : "")}>
     <section className={cn("flex flex-col")}>
       <div className="flex items-center justify-between pt-4">
         <div>
@@ -38,17 +26,26 @@ export const UrgentNoticeList = () => {
           onClick={pageRouter}
         >
           <span>전체보기</span>
-          {/* <span>{region}</span> */}
+
           <LeftButton width={15} height={15} className="rotate-180" />
         </div>
       </div>
 
       <div className="flex flex-col">
         {isError || dataCount ? (
-          <ListingsContent viewSet={false} />
+          <ListingsContent viewSet={false} enableInfiniteScroll={false} />
         ) : (
           <HomeContentsCard data={contents} />
         )}
+        <div className="relative z-10 -mt-12 flex justify-center">
+          <button
+            type="button"
+            onClick={pageRouter}
+            className="text-mainBlue text-sm font-semibold"
+          >
+            공고리스트로 이동하기
+          </button>
+        </div>
       </div>
 
       {isFetchingNextPage && (

--- a/src/features/home/ui/homeUseHooks/index.ts
+++ b/src/features/home/ui/homeUseHooks/index.ts
@@ -1,3 +1,6 @@
 export * from "./useHomeRouterHooks";
 export * from "./useHomeHooks";
 export * from "./homeUseHooks";
+export * from "./useUrgenNoticeListHooks";
+export * from "./homeResultHooks/useHomeResultAnimationHooks";
+export * from "./homeResultHooks/useHomeResultHooks";

--- a/src/features/home/ui/homeUseHooks/useUrgenNoticeListHooks.ts
+++ b/src/features/home/ui/homeUseHooks/useUrgenNoticeListHooks.ts
@@ -1,0 +1,32 @@
+﻿import { useRouter } from "next/navigation";
+import { useRouteStore } from "@/src/features/home/model/homeStore";
+import { useNoticeInfinite } from "@/src/entities/home/hooks/homeHooks";
+
+export const useUrgentNoticeListRouterHooks = () => {
+  const router = useRouter();
+  const { setPrevPath } = useRouteStore();
+
+  const pageRouter = () => {
+    setPrevPath("/home");
+    router.push("/listings?sortType=deadline");
+  };
+
+  return {
+    pageRouter,
+  };
+};
+
+export const useUrgentNoticeListHooks = () => {
+  const { data, isFetchingNextPage, isError, fetchNextPage } = useNoticeInfinite();
+  const contents = data?.pages?.flatMap(page => page.content) ?? [];
+  const dataCount = contents.length === 0;
+
+  return {
+    data,
+    contents,
+    dataCount,
+    isFetchingNextPage,
+    isError,
+    fetchNextPage,
+  };
+};

--- a/src/features/listings/hooks/useListingsContentListHooks.ts
+++ b/src/features/listings/hooks/useListingsContentListHooks.ts
@@ -7,6 +7,7 @@ type ListingsFetchingProps = {
   hasNextPage: boolean;
   isFetchingNextPage: boolean;
   root?: Element | null;
+  enableInfiniteScroll?: boolean;
 };
 
 export const useListingsContentListHooks = (data: InfiniteData<ListingListPage> | undefined) => {
@@ -48,10 +49,12 @@ export const useListingsContentsObserveHooks = ({
   hasNextPage,
   isFetchingNextPage,
   root,
+  enableInfiniteScroll = true,
 }: ListingsFetchingProps) => {
   const observerRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
     if (!observerRef.current) return;
+    if (!enableInfiniteScroll) return;
     const observer = new IntersectionObserver(
       entries => {
         const entry = entries[0];

--- a/src/features/listings/ui/listingsContents/listingsContents.tsx
+++ b/src/features/listings/ui/listingsContents/listingsContents.tsx
@@ -5,10 +5,17 @@ import { ListingContentsList } from "./listingsContentsList";
 import { ListingNoSearchResult } from "@/src/features/listings";
 import { Spinner } from "@/src/shared/ui/spinner/default";
 
-export const ListingsContent = ({ viewSet = true }: { viewSet?: boolean }) => {
+type ListingsContentProps = {
+  enableInfiniteScroll?: boolean;
+  viewSet?: boolean;
+};
+
+export const ListingsContent = ({
+  viewSet = true,
+  enableInfiniteScroll = true,
+}: ListingsContentProps) => {
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isError, isLoading, isSuccess } =
     useListingListInfiniteQuery();
-
   const totalCount = isLoading || !isSuccess ? null : (data?.pages[0]?.totalCount ?? 0);
 
   if (!data) {
@@ -37,6 +44,7 @@ export const ListingsContent = ({ viewSet = true }: { viewSet?: boolean }) => {
               hasNextPage={hasNextPage}
               isFetchingNextPage={isFetchingNextPage}
               isError={isError}
+              enableInfiniteScroll={enableInfiniteScroll}
             />
           </div>
         )}

--- a/src/features/listings/ui/listingsContents/listingsContentsList.tsx
+++ b/src/features/listings/ui/listingsContents/listingsContentsList.tsx
@@ -17,6 +17,7 @@ export const ListingContentsList = ({
   isFetchingNextPage,
   isError,
   isBottom = true,
+  enableInfiniteScroll = true,
 }: ListingContentsListProps) => {
   const { handleScroll, observerRoot, ready, items, isBottoms, setScrollContainerRef } =
     useListingsContentListHooks(data);
@@ -26,6 +27,7 @@ export const ListingContentsList = ({
     hasNextPage,
     isFetchingNextPage,
     root: observerRoot,
+    enableInfiniteScroll,
   });
   if (!data) {
     return <Spinner title="공고 탐색중..." description="잠시만 기다려주세요" />;

--- a/src/widgets/listingsSection/ui/listingsSection.tsx
+++ b/src/widgets/listingsSection/ui/listingsSection.tsx
@@ -1,12 +1,35 @@
-"use client";
+﻿"use client";
 import {
   ListingFilterPanel,
   ListingFilterPartialSheet,
   ListingsContent,
   ListingsHeaders,
 } from "@/src/features/listings";
+import { useListingsFilterStore } from "@/src/features/listings/model";
+import { useSearchParams } from "next/navigation";
+import { useEffect } from "react";
+
+const DEADLINE_SORT_TYPE = "\uB9C8\uAC10\uC784\uBC15\uC21C";
 
 export const ListingsSection = () => {
+  const searchParams = useSearchParams();
+  const sortType = useListingsFilterStore(state => state.sortType);
+  const setSortType = useListingsFilterStore(state => state.setSortType);
+
+  useEffect(() => {
+    const requestedSortType = searchParams.get("sortType");
+
+    if (requestedSortType !== "deadline") {
+      return;
+    }
+
+    if (sortType === DEADLINE_SORT_TYPE) {
+      return;
+    }
+
+    setSortType(DEADLINE_SORT_TYPE);
+  }, [searchParams, sortType, setSortType]);
+
   return (
     <section className="flex h-full w-full flex-col justify-between px-4">
       <div className="flex flex-col gap-2">


### PR DESCRIPTION
## #️⃣ Issue Number

#444 

<br/>
<br/>

## 📝 요약(Summary) (선택)

요약:
- 버그 1: 홈에서 무한스크롤이 꺼져야 하는데 observer가 계속 동작해서 끝 페이지까지 연속 조회됨.
- 버그 2: 홈에서 공고리스트 이동 버튼 클릭 시 setSortType 선반영 때문에 이동 직전 추가 렌더가 발생함.
- 수정:
  - 무한스크롤 플래그를 observer 내부 조건에 실제 적용해 홈 자동 연속조회 차단
  - 정렬 변경을 홈이 아니라 /listings 진입 후 처리로 이동

<br/>
<br/>
