### PR TITLE
refactor:리스트 헤더 정렬 로직 분리 및 헤더 UI 책임 단순화 리팩토링

### DIFF
--- a/src/features/listings/hooks/list/ListingsContentHeader.ts
+++ b/src/features/listings/hooks/list/ListingsContentHeader.ts
@@ -1,0 +1,40 @@
+import {
+  listingPoint,
+  useListingsFilterStore,
+  useListingsSearchState,
+} from "@/src/features/listings/model";
+import { useSearchParams } from "next/navigation";
+
+const LATEST_LABEL = "최신공고";
+const DEADLINE_LABEL = "마감임박";
+
+export const useListingsContentHeaderController = () => {
+  const sortType = useListingsFilterStore(state => state.sortType);
+  const setSortType = useListingsFilterStore(state => state.setSortType);
+  const setSearchSortType = useListingsSearchState(state => state.setSortType);
+  const searchSortType = useListingsSearchState(state => state.sortType);
+
+  const searchParams = useSearchParams();
+  const isSearchPage = searchParams.has("query");
+
+  const sortLabel = isSearchPage
+    ? searchSortType === "LATEST"
+      ? LATEST_LABEL
+      : DEADLINE_LABEL
+    : sortType;
+
+  const onToggleSort = () => {
+    if (isSearchPage) {
+      setSearchSortType(searchSortType === "LATEST" ? "DEADLINE" : "LATEST");
+      return;
+    }
+
+    setSortType(sortType === LATEST_LABEL ? DEADLINE_LABEL : LATEST_LABEL);
+  };
+
+  return {
+    listingPoint,
+    sortLabel,
+    onToggleSort,
+  };
+};

--- a/src/features/listings/ui/listingsContents/listingsContentCard.tsx
+++ b/src/features/listings/ui/listingsContents/listingsContentCard.tsx
@@ -1,14 +1,11 @@
 "use client";
 import { ListingUnion } from "@/src/entities/listings/model/type";
 import { ListingBookMark } from "./listingsBookMark";
-import {
-  HighlightCenteredText,
-  HouseICons,
-  HouseRental,
-} from "../../hooks/list/components/listingsHooks";
+
 import { formatApplyPeriod } from "@/src/shared/lib/utils";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { normalizeListing } from "../../model";
+import { HighlightCenteredText, HouseICons, HouseRental } from "@/src/features/listings/hooks";
 
 export const ListingContentsCard = <T extends ListingUnion>({ data }: { data: T[] }) => {
   const searchParams = useSearchParams();

--- a/src/features/listings/ui/listingsContents/listingsContentsHeader.tsx
+++ b/src/features/listings/ui/listingsContents/listingsContentsHeader.tsx
@@ -1,27 +1,16 @@
 "use client";
 import { ArrowUpArrowDown } from "@/src/assets/icons/button/arrowUpArrowDown";
-import { listingPoint, useListingsFilterStore, useListingsSearchState } from "../../model";
 import { CaretDropDown } from "@/src/shared/ui/dropDown/CaretDropDown";
 import { ListingsContentHeaderProps } from "@/src/entities/listings/model/type";
 import { MouseEvent } from "react";
-import { useSearchParams } from "next/navigation";
+
+import { useListingsContentHeaderController } from "@/src/features/listings/hooks/list/ListingsContentHeader";
 
 export const ListingsContentHeader = ({ totalCount }: ListingsContentHeaderProps) => {
-  const sortType = useListingsFilterStore(state => state.sortType);
-  const setSortType = useListingsFilterStore(state => state.setSortType);
-  const setSearchSortType = useListingsSearchState(state => state.setSortType);
-  const searchSortType = useListingsSearchState(state => state.sortType);
-
-  const searchParams = useSearchParams();
-  const isSearchPage = searchParams.has("query");
-
-  const onChange = (e: MouseEvent<HTMLDivElement>) => {
+  const { sortLabel, listingPoint, onToggleSort } = useListingsContentHeaderController();
+  const handleToggleSort = (e: MouseEvent<HTMLDivElement>) => {
     e.preventDefault();
-    const saveSortType = isSearchPage ? setSearchSortType : setSortType;
-    const nextSortType = sortType === "최신공고순" ? "마감임박순" : "최신공고순";
-    const nextSearchSortType = searchSortType === "LATEST" ? "DEADLINE" : "LATEST";
-    const sortTypeValue = isSearchPage ? nextSearchSortType : nextSortType;
-    saveSortType(sortTypeValue);
+    onToggleSort();
   };
 
   return (
@@ -44,10 +33,8 @@ export const ListingsContentHeader = ({ totalCount }: ListingsContentHeaderProps
           />
         </div>
 
-        <div className="flex items-center gap-1 hover:cursor-pointer" onClick={e => onChange(e)}>
-          <div className="text-sm font-bold">
-            {isSearchPage ? (searchSortType === "LATEST" ? "최신공고순" : "마감임박순") : sortType}
-          </div>
+        <div className="flex items-center gap-1 hover:cursor-pointer" onClick={handleToggleSort}>
+          <div className="text-sm font-bold">{sortLabel}</div>
           <ArrowUpArrowDown />
         </div>
       </div>


### PR DESCRIPTION


## #️⃣ Issue Number

#498 

<br/>
<br/>

## 📝 요약(Summary) (선택)

- 헤더에서 비즈니스 로직을 분리해 “표시 컴포넌트”에 가깝게 리팩토링했고, 정렬 동작은 전용 훅으로 이동했습니다. 구조가 명확해져 이후 변경 영향 범위가 줄어든 상태입니다.

<br/>
<br/>

