### PR TITLE
refactor:핀하우스 home / home 화면 description ssr 구조 변경 / home ssr 구조 리펙토링

### DIFF
--- a/app/api/home/count/route.ts
+++ b/app/api/home/count/route.ts
@@ -18,7 +18,10 @@ export async function GET(req: Request) {
       );
     }
 
-    return NextResponse.json({ success: true, data: { count: data.count } }, { status: 200 });
+    return NextResponse.json(
+      { success: true, data: { count: data.count } },
+      { status: 200, headers: { "x-route-hit": "home-count" } }
+    );
   } catch {
     return NextResponse.json({ success: false, message: "Internal Server Error" }, { status: 500 });
   }

--- a/src/features/home/server/getHomeNoticesFirstPageOnServer.ts
+++ b/src/features/home/server/getHomeNoticesFirstPageOnServer.ts
@@ -31,7 +31,6 @@ export async function getHomeNoticesFirstPageOnServer() {
   if (!res.ok) return null;
 
   const body = (await res.json()) as IResponse<SliceResponse<NoticeContent>>;
-  console.log("[SSR body]", body);
   if (!body?.success || !body.data) return null;
 
   return { pinpointId, page: body.data };

--- a/src/features/home/ui/homeHero.tsx
+++ b/src/features/home/ui/homeHero.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { HomeCharacter } from "@/src/assets/icons/home/homeCharacter";
 import { useOAuthStore } from "../../login/model";
 

--- a/src/features/home/ui/homePersonalShortcutList.tsx
+++ b/src/features/home/ui/homePersonalShortcutList.tsx
@@ -4,26 +4,40 @@ import {
   usePersonalRouteHooks,
   usePersonalShortcutHooks,
 } from "@/src/features/home/ui/homeUseHooks/usePersonalShortcutHooks";
-import { PERSONAL_SHORTCUTS } from "@/src/features/home/model/model";
+import type { ReactNode } from "react";
+
+type PersonalShortcutItem = {
+  id: string;
+  title: string;
+  description: string;
+  icon: ReactNode;
+  button: ReactNode;
+  message: string;
+  path: string;
+};
 
 const ShortcutMessage = ({ text }: { text: string }) => {
   return (
     <div className="z-5 absolute -top-2 left-4">
       <div className="relative rounded-lg bg-greyscale-grey-900 px-3 py-1 text-xs text-white">
         {text}
-        {/* 말풍선 꼬리 */}
         <span className="absolute left-4 top-full h-0 w-0 border-l-4 border-r-4 border-t-4 border-transparent border-t-greyscale-grey-900" />
       </div>
     </div>
   );
 };
 
-export const PersonalShortcutList = () => {
+export const PersonalShortcutListClient = ({
+  items,
+}: {
+  items: readonly PersonalShortcutItem[];
+}) => {
   const { showMessage } = usePersonalShortcutHooks();
   const { personalRoute } = usePersonalRouteHooks();
+
   return (
     <section className="flex flex-col gap-4">
-      {PERSONAL_SHORTCUTS.map(item => (
+      {items.map(item => (
         <div key={item.id} className="relative">
           {showMessage && item.message && <ShortcutMessage text={item.message} />}
 

--- a/src/features/home/ui/server/homePersonalShortcutList.server.tsx
+++ b/src/features/home/ui/server/homePersonalShortcutList.server.tsx
@@ -1,0 +1,6 @@
+import { PERSONAL_SHORTCUTS } from "@/src/features/home/model/model";
+import { PersonalShortcutListClient } from "@/src/features/home/ui/homePersonalShortcutList";
+
+export const PersonalShortcutList = () => {
+  return <PersonalShortcutListClient items={PERSONAL_SHORTCUTS} />;
+};

--- a/src/widgets/homeSection/homeSection.tsx
+++ b/src/widgets/homeSection/homeSection.tsx
@@ -1,14 +1,13 @@
-"use client";
 import {
   ActionCardList,
   HomeHeader,
   HomeHero,
-  PersonalShortcutList,
   QuickStatsList,
   UrgentNoticeList,
 } from "@/src/features/home";
 
 import { PageTransition } from "@/src/shared/ui/animation";
+import { PersonalShortcutList } from "@/src/features/home/ui/server/homePersonalShortcutList.server";
 
 export const HomeSection = () => {
   return (

--- a/src/widgets/homeSection/homeSectionPage.tsx
+++ b/src/widgets/homeSection/homeSectionPage.tsx
@@ -1,57 +1,11 @@
 import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
 import { HomeSection } from "./homeSection";
-import type { NoticeContent, NoticeCount, SliceResponse } from "@/src/entities/home/model/type";
-
-type HomeNoticeBffResponse = {
-  success: boolean;
-  data?: {
-    pinpointId: string;
-    page: SliceResponse<NoticeContent>;
-  };
-};
-
-type HomeCountBffResponse = {
-  success: boolean;
-  data?: NoticeCount;
-};
+import type { NoticeContent, SliceResponse } from "@/src/entities/home/model/type";
+import { getHomeInitialData } from "./server/getHomeInitialData";
 
 export async function HomeSectionPage() {
   const queryClient = new QueryClient();
-
-  let initial: HomeNoticeBffResponse["data"] | null = null;
-  let initialCountBffResponse: HomeCountBffResponse["data"] | null = null;
-
-  try {
-    const res = await fetch(`/api/home/notice`, {
-      method: "GET",
-      cache: "no-store",
-    });
-
-    if (res.ok) {
-      const body = (await res.json()) as HomeNoticeBffResponse;
-      if (body.success && body.data) {
-        initial = body.data;
-      }
-    }
-  } catch {
-    initial = null;
-  }
-
-  try {
-    const res = await fetch(`/api/home/count?maxTime=60`, {
-      method: "GET",
-      cache: "no-store",
-    });
-
-    if (res.ok) {
-      const body = (await res.json()) as HomeCountBffResponse;
-      if (body.success && body.data) {
-        initialCountBffResponse = body.data;
-      }
-    }
-  } catch {
-    initialCountBffResponse = null;
-  }
+  const { initial, initialCount } = await getHomeInitialData();
 
   if (initial) {
     await queryClient.prefetchInfiniteQuery({
@@ -63,10 +17,10 @@ export async function HomeSectionPage() {
     });
   }
 
-  if (initial && initialCountBffResponse) {
+  if (initial && initialCount) {
     await queryClient.prefetchQuery({
       queryKey: ["noticeCount", initial.pinpointId, 60],
-      queryFn: async () => initialCountBffResponse,
+      queryFn: async () => initialCount,
     });
   }
 

--- a/src/widgets/homeSection/server/getHomeInitialData.ts
+++ b/src/widgets/homeSection/server/getHomeInitialData.ts
@@ -1,0 +1,57 @@
+import type { NoticeContent, NoticeCount, SliceResponse } from "@/src/entities/home/model/type";
+import { headers } from "next/headers";
+
+type HomeNoticeBffResponse = {
+  success: boolean;
+  data?: {
+    pinpointId: string;
+    page: SliceResponse<NoticeContent>;
+  };
+};
+
+type HomeCountBffResponse = {
+  success: boolean;
+  data?: NoticeCount;
+};
+
+export async function getHomeInitialData() {
+  let initial: HomeNoticeBffResponse["data"] | null = null;
+  let initialCount: HomeCountBffResponse["data"] | null = null;
+  const h = await headers();
+  const host = h.get("x-forwarded-host") ?? h.get("host");
+  const proto = h.get("x-forwarded-proto") ?? "http";
+  const baseUrl = `${proto}://${host}`;
+  const cookieHeader = h.get("cookie") ?? "";
+
+  try {
+    const res = await fetch(`${baseUrl}/api/home/notice`, {
+      method: "GET",
+      cache: "no-store",
+      headers: { cookie: cookieHeader },
+    });
+
+    if (res.ok) {
+      const body = (await res.json()) as HomeNoticeBffResponse;
+      if (body.success && body.data) initial = body.data;
+    }
+  } catch {
+    initial = null;
+  }
+
+  try {
+    const res = await fetch(`${baseUrl}/api/home/count?maxTime=60`, {
+      method: "GET",
+      cache: "no-store",
+      headers: { cookie: cookieHeader },
+    });
+
+    if (res.ok) {
+      const body = (await res.json()) as HomeCountBffResponse;
+      if (body.success && body.data) initialCount = body.data;
+    }
+  } catch (e) {
+    initialCount = null;
+  }
+
+  return { initial, initialCount };
+}


### PR DESCRIPTION
## #️⃣ Issue Number

#462 

<br/>
<br/>

## 📝 요약(Summary) (선택)

•homeSectionPage.tsx는 데이터 호출을 제거하고, prefetch + hydration만 담당하도록 단순화됨.
•초기 데이터 조회 책임은 신규 getHomeInitialData.ts로 분리됨.
•/api/home/* 경유 SSR은 유지했고, 서버 fetch는 절대 URL + 쿠키 전달로 안정화됨.
•PersonalShortcutList는 서버(homePersonalShortcutList.server.tsx: 정적 데이터 주입)와 클라이언트(homePersonalShortcutList.tsx: 인터랙션)로 분리됨.
•결과적으로 역할/책임 분리가 완료되어 페이지 계층이 훨씬 명확해짐.

<br/>
<br/>

