### PR TITLE
feat:리스트 카드 북마크/공급사 노출 위치 정리 및 housingType 기준으로 라벨 통일

### DIFF
--- a/src/features/listings/hooks/list/components/listingsHooks.tsx
+++ b/src/features/listings/hooks/list/components/listingsHooks.tsx
@@ -168,7 +168,15 @@ export const HouseRental = ({ query, ...item }: HouseRentalProps) => {
   if (!rentalText) return null;
   return (
     <span className="flex w-full justify-between">
-      <ListingBgBookMark item={item.type} bg={rentalText.bg} text={rentalText.text} border="none" />
+      <div className="flex gap-2">
+        <ListingBgBookMark
+          item={item.type}
+          bg={rentalText.bg}
+          text={rentalText.text}
+          border="none"
+        />
+        <span className={"text-xs font-semibold"}>{item.supplier}</span>
+      </div>
       <LikeType liked={item.liked} id={item.id} type={"NOTICE"} resetQuery={[query]} />
     </span>
   );

--- a/src/features/listings/ui/listingsContents/listingsBookMark.tsx
+++ b/src/features/listings/ui/listingsContents/listingsBookMark.tsx
@@ -13,19 +13,6 @@ export const ListingBookMark = ({ item, border }: { item: string; border: string
   );
 };
 
-// export const ListingBookMark = ({ item, border }: { item: string; border: string }) => {
-//   return (
-//     <Toggle
-//       aria-label="Toggle bookmark"
-//       size="sm"
-//       variant="outline"
-//       className={` ${border} data-[state=on]:*:[svg]:fill-blue-500 data-[state=on]:*:[svg]:stroke-blue-500 inline-flex w-fit max-w-none rounded-[4px]`}
-//     >
-//       <p className="whitespace-nowrap text-xs-12">{item}</p>
-//     </Toggle>
-//   );
-// };
-
 export const ListingBgBookMark = ({
   item,
   bg,

--- a/src/features/listings/ui/listingsContents/listingsContentCard.tsx
+++ b/src/features/listings/ui/listingsContents/listingsContentCard.tsx
@@ -30,12 +30,12 @@ export const ListingContentsCard = <T extends ListingUnion>({ data }: { data: T[
             className="active: flex h-[112px] min-h-[100px] w-full rounded-xl border bg-blue-50 hover:cursor-pointer"
             onClick={() => handleRouter(normalized.id)}
           >
-            <div className="border-r-1 flex w-[35%] flex-col rounded-l-xl rounded-bl-xl bg-bgColor-mute pl-1 pt-2">
-              <div className="flex min-w-0 items-center gap-2">
-                <ListingBookMark item={normalized.type} border="border" />
-                <p className="min-w-0 flex-1 truncate text-xs font-semibold text-greyscale-grey-800">
-                  {normalized.supplier}
-                </p>
+            <div className="border-r-1 flex w-[35%] flex-col rounded-l-xl rounded-bl-xl bg-bgColor-mute p-2">
+              <div className="flex min-w-0 items-center">
+                <ListingBookMark item={normalized.housingType} border="border" />
+                {/*<p className="min-w-0 flex-1 truncate text-xs font-semibold text-greyscale-grey-800">*/}
+                {/*  {normalized.supplier}*/}
+                {/*</p>*/}
               </div>
               <div className="flex items-center justify-center">
                 <HouseICons {...normalized} />


### PR DESCRIPTION
<!--- Pull Request title = 커밋 메시지와 동일/ 해당 이슈를 close 하지 않을 경우, footer #이슈 번호 제외  -->

## #️⃣ Issue Number

#496 

<br/>
<br/>

## 📝 요약(Summary) (선택)

공급사 표시 위치를 재배치하고, 북마크 라벨 기준 필드를 통일(housingType)하는 UI/코드 정리


<br/>
<br/>

## 📸스크린샷 (선택)2

<img width="349" height="118" alt="image" src="https://github.com/user-attachments/assets/46782384-84a8-47f9-b489-1dcf376ead16" />
<br/>
<br/>
