### PR TITLE
refactor:핀하우스 home / 헤더 ssr 컴포넌트 분리

### DIFF
--- a/src/features/home/index.server.ts
+++ b/src/features/home/index.server.ts
@@ -3,3 +3,4 @@ export * from "./ui/server/homeHero.server";
 export * from "./ui/server/homeQuickStatsList.server";
 export * from "./ui/server/shortcutMessageBox.server";
 export * from "./ui/server/homeUrgentNoticeList.server";
+export * from "./ui/server/homeHeader.server";

--- a/src/features/home/index.ts
+++ b/src/features/home/index.ts
@@ -1,7 +1,5 @@
 export * from "./ui/client/homeContentsCard";
 export * from "./ui/homeAction/homeActionCardList";
-export * from "./ui/client/homeContentsCard";
-export * from "./ui/client/homeHeader";
 export * from "./ui/client/homeHero";
 export * from "./ui/client/homePersonalShortcutList";
 export * from "./ui/client/homeQuickStatsList";

--- a/src/features/home/ui/client/homeHeader.tsx
+++ b/src/features/home/ui/client/homeHeader.tsx
@@ -1,6 +1,5 @@
 "use client";
-import { HomeScreenLogo } from "@/src/assets/icons/home/homeScreenLogo";
-import { PinhouseLogo } from "@/src/assets/icons/logo";
+
 import { SearchLine } from "@/src/assets/icons/home";
 import { useHomeHeaderHooks } from "@/src/widgets/homeSection/hooks/homeHeaderHooks";
 
@@ -8,15 +7,10 @@ export const HomeHeader = () => {
   const { onRouteChange } = useHomeHeaderHooks();
 
   return (
-    <header className="flex items-center justify-between pt-5">
-      <div className="flex items-center gap-1">
-        <HomeScreenLogo /> <PinhouseLogo className="h-7 w-auto" />
-      </div>
-      <div className="flex items-center gap-3">
-        <button aria-label="검색">
-          <SearchLine onClick={onRouteChange} />
-        </button>
-      </div>
-    </header>
+    <div className="flex items-center gap-3">
+      <button aria-label="검색">
+        <SearchLine onClick={onRouteChange} />
+      </button>
+    </div>
   );
 };

--- a/src/features/home/ui/server/homeHeader.server.tsx
+++ b/src/features/home/ui/server/homeHeader.server.tsx
@@ -1,0 +1,14 @@
+import { HomeScreenLogo } from "@/src/assets/icons/home/homeScreenLogo";
+import { PinhouseLogo } from "@/src/assets/icons/logo";
+import { HomeHeader } from "@/src/features/home/ui/client/homeHeader";
+
+export const HomeHeaderServer = () => {
+  return (
+    <header className="flex items-center justify-between pt-5">
+      <div className="flex items-center gap-1">
+        <HomeScreenLogo /> <PinhouseLogo className="h-7 w-auto" />
+      </div>
+      <HomeHeader />
+    </header>
+  );
+};

--- a/src/widgets/homeSection/homeSection.tsx
+++ b/src/widgets/homeSection/homeSection.tsx
@@ -1,9 +1,10 @@
-import { ActionCardList, HomeHeader } from "@/src/features/home";
+import { ActionCardList } from "@/src/features/home";
 import { PageTransition } from "@/src/shared/ui/animation";
 import { PersonalShortcutList } from "@/src/features/home/ui/server/homePersonalShortcutList.server";
 import { HomeHeroServer } from "@/src/features/home/ui/server/homeHero.server";
 import { HomeQuickStatsListServer } from "@/src/features/home/ui/server/homeQuickStatsList.server";
 import { HomeUrgentNoticeListServer } from "@/src/features/home/ui/server/homeUrgentNoticeList.server";
+import { HomeHeaderServer } from "@/src/features/home/ui/server/homeHeader.server";
 
 export const HomeSection = () => {
   return (
@@ -11,7 +12,7 @@ export const HomeSection = () => {
       <PageTransition>
         <div className="flex flex-col">
           <div className="px-4">
-            <HomeHeader />
+            <HomeHeaderServer />
             <HomeHeroServer />
           </div>
           <div className="flex flex-col gap-3 border-b-8 border-greyscale-grey-50 px-4">


### PR DESCRIPTION
<!--- Pull Request title = 커밋 메시지와 동일/ 해당 이슈를 close 하지 않을 경우, footer #이슈 번호 제외  -->

## #️⃣ Issue Number

#468 

<br/>
<br/>

## 📝 요약(Summary) (선택)

홈 헤더를 서버 렌더링 영역(로고/레이아웃)과 클라이언트 영역(검색 인터랙션)으로 분리해 SSR 구조를 명확히 했고, 홈 섹션 연결 및 export 정리까지 완료해 렌더링 책임과 코드 경계 정리

<br/>
<br/>

