### PR TITLE
refactor:공고 상세 API 호출 구조를 BFF 패턴으로 전환

### DIFF
--- a/app/api/listings/detail/[noticeId]/compare/route.ts
+++ b/app/api/listings/detail/[noticeId]/compare/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getListingCompareOnServer } from "@/src/features/listings/server/callServer/getListingDetailOnServer";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ noticeId: string }> }
+) {
+  try {
+    const { noticeId } = await params;
+    const sp = req.nextUrl.searchParams;
+    const sortType = sp.get("sortType") ?? "LATEST";
+    const pinPointId = sp.get("pinPointId") ?? undefined;
+    const nearbyFacilities = sp.getAll("nearbyFacilities");
+
+    const data = await getListingCompareOnServer({
+      noticeId,
+      sortType,
+      nearbyFacilities,
+      pinPointId,
+    });
+
+    if (!data) {
+      return NextResponse.json(
+        { success: false, message: "Failed to fetch listing compare." },
+        { status: 401 }
+      );
+    }
+
+    return NextResponse.json({ success: true, data }, { status: 200 });
+  } catch {
+    return NextResponse.json({ success: false, message: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/app/api/listings/detail/[noticeId]/filter/[filterType]/route.ts
+++ b/app/api/listings/detail/[noticeId]/filter/[filterType]/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { getListingDetailFilterOnServer } from "@/src/features/listings/server/callServer/getListingDetailOnServer";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ noticeId: string; filterType: string }> }
+) {
+  try {
+    const { noticeId, filterType } = await params;
+    const data = await getListingDetailFilterOnServer(noticeId, filterType);
+
+    if (!data) {
+      return NextResponse.json(
+        { success: false, message: "Failed to fetch listing detail filter." },
+        { status: 401 }
+      );
+    }
+
+    return NextResponse.json({ success: true, data }, { status: 200 });
+  } catch {
+    return NextResponse.json({ success: false, message: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/app/api/listings/detail/[noticeId]/route.ts
+++ b/app/api/listings/detail/[noticeId]/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getListingDetailBasicOnServer } from "@/src/features/listings/server/callServer/getListingDetailOnServer";
+import type { LstingBody } from "@/src/entities/listings/model/type";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ noticeId: string }> }
+) {
+  try {
+    const { noticeId } = await params;
+    const body = (await req.json()) as LstingBody;
+    const data = await getListingDetailBasicOnServer(noticeId, body);
+
+    if (!data) {
+      return NextResponse.json(
+        { success: false, message: "Failed to fetch listing detail." },
+        { status: 401 }
+      );
+    }
+
+    return NextResponse.json({ success: true, data }, { status: 200 });
+  } catch {
+    return NextResponse.json({ success: false, message: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/app/api/listings/detail/complexes/[complexId]/[resource]/route.ts
+++ b/app/api/listings/detail/complexes/[complexId]/[resource]/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  getListingComplexResourceOnServer,
+  getListingComplexTransitOnServer,
+} from "@/src/features/listings/server/callServer/getListingDetailOnServer";
+
+export const dynamic = "force-dynamic";
+
+const ALLOWED_RESOURCES = new Set(["unit", "transit"]);
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ complexId: string; resource: string }> }
+) {
+  try {
+    const { complexId, resource } = await params;
+
+    if (!ALLOWED_RESOURCES.has(resource)) {
+      return NextResponse.json(
+        { success: false, message: "Unsupported listing complex resource." },
+        { status: 404 }
+      );
+    }
+
+    const data =
+      resource === "transit"
+        ? await getListingComplexTransitOnServer(complexId, {
+            pinPointId: req.nextUrl.searchParams.get("pinPointId"),
+          })
+        : await getListingComplexResourceOnServer(complexId, resource);
+
+    if (!data) {
+      return NextResponse.json(
+        { success: false, message: "Failed to fetch listing complex resource." },
+        { status: 401 }
+      );
+    }
+
+    return NextResponse.json({ success: true, data }, { status: 200 });
+  } catch {
+    return NextResponse.json({ success: false, message: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/app/api/listings/detail/complexes/[complexId]/infra/route.ts
+++ b/app/api/listings/detail/complexes/[complexId]/infra/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { getListingComplexInfraOnServer } from "@/src/features/listings/server/callServer/getListingDetailOnServer";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ complexId: string }> }
+) {
+  try {
+    const { complexId } = await params;
+    const data = await getListingComplexInfraOnServer(complexId);
+
+    if (!data) {
+      return NextResponse.json(
+        { success: false, message: "Failed to fetch listing complex infra." },
+        { status: 401 }
+      );
+    }
+
+    return NextResponse.json({ success: true, data }, { status: 200 });
+  } catch {
+    return NextResponse.json({ success: false, message: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/app/api/listings/detail/complexes/[complexId]/route.ts
+++ b/app/api/listings/detail/complexes/[complexId]/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getListingComplexSummaryOnServer } from "@/src/features/listings/server/callServer/getListingDetailOnServer";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ complexId: string }> }
+) {
+  try {
+    const { complexId } = await params;
+    const pinPointId = req.nextUrl.searchParams.get("pinPointId") ?? undefined;
+    const data = await getListingComplexSummaryOnServer(complexId, pinPointId);
+
+    if (!data) {
+      return NextResponse.json(
+        { success: false, message: "Failed to fetch listing complex summary." },
+        { status: 401 }
+      );
+    }
+
+    return NextResponse.json({ success: true, data }, { status: 200 });
+  } catch {
+    return NextResponse.json({ success: false, message: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/src/entities/listings/api/listingDetailBffApi.ts
+++ b/src/entities/listings/api/listingDetailBffApi.ts
@@ -1,0 +1,146 @@
+import type {
+  Environmnt,
+  ListingDetailData,
+  ListingDetailResponse,
+  ListingRentalDetailVM,
+  ListingSummary,
+  LstingBody,
+  UnitTypeRespnse,
+} from "@/src/entities/listings/model/type";
+
+type BffResponse<T> = {
+  success: boolean;
+  data?: T;
+};
+
+async function requestBff<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    cache: "no-store",
+    credentials: "include",
+    ...init,
+  });
+
+  if (!res.ok) {
+    throw new Error("Failed to fetch listing detail BFF.");
+  }
+
+  const body = (await res.json()) as BffResponse<T>;
+  if (!body.success || body.data === undefined || body.data === null) {
+    throw new Error("Invalid listing detail BFF response.");
+  }
+
+  return body.data;
+}
+
+function appendArrayParam(query: URLSearchParams, key: string, values?: string[]) {
+  values?.forEach(value => {
+    if (value) query.append(key, value);
+  });
+}
+
+export async function getListingDetailBasicFromBff(
+  noticeId: string,
+  body: LstingBody
+): Promise<ListingDetailResponse> {
+  const data = await requestBff<ListingDetailData>(
+    `/api/listings/detail/${encodeURIComponent(noticeId)}`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    }
+  );
+
+  return {
+    success: true,
+    code: 200,
+    message: "OK",
+    data,
+  };
+}
+
+export async function getListingComplexSummaryFromBff({
+  complexId,
+  pinPointId,
+}: {
+  complexId: string;
+  pinPointId?: string;
+}): Promise<ListingSummary> {
+  const query = new URLSearchParams();
+  if (pinPointId) query.set("pinPointId", pinPointId);
+
+  const queryString = query.toString();
+  return requestBff<ListingSummary>(
+    `/api/listings/detail/complexes/${encodeURIComponent(complexId)}${queryString ? `?${queryString}` : ""}`
+  );
+}
+
+export async function getListingComplexInfraFromBff(complexId: string): Promise<Environmnt> {
+  return requestBff<Environmnt>(
+    `/api/listings/detail/complexes/${encodeURIComponent(complexId)}/infra`
+  );
+}
+
+export async function getListingComplexResourceFromBff<T>({
+  complexId,
+  resource,
+}: {
+  complexId: string;
+  resource: string;
+}): Promise<T> {
+  return requestBff<T>(
+    `/api/listings/detail/complexes/${encodeURIComponent(complexId)}/${encodeURIComponent(resource)}`
+  );
+}
+
+export async function getListingComplexTransitFromBff<T>({
+  complexId,
+  pinPointId,
+}: {
+  complexId: string;
+  pinPointId?: string;
+}): Promise<T> {
+  const query = new URLSearchParams();
+  if (pinPointId) query.set("pinPointId", pinPointId);
+
+  const queryString = query.toString();
+  return requestBff<T>(
+    `/api/listings/detail/complexes/${encodeURIComponent(complexId)}/transit${queryString ? `?${queryString}` : ""}`
+  );
+}
+
+export async function getListingDetailFilterFromBff<T>({
+  noticeId,
+  filterType,
+}: {
+  noticeId: string;
+  filterType: string;
+}): Promise<T> {
+  return requestBff<T>(
+    `/api/listings/detail/${encodeURIComponent(noticeId)}/filter/${encodeURIComponent(filterType)}`
+  );
+}
+
+export async function getListingCompareFromBff({
+  noticeId,
+  sortType,
+  nearbyFacilities,
+  pinPointId,
+}: {
+  noticeId: string;
+  sortType: string;
+  nearbyFacilities?: string[];
+  pinPointId?: string;
+}): Promise<UnitTypeRespnse> {
+  const query = new URLSearchParams({ sortType });
+  if (pinPointId) query.set("pinPointId", pinPointId);
+  appendArrayParam(query, "nearbyFacilities", nearbyFacilities);
+
+  return requestBff<UnitTypeRespnse>(
+    `/api/listings/detail/${encodeURIComponent(noticeId)}/compare?${query.toString()}`
+  );
+}
+
+export type { ListingRentalDetailVM };

--- a/src/entities/listings/hooks/useListingDetailHooks.ts
+++ b/src/entities/listings/hooks/useListingDetailHooks.ts
@@ -1,26 +1,24 @@
 import { useQuery } from "@tanstack/react-query";
 import {
-  endPoint,
   Environmnt,
   InfraConfig,
   InfraLabel,
+  ListingDetailResponse,
   ListingDetailResponseWithColor,
   ListingRentalDetailVM,
   ListingRoomCompareParams,
   ListingSummary,
-  LstingBody,
   UseListingsHooksType,
   UseListingsHooksWithParam,
 } from "../model/type";
 import {
-  getNoticeParam,
-  PostBasicRequest,
-  PostParamsBodyRequest,
-  QueryParams,
-  requestListingList,
-} from "../api/listingsApi";
-import { COMPLEXES_ENDPOINT, NOTICE_ENDPOINT } from "@/src/shared/api";
-import { IResponse } from "@/src/shared/types";
+  getListingCompareFromBff,
+  getListingComplexInfraFromBff,
+  getListingComplexResourceFromBff,
+  getListingComplexSummaryFromBff,
+  getListingComplexTransitFromBff,
+  getListingDetailBasicFromBff,
+} from "../api/listingDetailBffApi";
 import { getListingsRental } from "@/src/features/listings/hooks/list/components/listingsHooks";
 import {
   INFRA_ENVIRONMENT_CONFIG,
@@ -46,7 +44,7 @@ export const useListingDetailBasic = (id: string) => {
   const debouncedMaxMonthPay = useDebounce(maxMonthPay, 500);
   const parseMoney = (value: string) => (value ? Number(value.replace(/[^0-9]/g, "")) : 0);
 
-  return useQuery<ListingDetailResponseWithColor>({
+  return useQuery<ListingDetailResponse, Error, ListingDetailResponseWithColor>({
     queryKey: [
       "listingDetailBasic",
       id,
@@ -64,12 +62,7 @@ export const useListingDetailBasic = (id: string) => {
     retry: false,
 
     queryFn: async () => {
-      return PostBasicRequest<
-        ListingDetailResponseWithColor,
-        IResponse<ListingDetailResponseWithColor>,
-        LstingBody,
-        ListingDetailResponseWithColor
-      >(`${NOTICE_ENDPOINT}/${id}`, "post", {
+      return getListingDetailBasicFromBff(id, {
         sortType,
         pinPointId,
         transitTime: debouncedDistance,
@@ -82,12 +75,13 @@ export const useListingDetailBasic = (id: string) => {
       });
     },
     select: response => {
-      const basic = response.data?.basicInfo;
+      const data = response.data!;
+      const basic = data.basicInfo;
 
       return {
         ...response,
         data: {
-          ...response.data,
+          ...data,
           basicInfo: {
             ...basic,
             rentalColor: getListingsRental(basic.type),
@@ -107,14 +101,9 @@ export const useListingRentalDetail = (id: string) => {
     enabled: !!id,
     staleTime: 1000 * 60 * 5,
     queryFn: async () => {
-      return await requestListingList<
-        ListingSummary,
-        IResponse<ListingSummary>,
-        undefined,
-        { pinPointId: string },
-        ListingSummary
-      >(`${COMPLEXES_ENDPOINT}/${encodedId}`, "get", {
-        params: { pinPointId: pinPointId },
+      return await getListingComplexSummaryFromBff({
+        complexId: id,
+        pinPointId,
       });
     },
     select: (response): ListingRentalDetailVM => {
@@ -139,18 +128,14 @@ export const useListingRentalDetail = (id: string) => {
 export const useListingInfraDetail = (id: string) => {
   const encodedId = encodeURIComponent(id);
 
-  return useQuery<IResponse<Environmnt>, Error, InfraConfig[]>({
+  return useQuery<Environmnt, Error, InfraConfig[]>({
     queryKey: ["useListingInfraDetail", encodedId],
     enabled: !!id,
     staleTime: 1000 * 60 * 5,
-    queryFn: () =>
-      PostBasicRequest<Environmnt, IResponse<Environmnt>, {}, IResponse<Environmnt>>(
-        `${COMPLEXES_ENDPOINT}/infra/${encodedId}`,
-        "get"
-      ),
+    queryFn: () => getListingComplexInfraFromBff(id),
 
     select: response => {
-      const infraLabels = (response.data?.infra ?? []) as InfraLabel[];
+      const infraLabels = (response.infra ?? []) as InfraLabel[];
 
       return infraLabels
         .map(label => {
@@ -166,16 +151,16 @@ export const useListingInfraDetail = (id: string) => {
 
 export const useListingRoomTypeDetail = <T>({ id, queryK, url }: UseListingsHooksType) => {
   const encodedId = encodeURIComponent(id);
-  return useQuery<IResponse<T[]>, Error, T[]>({
+  return useQuery<T[], Error, T[]>({
     queryKey: [queryK, encodedId],
     enabled: !!id,
     staleTime: 1000 * 60 * 5,
     queryFn: () =>
-      PostBasicRequest<T[], IResponse<T[]>, {}, IResponse<T[]>>(
-        `${COMPLEXES_ENDPOINT}/${url}/${encodedId}`,
-        "get"
-      ),
-    select: response => response.data ?? [],
+      getListingComplexResourceFromBff<T[]>({
+        complexId: id,
+        resource: url,
+      }),
+    select: response => response ?? [],
   });
 };
 
@@ -187,39 +172,35 @@ export const useListingRouteDetail = <T, TParam extends object>({
 }: UseListingsHooksWithParam<TParam>) => {
   const encodedId = encodeURIComponent(id);
 
-  return useQuery<IResponse<T>, Error, T | null>({
+  return useQuery<T, Error, T | null>({
     queryKey: [queryK, encodedId, params],
     enabled: !!id,
     staleTime: 1000 * 60 * 5,
 
-    queryFn: () =>
-      PostParamsBodyRequest<T, IResponse<T>, {}, IResponse<T>, TParam>(
-        `${COMPLEXES_ENDPOINT}/${url}/${encodedId}`,
-        "get",
-        {},
-        { query: params }
-      ),
+    queryFn: () => {
+      const pinPointId =
+        "pinPointId" in params && typeof params.pinPointId === "string"
+          ? params.pinPointId
+          : undefined;
+
+      if (url === "transit") {
+        return getListingComplexTransitFromBff<T>({
+          complexId: id,
+          pinPointId,
+        });
+      }
+
+      return getListingComplexResourceFromBff<T>({
+        complexId: id,
+        resource: url,
+      });
+    },
 
     select: response => {
-      return response.data ?? null;
+      return response ?? null;
     },
   });
 };
-
-// export const useListingFilterDetail = <T>() => {
-//   return useQuery<IResponse<T>, Error, T>({
-//     queryKey: ["pinpointSettings"],
-//     staleTime: 1000 * 60 * 5,
-//     placeholderData: previousData => previousData,
-//     queryFn: () => PostBasicRequest<T, IResponse<T>, {}, IResponse<T>>(endPoint["pinpoint"], "get"),
-//     select: response => {
-//       if (response.data === undefined) {
-//         throw new Error("Response data is undefined");
-//       }
-//       return response.data;
-//     },
-//   });
-// };
 
 export const useListingFilterDetail = <T = PinPointsPayload>() => {
   return useQuery<PinPointsPayload, Error, T>({
@@ -240,20 +221,20 @@ export const useListingRoomCompare = <T>({
   const { pinPointId: storePinPointId } = useOAuthStore();
   const resolvedPinPointId = pinPointId ?? storePinPointId;
 
-  const params: QueryParams = {
-    pinPointId,
-    sortType,
-    nearbyFacilities,
-  };
-
-  return useQuery<IResponse<T>, Error, T>({
+  return useQuery<T, Error, T>({
     queryKey: compareNoticeQueryKey({
       noticeId,
       sortType,
       nearbyFacilities,
       pinPointId: resolvedPinPointId,
     }),
-    queryFn: () => getNoticeParam<IResponse<T>>(`${NOTICE_ENDPOINT}/${noticeId}/compare`, params),
+    queryFn: () =>
+      getListingCompareFromBff({
+        noticeId,
+        sortType,
+        nearbyFacilities,
+        pinPointId: resolvedPinPointId,
+      }) as Promise<T>,
     placeholderData: prevData => prevData,
     staleTime: 1000 * 60 * 60 * 24,
     enabled: Boolean(noticeId && resolvedPinPointId),

--- a/src/entities/listings/hooks/useListingDetailSheetHooks.ts
+++ b/src/entities/listings/hooks/useListingDetailSheetHooks.ts
@@ -1,8 +1,6 @@
-import { IResponse } from "@/src/shared/types";
-import { QueryKey, useQuery, UseQueryOptions } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { UseListingsHooksWithSheet } from "../model/type";
-import { getNoticeSheetFilter, PostParamsBodyRequest } from "../api/listingsApi";
-import { NOTICE_ENDPOINT } from "@/src/shared/api";
+import { getListingDetailFilterFromBff } from "../api/listingDetailBffApi";
 
 export const useListingDetailNoticeSheet = <T>({ id, url }: UseListingsHooksWithSheet) => {
   const encodedId = encodeURIComponent(id);
@@ -13,10 +11,13 @@ export const useListingDetailNoticeSheet = <T>({ id, url }: UseListingsHooksWith
     staleTime: 1000 * 60 * 5,
 
     queryFn: () =>
-      getNoticeSheetFilter<IResponse<T>, T>(`${NOTICE_ENDPOINT}/${encodedId}/filter/${url}`),
+      getListingDetailFilterFromBff<T>({
+        noticeId: id,
+        filterType: url,
+      }),
 
-    select: (response: any) => {
-      return response?.data ?? response ?? null;
+    select: response => {
+      return response ?? null;
     },
   });
 };

--- a/src/features/listings/server/bff/getCompareInitialFromBff.ts
+++ b/src/features/listings/server/bff/getCompareInitialFromBff.ts
@@ -1,5 +1,5 @@
-import { headers } from "next/headers";
 import { UnitTypeRespnse } from "@/src/entities/listings/model/type";
+import { getBffRequestContext } from "@/src/shared/api/server/fowardHeaders";
 
 export type CompareBffResponse = {
   success: boolean;
@@ -19,12 +19,7 @@ export async function fetchCompareInitialFromBff({
 }: FetchCompareInitialFromBffArgs) {
   if (!noticeId) return null;
 
-  const h = await headers();
-  const host = h.get("x-forwarded-host") ?? h.get("host");
-  const proto = h.get("x-forwarded-proto") ?? "http";
-  const baseUrl = `${proto}://${host}`;
-  const cookieHeader = h.get("cookie") ?? "";
-
+  const { baseUrl, forwardedHeaders } = await getBffRequestContext();
   const query = new URLSearchParams({
     noticeId,
     sortType,
@@ -35,7 +30,7 @@ export async function fetchCompareInitialFromBff({
   const res = await fetch(`${baseUrl}/api/listings/compare?${query.toString()}`, {
     method: "GET",
     cache: "no-store",
-    credentials: "include",
+    headers: forwardedHeaders,
   });
 
   if (!res.ok) return null;

--- a/src/features/listings/server/callServer/getCompareFirstPageOnserver.ts
+++ b/src/features/listings/server/callServer/getCompareFirstPageOnserver.ts
@@ -1,9 +1,4 @@
-import { cookies } from "next/headers";
-import { NOTICE_ENDPOINT, POPULAR_SEARCH_ENDPOINT } from "@/src/shared/api";
-import { IResponse } from "@/src/shared/types";
-import { UnitTypeRespnse } from "@/src/entities/listings/model/type";
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
+import { getListingCompareOnServer } from "./getListingDetailOnServer";
 
 type GetCompareFirstPageOnServerArgs = {
   noticeId: string;
@@ -18,37 +13,10 @@ export async function getCompareFirstPageOnServer({
   nearbyFacilities = [],
   pinPointId: pinPointIdFromArg,
 }: GetCompareFirstPageOnServerArgs) {
-  if (!API_BASE_URL || !noticeId) return null;
-
-  const cookieStore = await cookies();
-  const pinPointId = cookieStore.get("pinpoint_id")?.value ?? pinPointIdFromArg;
-  const accessToken = cookieStore.get("access_token")?.value;
-
-  if (!pinPointId) return null;
-
-  const query = new URLSearchParams({
-    pinPointId,
+  return getListingCompareOnServer({
+    noticeId,
     sortType,
+    nearbyFacilities,
+    pinPointId: pinPointIdFromArg,
   });
-
-  for (const f of nearbyFacilities) query.append("nearbyFacilities", f);
-
-  const url = `${API_BASE_URL}${NOTICE_ENDPOINT}/${encodeURIComponent(noticeId)}/compare?${query.toString()}`;
-
-  const res = await fetch(url, {
-    method: "GET",
-    cache: "no-store",
-    credentials: "include",
-    // headers: {
-    //   cookie: cookieStore.toString(),
-    //   ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
-    // },
-  });
-
-  if (!res.ok) return null;
-
-  const body = (await res.json()) as IResponse<UnitTypeRespnse>;
-  if (!body?.success || !body.data) return null;
-
-  return body.data;
 }

--- a/src/features/listings/server/callServer/getListingDetailOnServer.ts
+++ b/src/features/listings/server/callServer/getListingDetailOnServer.ts
@@ -1,0 +1,183 @@
+import "server-only";
+
+import { cookies } from "next/headers";
+import { COMPLEXES_ENDPOINT, NOTICE_ENDPOINT } from "@/src/shared/api";
+import type { IResponse } from "@/src/shared/types";
+import type {
+  Environmnt,
+  ListingDetailData,
+  ListingSummary,
+  LstingBody,
+  UnitTypeRespnse,
+} from "@/src/entities/listings/model/type";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
+
+type QueryValue = string | number | boolean | string[] | undefined | null;
+type QueryParams = Record<string, QueryValue>;
+
+async function getServerRequestContext() {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get("access_token")?.value;
+  const pinPointId = cookieStore.get("pinpoint_id")?.value;
+
+  return {
+    pinPointId,
+    headers: {
+      cookie: cookieStore.toString(),
+      ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+    },
+  };
+}
+
+function appendQuery(params?: QueryParams) {
+  const query = new URLSearchParams();
+
+  Object.entries(params ?? {}).forEach(([key, value]) => {
+    if (value === undefined || value === null || value === "") return;
+    if (Array.isArray(value)) {
+      value.forEach(item => query.append(key, item));
+      return;
+    }
+    query.set(key, String(value));
+  });
+
+  const queryString = query.toString();
+  return queryString ? `?${queryString}` : "";
+}
+
+async function fetchFromApi<T>(
+  path: string,
+  options: RequestInit & { query?: QueryParams } = {}
+): Promise<T | null> {
+  if (!API_BASE_URL) return null;
+
+  const { headers, query, ...init } = options;
+  const context = await getServerRequestContext();
+  const res = await fetch(`${API_BASE_URL}${path}${appendQuery(query)}`, {
+    ...init,
+    cache: "no-store",
+    headers: {
+      ...context.headers,
+      ...headers,
+    },
+  });
+
+  if (!res.ok) return null;
+
+  const body = (await res.json()) as IResponse<T>;
+  if (!body?.success || body.data === undefined || body.data === null) return null;
+
+  return body.data;
+}
+
+export async function getListingDetailBasicOnServer(noticeId: string, body: LstingBody) {
+  if (!noticeId) return null;
+
+  const { pinPointId } = await getServerRequestContext();
+  const resolvedPinPointId = body.pinPointId || pinPointId;
+  if (!resolvedPinPointId) return null;
+
+  return fetchFromApi<ListingDetailData>(`${NOTICE_ENDPOINT}/${encodeURIComponent(noticeId)}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      ...body,
+      pinPointId: resolvedPinPointId,
+    }),
+  });
+}
+
+export async function getListingComplexSummaryOnServer(complexId: string, pinPointId?: string) {
+  if (!complexId) return null;
+
+  const { pinPointId: cookiePinPointId } = await getServerRequestContext();
+  const resolvedPinPointId = pinPointId || cookiePinPointId;
+  if (!resolvedPinPointId) return null;
+
+  return fetchFromApi<ListingSummary>(`${COMPLEXES_ENDPOINT}/${encodeURIComponent(complexId)}`, {
+    method: "GET",
+    query: { pinPointId: resolvedPinPointId },
+  });
+}
+
+export async function getListingComplexInfraOnServer(complexId: string) {
+  if (!complexId) return null;
+
+  return fetchFromApi<Environmnt>(
+    `${COMPLEXES_ENDPOINT}/infra/${encodeURIComponent(complexId)}`,
+    {
+      method: "GET",
+    }
+  );
+}
+
+export async function getListingComplexResourceOnServer<T>(complexId: string, resource: string) {
+  if (!complexId || !resource) return null;
+
+  return fetchFromApi<T>(`${COMPLEXES_ENDPOINT}/${resource}/${encodeURIComponent(complexId)}`, {
+    method: "GET",
+  });
+}
+
+export async function getListingComplexTransitOnServer<T>(
+  complexId: string,
+  params: QueryParams = {}
+) {
+  if (!complexId) return null;
+
+  const { pinPointId } = await getServerRequestContext();
+  const resolvedPinPointId = params.pinPointId || pinPointId;
+  if (!resolvedPinPointId) return null;
+
+  return fetchFromApi<T>(`${COMPLEXES_ENDPOINT}/transit/${encodeURIComponent(complexId)}`, {
+    method: "GET",
+    query: {
+      ...params,
+      pinPointId: resolvedPinPointId,
+    },
+  });
+}
+
+export async function getListingDetailFilterOnServer<T>(noticeId: string, filterType: string) {
+  if (!noticeId || !filterType) return null;
+
+  return fetchFromApi<T>(
+    `${NOTICE_ENDPOINT}/${encodeURIComponent(noticeId)}/filter/${filterType}`,
+    {
+      method: "GET",
+    }
+  );
+}
+
+export async function getListingCompareOnServer({
+  noticeId,
+  sortType,
+  nearbyFacilities = [],
+  pinPointId,
+}: {
+  noticeId: string;
+  sortType: string;
+  nearbyFacilities?: string[];
+  pinPointId?: string;
+}) {
+  if (!noticeId) return null;
+
+  const { pinPointId: cookiePinPointId } = await getServerRequestContext();
+  const resolvedPinPointId = pinPointId || cookiePinPointId;
+  if (!resolvedPinPointId) return null;
+
+  return fetchFromApi<UnitTypeRespnse>(
+    `${NOTICE_ENDPOINT}/${encodeURIComponent(noticeId)}/compare`,
+    {
+      method: "GET",
+      query: {
+        pinPointId: resolvedPinPointId,
+        sortType,
+        nearbyFacilities,
+      },
+    }
+  );
+}

--- a/src/features/listings/server/index.ts
+++ b/src/features/listings/server/index.ts
@@ -2,3 +2,4 @@ export * from "./bff/getNoticeInitialFromBff";
 export * from "./bff/getPopularSearchFromBff";
 export * from "./bff/getSearchNoticeInitialFromBff";
 export * from "./callServer/getNoticeFirstPagOnServer";
+export * from "./callServer/getSearchPageOnServer";

--- a/src/features/listings/ui/listingsCardDetail/components/listingsCardDetailHeader.tsx
+++ b/src/features/listings/ui/listingsCardDetail/components/listingsCardDetailHeader.tsx
@@ -9,11 +9,7 @@ export const ListingsCardDetailHeader = () => {
   const handleRouter = () => {
     const nextPath = prevPath ?? "/listings";
     reset();
-    if (!prevPath) {
-      router.back();
-    } else {
-      router.push(nextPath);
-    }
+    router.push(nextPath);
   };
 
   return (

--- a/src/features/listings/ui/listingsCardDetail/components/listingsCardDetailSummary.tsx
+++ b/src/features/listings/ui/listingsCardDetail/components/listingsCardDetailSummary.tsx
@@ -23,20 +23,18 @@ export const ListingsCardDetailSummary = ({
           {basicInfo.type}
         </TagButton>
 
-        <span className="flex items-center gap-2 text-xs text-greyscale-grey-500">
-          <div>
-            <TagButton
-              size="xs"
-              variant={"ghost"}
-              className={cn(`rounded-md border text-xs transition-all`)}
-            >
-              {basicInfo.housingType}
-            </TagButton>
-          </div>
+        <div className="flex items-center gap-2 text-xs text-greyscale-grey-500">
+          <TagButton
+            size="xs"
+            variant={"ghost"}
+            className={cn(`rounded-md border text-xs transition-all`)}
+          >
+            {basicInfo.housingType}
+          </TagButton>
           <p className="font-semibold">{basicInfo.supplier}</p>
-        </span>
+        </div>
       </div>
-      <h1 className="line-clamp-2 truncate text-lg font-semibold leading-snug text-greyscale-grey-900">
+      <h1 className="line-clamp-2 text-lg font-semibold leading-snug text-greyscale-grey-900">
         {basicInfo.name}
       </h1>
       <p className="mt-1 text-sm font-semibold text-greyscale-grey-400">{basicInfo.period}</p>


### PR DESCRIPTION
<!--- Pull Request title = 커밋 메시지와 동일/ 해당 이슈를 close 하지 않을 경우, footer #이슈 번호 제외  -->

## #️⃣ Issue Number

#535 

<br/>
<br/>

## 📝 요약(Summary) (선택)

> listings/[id] 상세 페이지의 API 호출 구조를 home/listings 목록과 같은 BFF 구조
> 클라이언트가 외부 API를 직접 호출하지 않고 Next API route를 거치도록 변경
> 외부 API 호출 책임은 server 계층으로 분리

<br/>
<br/>

