### PR TITLE
feat:채팅 입력 상태를 useChangeChat으로 분리하고 버튼 활성

### DIFF
--- a/src/features/chat/hooks/useChatHooks.ts
+++ b/src/features/chat/hooks/useChatHooks.ts
@@ -1,9 +1,4 @@
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useState } from "react";
-
-interface ChatEntryProps {
-  initialChatOpen?: boolean;
-}
+import { ChangeEvent, KeyboardEvent, useState } from "react";
 
 export const useChatHooks = ({ initialChatOpen = false }) => {
   const [isChatOpen, setIsChatOpen] = useState(initialChatOpen);
@@ -29,5 +24,33 @@ export const useChatHooks = ({ initialChatOpen = false }) => {
     openChat,
     closeChat,
     isChatOpen,
+  };
+};
+
+export const useChangeChat = () => {
+  const [query, setQuery] = useState("");
+  const hasQuery = query.trim().length > 0;
+
+  const handleChangeQuery = (event: ChangeEvent<HTMLInputElement>) => {
+    setQuery(event.target.value);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== "Enter") return;
+    if (event.nativeEvent.isComposing) return;
+    onSubmitQuery(query);
+  };
+
+  const onSubmitQuery = (query: string) => {
+    const url = new URL(window.location.href);
+    url.searchParams.set("chat", query);
+    window.history.replaceState(null, "", `${url.pathname}${url.search}${url.hash}`);
+  };
+
+  return {
+    query,
+    handleChangeQuery,
+    handleKeyDown,
+    hasQuery,
   };
 };

--- a/src/features/chat/ui/chatEntry.tsx
+++ b/src/features/chat/ui/chatEntry.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useChatHooks } from "@/src/features/chat/hooks/useChatHooks";
+import { useChangeChat, useChatHooks } from "@/src/features/chat/hooks/useChatHooks";
 import ChatWidgets from "./chat";
 import ChatPanel from "./chatPanel";
 import ChatSheet from "./chatSheet";
@@ -11,11 +11,18 @@ interface ChatEntryProps {
 
 export default function ChatEntry({ initialChatOpen = false }: ChatEntryProps) {
   const { isChatOpen, openChat, closeChat } = useChatHooks({ initialChatOpen: initialChatOpen });
+  const { query, hasQuery, handleChangeQuery, handleKeyDown } = useChangeChat();
   return (
     <>
       <ChatWidgets onClick={openChat} />
       <ChatSheet open={isChatOpen} onClose={closeChat}>
-        <ChatPanel onClose={closeChat} />
+        <ChatPanel
+          onClose={closeChat}
+          query={query}
+          hasQuery={hasQuery}
+          onChangeQuery={handleChangeQuery}
+          onSubmitQuery={handleKeyDown}
+        />
       </ChatSheet>
     </>
   );

--- a/src/features/chat/ui/chatPanel.tsx
+++ b/src/features/chat/ui/chatPanel.tsx
@@ -1,15 +1,25 @@
 "use client";
 
+import { ChangeEvent, KeyboardEvent } from "react";
 import { ArrowUp } from "lucide-react";
 import { LeftButton } from "@/src/assets/icons/button/leftButton";
-import { ChatIcon } from "@/src/assets/images/chat/chatIcon";
 import { ChatCounselor } from "@/src/assets/images/chat/chatCounselor";
 
 type ChatPanelProps = {
   onClose: () => void;
+  query: string;
+  hasQuery: boolean;
+  onChangeQuery: (event: ChangeEvent<HTMLInputElement>) => void;
+  onSubmitQuery: (event: KeyboardEvent<HTMLInputElement>) => void;
 };
 
-export default function ChatPanel({ onClose }: ChatPanelProps) {
+export default function ChatPanel({
+  onClose,
+  query,
+  hasQuery,
+  onChangeQuery,
+  onSubmitQuery,
+}: ChatPanelProps) {
   return (
     <section className="flex h-full min-h-0 flex-col bg-white">
       <header className="relative flex items-center justify-center px-5 pb-4 pt-6">
@@ -42,12 +52,17 @@ export default function ChatPanel({ onClose }: ChatPanelProps) {
           <div className="flex items-center gap-3">
             <input
               type="text"
+              value={query}
               placeholder="궁금한 질문이 있으면 물어보세요."
               className="flex-1 bg-transparent text-[14px] text-[#191F28] outline-none placeholder:text-[#B8BED3]"
+              onChange={onChangeQuery}
+              onKeyDown={onSubmitQuery}
             />
             <button
               type="button"
-              className="flex h-6 w-6 items-center justify-center rounded-full bg-[#D9DEEC] text-white"
+              className={`flex h-6 w-6 items-center justify-center rounded-full transition-colors ${
+                hasQuery ? "bg-[#4E80FF] text-white" : "bg-[#D9DEEC] text-white"
+              }`}
               aria-label="메시지 전송"
             >
               <ArrowUp className="h-3.5 w-3.5" strokeWidth={2.5} />


### PR DESCRIPTION
<!--- Pull Request title = 커밋 메시지와 동일/ 해당 이슈를 close 하지 않을 경우, footer #이슈 번호 제외  -->

## #️⃣ Issue Number

#513 

<br/>
<br/>

## 📝 요약(Summary) (선택)

useChangeChat가 query 상태, hasQuery 파생값, 입력 변경 핸들러, 엔터 제출 핸들러를 모두 갖도록 정리했습니다. ChatEntry는 훅에서 받은 값을 ChatPanel에 전달만 하도록 바뀌었고, ChatPanel은 controlled input과 버튼 배경색 렌더링만 담당하도록 분리했습니다.

<br/>
<br/>

