### PR TITLE
refacotr:핀하우스 home / SSR 구조변환 / BFF

### DIFF
--- a/app/api/home/notice/route.ts
+++ b/app/api/home/notice/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import { getHomeNoticesFirstPageOnServer } from "@/src/features/home/server/getHomeNoticesFirstPageOnServer";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const data = await getHomeNoticesFirstPageOnServer();
+
+    if (!data) {
+      return NextResponse.json(
+        { success: false, message: "Failed to fetch home notices first page." },
+        { status: 401 }
+      );
+    }
+
+    return NextResponse.json({ success: true, data }, { status: 200 });
+  } catch {
+    return NextResponse.json({ success: false, message: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/src/widgets/homeSection/homeSectionPage.tsx
+++ b/src/widgets/homeSection/homeSectionPage.tsx
@@ -1,11 +1,34 @@
 import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
 import { HomeSection } from "./homeSection";
-import { getHomeNoticesFirstPageOnServer } from "@/src/features/home/server/getHomeNoticesFirstPageOnServer";
 import type { NoticeContent, SliceResponse } from "@/src/entities/home/model/type";
+
+type HomeNoticeBffResponse = {
+  success: boolean;
+  data?: {
+    pinpointId: string;
+    page: SliceResponse<NoticeContent>;
+  };
+};
 
 export async function HomeSectionPage() {
   const queryClient = new QueryClient();
-  const initial = await getHomeNoticesFirstPageOnServer();
+
+  let initial: HomeNoticeBffResponse["data"] | null = null;
+  try {
+    const res = await fetch(`/api/home/notice`, {
+      method: "GET",
+      cache: "no-store",
+    });
+
+    if (res.ok) {
+      const body = (await res.json()) as HomeNoticeBffResponse;
+      if (body.success && body.data) {
+        initial = body.data;
+      }
+    }
+  } catch {
+    initial = null;
+  }
 
   if (initial) {
     await queryClient.prefetchInfiniteQuery({


### PR DESCRIPTION
## #️⃣ Issue Number

#455 
<br/>
<br/>

## 📝 요약(Summary) (선택)

route.ts 추가
◦/api/home/notice 엔드포인트 생성
◦내부에서 getHomeNoticesFirstPageOnServer 호출
◦실패 401, 예외 500 응답
•homeSectionPage.tsx 수정
◦기존 서버함수 직접 호출 제거
◦/api/home/notice fetch로 SSR 초기데이터 조회
◦응답 타입(HomeNoticeBffResponse) 추가 후 hydration prefetch 연결

<br/>
<br/>
