### PR TITLE
refactor:비교/리스트 쿼리키 공통화 및 ListingCompareSection 훅 분리

### DIFF
--- a/src/entities/listings/hooks/useListingDetailHooks.ts
+++ b/src/entities/listings/hooks/useListingDetailHooks.ts
@@ -6,9 +6,9 @@ import {
   InfraLabel,
   ListingDetailResponseWithColor,
   ListingRentalDetailVM,
+  ListingRoomCompareParams,
   ListingSummary,
   LstingBody,
-  UnitTypeRespnse,
   UseListingsHooksType,
   UseListingsHooksWithParam,
 } from "../model/type";
@@ -30,6 +30,7 @@ import {
 } from "@/src/features/listings/model";
 import { useOAuthStore } from "@/src/features/login/model";
 import { useDebounce } from "@/src/shared/hooks/useDebounce/useDebounce";
+import { compareNoticeQueryKey } from "@/src/shared/config";
 
 export const useListingDetailBasic = (id: string) => {
   const pinPointId = useOAuthStore(state => state.pinPointId);
@@ -219,8 +220,14 @@ export const useListingFilterDetail = <T>() => {
   });
 };
 
-export const useListingRoomCompare = <T>({ noticeId, sortType, nearbyFacilities }: QueryParams) => {
-  const { pinPointId } = useOAuthStore();
+export const useListingRoomCompare = <T>({
+  noticeId,
+  sortType,
+  nearbyFacilities,
+  pinPointId,
+}: ListingRoomCompareParams) => {
+  const { pinPointId: storePinPointId } = useOAuthStore();
+  const resolvedPinPointId = pinPointId ?? storePinPointId;
 
   const params: QueryParams = {
     pinPointId,
@@ -229,9 +236,15 @@ export const useListingRoomCompare = <T>({ noticeId, sortType, nearbyFacilities 
   };
 
   return useQuery<IResponse<T>, Error, T>({
-    queryKey: ["compareNotice", noticeId, sortType, nearbyFacilities, pinPointId],
+    queryKey: compareNoticeQueryKey({
+      noticeId,
+      sortType,
+      nearbyFacilities,
+      pinPointId: resolvedPinPointId,
+    }),
     queryFn: () => getNoticeParam<IResponse<T>>(`${NOTICE_ENDPOINT}/${noticeId}/compare`, params),
     placeholderData: prevData => prevData,
-    enabled: Boolean(noticeId && pinPointId),
+    staleTime: 1000 * 60 * 60 * 24,
+    enabled: Boolean(noticeId && resolvedPinPointId),
   });
 };

--- a/src/entities/listings/hooks/useListingHooks.ts
+++ b/src/entities/listings/hooks/useListingHooks.ts
@@ -1,6 +1,5 @@
 "use client";
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useMemo } from "react";
 import { PostBasicRequest, requestListingList } from "../api/listingsApi";
 import {
   LikeReturn,
@@ -24,8 +23,8 @@ import {
   useListingsSearchState,
   useListingState,
 } from "@/src/features/listings/model";
-import { useSearchParams } from "next/navigation";
-import { useDebounce } from "@/src/shared/hooks/useDebounce/useDebounce";
+
+import { listingListInfiniteQueryKey, listingSearchInfiniteQueryKey } from "@/src/shared/config";
 
 export const useListingListInfiniteQuery = () => {
   const status = useListingState(state => state.status);
@@ -44,7 +43,7 @@ export const useListingListInfiniteQuery = () => {
   };
 
   return useInfiniteQuery<ListingListPage>({
-    queryKey: ["listingListInfinite", filter, status],
+    queryKey: listingListInfiniteQueryKey({ filter, status }),
     enabled: !!status,
     initialPageParam: 1,
     queryFn: async ({ pageParam = 1 }) => {
@@ -138,7 +137,7 @@ export const useListingSearchInfiniteQuery = (queryOpt: SearchOptions) => {
   const status = useListingsSearchState(s => s.status);
 
   return useInfiniteQuery<ListingListPage>({
-    queryKey: ["listingSearchInfinite", keyword, sortType, status],
+    queryKey: listingSearchInfiniteQueryKey({ keyword, sortType, status }),
     enabled,
     staleTime,
     initialPageParam: 1,

--- a/src/entities/listings/model/type.ts
+++ b/src/entities/listings/model/type.ts
@@ -648,3 +648,10 @@ export interface UnitType {
 export interface UnitTypeRespnse {
   unitTypes: UnitType[];
 }
+
+export type ListingRoomCompareParams = {
+  noticeId: string;
+  sortType: string;
+  nearbyFacilities?: string[];
+  pinPointId?: string;
+};

--- a/src/features/listings/hooks/compare/useListingCompareSectionHooks.ts
+++ b/src/features/listings/hooks/compare/useListingCompareSectionHooks.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { useState } from "react";
+import { useListingRoomCompare } from "@/src/entities/listings/hooks/useListingDetailHooks";
+import { UnitTypeRespnse } from "@/src/entities/listings/model/type";
+import { SheetState, useListingState } from "@/src/features/listings/model";
+
+type UseListingCompareSectionHooksArgs = {
+  id: string;
+  sortType?: string;
+  nearbyFacilities?: string[];
+  pinPointId?: string;
+};
+
+export const useListingCompareSectionHooks = ({
+  id,
+  sortType,
+  nearbyFacilities,
+  pinPointId,
+}: UseListingCompareSectionHooksArgs) => {
+  const { status } = useListingState();
+  const [sheetState, setSheetState] = useState<SheetState>({ open: false });
+  const resolvedSortType = sortType ?? status;
+  const resolvedNearbyFacilities = nearbyFacilities ?? [];
+  const { data, isLoading } = useListingRoomCompare<UnitTypeRespnse>({
+    noticeId: id,
+    sortType: resolvedSortType,
+    nearbyFacilities: resolvedNearbyFacilities,
+    pinPointId,
+  });
+  const unitData = data?.unitTypes ?? [];
+  const count = unitData.length;
+  const zeroCount = count > 10 ? `0${count}` : `${count}`;
+  return {
+    sheetState,
+    setSheetState,
+    isLoading,
+    unitData,
+    zeroCount,
+  };
+};

--- a/src/features/listings/hooks/index.ts
+++ b/src/features/listings/hooks/index.ts
@@ -7,3 +7,4 @@ export * from "./list/useDetailColorHooks";
 export * from "./search/useListingsSearchData";
 export * from "./search/getSearchViewMode";
 export * from "./search/useListingsSearchRoute";
+export * from "./compare/useListingCompareSectionHooks";

--- a/src/shared/config/queryKeys.ts
+++ b/src/shared/config/queryKeys.ts
@@ -40,3 +40,42 @@ export const eligibilityKeys = {
   recommendedList: (userName?: string) =>
     [...eligibilityKeys.all, "recommendedList", userName] as const,
 } as const;
+
+// 방비교 QueryKeys
+export const compareNoticeQueryKey = ({
+  noticeId,
+  sortType,
+  nearbyFacilities = [],
+  pinPointId = "",
+}: {
+  noticeId: string;
+  sortType: string;
+  nearbyFacilities?: string[];
+  pinPointId?: string;
+}) => ["compareNotice", noticeId, sortType, nearbyFacilities, pinPointId] as const;
+
+//공고리스트 무한스크롤 QueryKeys
+export const listingListInfiniteQueryKey = ({
+  filter,
+  status,
+}: {
+  filter: {
+    regionType: string[];
+    rentalTypes: string[];
+    supplyTypes: string[];
+    houseTypes: string[];
+    sortType: string;
+  };
+  status: string;
+}) => ["listingListInfinite", filter, status] as const;
+
+//공고 조회 무한스크롤 QueryKeys
+export const listingSearchInfiniteQueryKey = ({
+  keyword,
+  sortType,
+  status,
+}: {
+  keyword: string;
+  sortType: string;
+  status: string;
+}) => ["listingSearchInfinite", keyword, sortType, status] as const;

--- a/src/shared/ui/animation/pageTransition.tsx
+++ b/src/shared/ui/animation/pageTransition.tsx
@@ -34,7 +34,11 @@ export const PageTransition = ({ children }: { children: ReactNode }) => {
 
   return (
     <div className="relative h-full min-h-0 w-full overflow-hidden">
-      <div className="no-scrollbar h-full min-h-0 overflow-y-auto" ref={scrollRef} onScroll={handleScroll}>
+      <div
+        className="no-scrollbar h-full min-h-0 overflow-y-auto"
+        ref={scrollRef}
+        onScroll={handleScroll}
+      >
         <AnimatePresence mode="wait">
           <motion.div
             key={pathname}

--- a/src/widgets/listingsSection/server/compare/prefetchCompareQueries.ts
+++ b/src/widgets/listingsSection/server/compare/prefetchCompareQueries.ts
@@ -1,6 +1,6 @@
 import type { QueryClient } from "@tanstack/react-query";
 import { CompareBffResponse } from "@/src/features/listings/server/bff/getCompareInitialFromBff";
-import { cookies } from "next/headers";
+import { compareNoticeQueryKey } from "@/src/shared/config";
 
 type CompareInitialData = CompareBffResponse["data"];
 type PrefetchNoticeArgs = {
@@ -22,8 +22,14 @@ export async function preFetchCompareQueries({
 }: PrefetchNoticeArgs) {
   if (initial) {
     await queryClient.prefetchQuery({
-      queryKey: ["compareNotice", id, sortType, nearbyFacilities, pinPointId],
+      queryKey: compareNoticeQueryKey({
+        noticeId: id,
+        sortType,
+        nearbyFacilities,
+        pinPointId,
+      }),
       queryFn: async () => initial,
+      staleTime: 1000 * 60 * 60 * 24,
     });
   }
 }

--- a/src/widgets/listingsSection/server/notice/prefetchNoticeQueries.ts
+++ b/src/widgets/listingsSection/server/notice/prefetchNoticeQueries.ts
@@ -2,6 +2,7 @@ import type { QueryClient } from "@tanstack/react-query";
 import type { ListingListPage } from "@/src/entities/listings/model/type";
 import { useListingsFilterStore, useListingState } from "@/src/features/listings/model";
 import { ListingsNoticeBffResponse } from "@/src/features/listings/server/bff/getNoticeInitialFromBff";
+import { listingListInfiniteQueryKey } from "@/src/shared/config";
 
 type NoticeInitialData = ListingsNoticeBffResponse["data"];
 type PrefetchNoticeArgs = {
@@ -16,12 +17,10 @@ export async function prefetchNoticeQueries({ queryClient, initial }: PrefetchNo
     useListingsFilterStore.getState();
   const { status } = useListingState.getState();
 
+  const filter = { regionType, rentalTypes, supplyTypes, houseTypes, sortType };
+
   await queryClient.prefetchInfiniteQuery({
-    queryKey: [
-      "listingListInfinite",
-      { regionType, rentalTypes, supplyTypes, houseTypes, sortType },
-      status,
-    ],
+    queryKey: listingListInfiniteQueryKey({ filter, status }),
     initialPageParam: 1,
     queryFn: async () => initial.page,
     getNextPageParam: (lastPage: ListingListPage) =>

--- a/src/widgets/listingsSection/ui/listingsCompareRoomSection/listingsCompareRoomPage.tsx
+++ b/src/widgets/listingsSection/ui/listingsCompareRoomSection/listingsCompareRoomPage.tsx
@@ -33,7 +33,12 @@ export async function ListingsCompareRoomPage({ id }: ListingsCompareRoomPagePro
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
       <main className="flex h-full flex-col">
-        <ListingCompareSection id={id} sortType={sortType} nearbyFacilities={nearbyFacilities} />
+        <ListingCompareSection
+          id={id}
+          sortType={sortType}
+          nearbyFacilities={nearbyFacilities}
+          pinPointId={pinPointId}
+        />
       </main>
     </HydrationBoundary>
   );

--- a/src/widgets/listingsSection/ui/listingsCompareRoomSection/listingsCompareRoomSection.tsx
+++ b/src/widgets/listingsSection/ui/listingsCompareRoomSection/listingsCompareRoomSection.tsx
@@ -1,9 +1,5 @@
 "use client";
 
-import { useState } from "react";
-import { useListingRoomCompare } from "@/src/entities/listings/hooks/useListingDetailHooks";
-import { UnitTypeRespnse } from "@/src/entities/listings/model/type";
-import { SheetState, useListingState } from "@/src/features/listings/model";
 import {
   ListingCompareCard,
   ListingCompareHeader,
@@ -12,32 +8,28 @@ import {
 import { InfraSheet } from "@/src/features/listings/ui/listingsCardDetail/infra/infraSheet";
 import { ListingCompareCardSkeleton } from "@/src/features/listings/ui/listingsCompareRoom/components/listingsCompareCardSkeleton";
 import { PageTransition } from "@/src/shared/ui/animation";
+import { useListingCompareSectionHooks } from "@/src/features/listings/hooks";
 
 type ListingCompareSectionProps = {
   id: string;
   sortType?: string;
   nearbyFacilities?: string[];
+  pinPointId: string;
 };
 
 export const ListingCompareSection = ({
   id,
   sortType,
   nearbyFacilities,
+  pinPointId,
 }: ListingCompareSectionProps) => {
-  const { status } = useListingState();
-  const [sheetState, setSheetState] = useState<SheetState>({ open: false });
-  const resolvedSortType = sortType ?? status;
-  const resolvedNearbyFacilities = nearbyFacilities ?? [];
-
-  const { data, isLoading } = useListingRoomCompare<UnitTypeRespnse>({
-    noticeId: id,
-    sortType: resolvedSortType,
-    nearbyFacilities: resolvedNearbyFacilities,
-  });
-
-  const unitData = data?.unitTypes;
-  const count = Number(data?.unitTypes?.length);
-  const zeroCount = count > 10 ? `0${count}` : `${count}`;
+  const { sheetState, setSheetState, isLoading, unitData, zeroCount } =
+    useListingCompareSectionHooks({
+      id,
+      sortType,
+      nearbyFacilities,
+      pinPointId,
+    });
 
   return (
     <section className="mx-auto min-h-full w-full">


### PR DESCRIPTION

## #️⃣ Issue Number

#504 

<br/>
<br/>

## 📝 요약(Summary) (선택)

- 쿼리키 중앙화 + compare 섹션 훅 분리 + SSR/CSR 키 정합성
- useListingCompareSectionHooks 신설로 compare 섹션 UI/로직 분리
- SSR prefetch(compare/notice)에서 공통 queryKey 사용하도록 정합성 개선
- compare 쿼리 staleTime 적용 및 pinPointId 전달 경로 정리

<br/>
<br/>
