### PR TITLE
feat:채팅 엔트리를 서버·클라이언트로 분리하고 초기 chat 쿼리 SSR 연동 추가

### DIFF
--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -6,7 +6,9 @@ export const dynamic = "force-dynamic";
 
 export default async function Page({ searchParams }: { searchParams: Promise<SearchParams> }) {
   const params = await searchParams;
+  const rawChat = params.chat;
+  const initialQuery = typeof rawChat === "string" ? rawChat : "";
   const initialChatOpen = Object.prototype.hasOwnProperty.call(params, "chat");
 
-  return <HomeSectionPage initialChatOpen={initialChatOpen} />;
+  return <HomeSectionPage initialChatOpen={initialChatOpen} initialQuery={initialQuery} />;
 }

--- a/src/features/chat/client/chatEntryClient.tsx
+++ b/src/features/chat/client/chatEntryClient.tsx
@@ -1,17 +1,20 @@
 "use client";
-
 import { useChangeChat, useChatHooks } from "@/src/features/chat/hooks/useChatHooks";
-import ChatWidgets from "./chat";
-import ChatPanel from "./chatPanel";
-import ChatSheet from "./chatSheet";
+import ChatWidgets from "@/src/features/chat/ui/chat";
+import ChatSheet from "@/src/features/chat/ui/chatSheet";
+import ChatPanel from "@/src/features/chat/ui/chatPanel";
 
 interface ChatEntryProps {
   initialChatOpen?: boolean;
+  initialQuery?: string;
 }
 
-export default function ChatEntry({ initialChatOpen = false }: ChatEntryProps) {
+export default function ChatEntryClient({
+  initialChatOpen = false,
+  initialQuery = "",
+}: ChatEntryProps) {
   const { isChatOpen, openChat, closeChat } = useChatHooks({ initialChatOpen: initialChatOpen });
-  const { query, hasQuery, handleChangeQuery, handleKeyDown } = useChangeChat();
+  const { query, hasQuery, handleChangeQuery, handleKeyDown } = useChangeChat({ initialQuery });
   return (
     <>
       <ChatWidgets onClick={openChat} />

--- a/src/features/chat/hooks/useChatHooks.ts
+++ b/src/features/chat/hooks/useChatHooks.ts
@@ -1,7 +1,7 @@
 import { ChangeEvent, KeyboardEvent, useState } from "react";
 
 export const useChatHooks = ({ initialChatOpen = false }) => {
-  const [isChatOpen, setIsChatOpen] = useState(initialChatOpen);
+  const [isChatOpen, setIsChatOpen] = useState<boolean>(initialChatOpen);
 
   const setChatQuery = (open: boolean) => {
     const url = new URL(window.location.href);
@@ -27,8 +27,8 @@ export const useChatHooks = ({ initialChatOpen = false }) => {
   };
 };
 
-export const useChangeChat = () => {
-  const [query, setQuery] = useState("");
+export const useChangeChat = ({ initialQuery = "" }: { initialQuery: string }) => {
+  const [query, setQuery] = useState<string>(initialQuery);
   const hasQuery = query.trim().length > 0;
 
   const handleChangeQuery = (event: ChangeEvent<HTMLInputElement>) => {

--- a/src/features/chat/index.ts
+++ b/src/features/chat/index.ts
@@ -1,1 +1,1 @@
-export { default as ChatEntry } from "@/src/features/chat/ui/chatEntry";
+export * from "./server/ui/chatEntry";

--- a/src/features/chat/server/ui/chatEntry.tsx
+++ b/src/features/chat/server/ui/chatEntry.tsx
@@ -1,0 +1,10 @@
+import ChatEntryClient from "@/src/features/chat/client/chatEntryClient";
+
+interface ChatEntryProps {
+  initialChatOpen?: boolean;
+  initialQuery?: string;
+}
+
+export default function ChatEntry({ initialChatOpen = false, initialQuery = "" }: ChatEntryProps) {
+  return <ChatEntryClient initialChatOpen={initialChatOpen} initialQuery={initialQuery} />;
+}

--- a/src/widgets/homeSection/homeSection.tsx
+++ b/src/widgets/homeSection/homeSection.tsx
@@ -5,13 +5,14 @@ import { HomeHeroServer } from "@/src/features/home/ui/server/homeHero.server";
 import { HomeQuickStatsListServer } from "@/src/features/home/ui/server/homeQuickStatsList.server";
 import { HomeUrgentNoticeListServer } from "@/src/features/home/ui/server/homeUrgentNoticeList.server";
 import { HomeHeaderServer } from "@/src/features/home/ui/server/homeHeader.server";
-import { ChatEntry } from "@/src/features/chat";
+import ChatEntry from "@/src/features/chat/server/ui/chatEntry";
 
 interface ChatEntryProps {
   initialChatOpen?: boolean;
+  initialQuery?: string;
 }
 
-export const HomeSection = ({ initialChatOpen = false }: ChatEntryProps) => {
+export const HomeSection = ({ initialChatOpen = false, initialQuery = "" }: ChatEntryProps) => {
   return (
     <section className="relative min-h-screen w-full bg-greyscale-grey-25 text-greyscale-grey-900 scrollbar-hide">
       <PageTransition>
@@ -30,7 +31,7 @@ export const HomeSection = ({ initialChatOpen = false }: ChatEntryProps) => {
           <div className="px-5">
             <HomeUrgentNoticeListServer />
           </div>
-          <ChatEntry initialChatOpen={initialChatOpen} />
+          <ChatEntry initialChatOpen={initialChatOpen} initialQuery={initialQuery} />
         </div>
       </PageTransition>
     </section>

--- a/src/widgets/homeSection/homeSectionPage.tsx
+++ b/src/widgets/homeSection/homeSectionPage.tsx
@@ -5,9 +5,13 @@ import { getHomeInitialData } from "./server/getHomeInitialData";
 
 interface HomeSectionPageProps {
   initialChatOpen?: boolean;
+  initialQuery?: string;
 }
 
-export async function HomeSectionPage({ initialChatOpen = false }: HomeSectionPageProps) {
+export async function HomeSectionPage({
+  initialChatOpen = false,
+  initialQuery = "",
+}: HomeSectionPageProps) {
   const queryClient = new QueryClient();
   const { initial, initialCount } = await getHomeInitialData();
 
@@ -31,7 +35,7 @@ export async function HomeSectionPage({ initialChatOpen = false }: HomeSectionPa
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
       <main className="flex h-full flex-col">
-        <HomeSection initialChatOpen={initialChatOpen} />
+        <HomeSection initialChatOpen={initialChatOpen} initialQuery={initialQuery} />
       </main>
     </HydrationBoundary>
   );


### PR DESCRIPTION
<!--- Pull Request title = 커밋 메시지와 동일/ 해당 이슈를 close 하지 않을 경우, footer #이슈 번호 제외  -->

## #️⃣ Issue Number

#515 

<br/>
<br/>

## 📝 요약(Summary) (선택)

현재 git status 기준으로 페이지, 홈 섹션, 채팅 훅, 채팅 엔트리 관련 파일들이 변경됐고, 기존 클라이언트 엔트리 파일은 삭제 후 서버/클라이언트 분리 구조로 대체됐습니다. 핵심은 “초기값은 서버, 인터랙션은 클라이언트”로 리팩터링한 것입니다.

<br/>
<br/>
