### PR TITLE
fix:리스트 헤더 정렬값 기준 통일로 sortType 파싱 이슈 수정

### DIFF
--- a/src/features/listings/hooks/list/ListingsContentHeader.ts
+++ b/src/features/listings/hooks/list/ListingsContentHeader.ts
@@ -5,8 +5,10 @@ import {
 } from "@/src/features/listings/model";
 import { useSearchParams } from "next/navigation";
 
-const LATEST_LABEL = "최신공고";
-const DEADLINE_LABEL = "마감임박";
+const NOTICE_LATEST = "최신공고순";
+const NOTICE_DEADLINE = "마감임박순";
+const SEARCH_LATEST = "LATEST";
+const SEARCH_DEADLINE = "DEADLINE";
 
 export const useListingsContentHeaderController = () => {
   const sortType = useListingsFilterStore(state => state.sortType);
@@ -18,18 +20,18 @@ export const useListingsContentHeaderController = () => {
   const isSearchPage = searchParams.has("query");
 
   const sortLabel = isSearchPage
-    ? searchSortType === "LATEST"
-      ? LATEST_LABEL
-      : DEADLINE_LABEL
+    ? searchSortType === SEARCH_LATEST
+      ? NOTICE_LATEST
+      : NOTICE_DEADLINE
     : sortType;
 
   const onToggleSort = () => {
     if (isSearchPage) {
-      setSearchSortType(searchSortType === "LATEST" ? "DEADLINE" : "LATEST");
+      setSearchSortType(searchSortType === SEARCH_LATEST ? SEARCH_DEADLINE : SEARCH_LATEST);
       return;
     }
 
-    setSortType(sortType === LATEST_LABEL ? DEADLINE_LABEL : LATEST_LABEL);
+    setSortType(sortType === NOTICE_LATEST ? NOTICE_DEADLINE : NOTICE_LATEST);
   };
 
   return {


### PR DESCRIPTION
<!--- Pull Request title = 커밋 메시지와 동일/ 해당 이슈를 close 하지 않을 경우, footer #이슈 번호 제외  -->

## #️⃣ Issue Number

#500 

<br/>
<br/>

## 📝 요약(Summary) (선택)

- 헤더 로직 분리 이후 생길 수 있던 “라벨 문자열 vs 실제 전송값” 불일치 포인트를 정렬 기준값 통일로 정리
- 결과적으로 서버/클라이언트 정렬 파라미터 호환성이 유지

<br/>
<br/>

