### PR TITLE
refactor:노선 상세 컴포넌트 로직을 커스텀 훅으로 분리

### DIFF
--- a/src/entities/listings/model/type.ts
+++ b/src/entities/listings/model/type.ts
@@ -505,6 +505,7 @@ export interface RouteStep {
   stopName?: string | number | null;
   type?: TransportType | string | null;
   secondaryText: string;
+  distanceMeters: number;
 }
 
 // 사용처: 경로 요약 정보 (총 시간/거리) — routeDetail header

--- a/src/features/listings/hooks/index.ts
+++ b/src/features/listings/hooks/index.ts
@@ -4,6 +4,7 @@ export * from "./list/useListingDetailsHooks";
 export * from "./list/components/listingsHooks";
 export * from "./list/useTransportIconRenderHooks";
 export * from "./list/useDetailColorHooks";
+export * from "./list/useRouteDetailHooks";
 export * from "./search/useListingsSearchData";
 export * from "./search/getSearchViewMode";
 export * from "./search/useListingsSearchRoute";

--- a/src/features/listings/hooks/list/useRouteDetailHooks.ts
+++ b/src/features/listings/hooks/list/useRouteDetailHooks.ts
@@ -1,0 +1,138 @@
+"use client";
+
+import { CSSProperties, useCallback, useEffect, useMemo, useState } from "react";
+import { useListingRouteDetail } from "@/src/entities/listings/hooks/useListingDetailHooks";
+import { ListingRouteInfo, TransportType } from "@/src/entities/listings/model/type";
+import { useOAuthStore } from "@/src/features/login/model";
+import { parseMinutes } from "@/src/features/listings/hooks/list/components/listingsHooks";
+
+type RouteSegmentItem = ListingRouteInfo["routes"][number];
+type RouteStepItem = RouteSegmentItem["steps"][number];
+
+const formatMinutesToText = (minutes?: number) => {
+  if (!minutes || Number.isNaN(minutes)) return "";
+  const hours = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+  if (hours && mins) return `${hours}시간 ${mins}분`;
+  if (hours) return `${hours}시간`;
+  return `${mins}분`;
+};
+
+const formatFareText = (fare?: number | null) => {
+  if (typeof fare !== "number" || Number.isNaN(fare) || fare <= 0) return "0원";
+  return `${fare.toLocaleString("ko-KR")}원`;
+};
+
+const resolveStepLabel = (step?: RouteStepItem) => {
+  if (!step) return "";
+  if (step.primaryText) return step.primaryText;
+  if (typeof step.stopName === "string") return step.stopName;
+  if (typeof step.stopName === "number") return `${step.stopName}`;
+  return "";
+};
+
+const resolveLineText = (line?: RouteStepItem["line"]) => {
+  if (!line) return "";
+  return typeof line === "object" ? line.line : line;
+};
+
+const timelineStyle = {
+  ["--icon-size" as any]: "clamp(25px, 5vw, 28px)",
+  ["--line-w" as any]: "clamp(2px, 0.6vw, 3px)",
+  ["--item-gap" as any]: "clamp(20px, 4.5vw, 28px)",
+  ["--col-gap" as any]: "clamp(8px, 2.5vw, 14px)",
+} as CSSProperties;
+
+export const useRouteDetail = (listingId: string) => {
+  const pinPointId = useOAuthStore.getState().pinPointId;
+  const { data, isFetching } = useListingRouteDetail<ListingRouteInfo, { pinPointId: string }>({
+    id: listingId,
+    queryK: "useListingRouteDetail",
+    url: "transit",
+    params: { pinPointId },
+  });
+
+  const [index, setIndex] = useState(0);
+  const routes = data?.routes ?? [];
+
+  useEffect(() => {
+    if (index > 0 && index > routes.length - 1) {
+      setIndex(0);
+    }
+  }, [index, routes.length]);
+
+  const current = routes[index] ?? null;
+
+  const routeView = useMemo(() => {
+    const summaryData = current?.summary;
+    const summary = Array.isArray(summaryData) ? (summaryData[0] ?? null) : (summaryData ?? null);
+    const distances = current?.distance ?? [];
+    const steps = current?.steps ?? [];
+    const totalMinutes =
+      summary?.totalMinutes ||
+      distances.reduce((sum, segment) => sum + (parseMinutes(segment.minutes || "") || 0), 0);
+    const prevLastStep = steps[steps.length - 2] ?? null;
+    const lastDistanceIndex = distances.length - 1;
+
+    return {
+      summaryText:
+        summary?.displayText || formatMinutesToText(summary?.totalMinutes ?? totalMinutes) || "-",
+      fareText: formatFareText(summary?.totalFareWon),
+      shouldStretch: steps.length <= 7,
+      distanceSegments: distances
+        .map((segment, segmentIndex) => {
+          const minutes = segment.minutes || 0;
+          if (minutes === 0) return null;
+
+          return {
+            key: `${segment.type}-${segmentIndex}`,
+            minutes,
+            color: String(segment.colorHex || "#4B5563"),
+            widthPct: totalMinutes ? Math.max(5, (minutes / totalMinutes) * 100) : 0,
+            isFirst: segmentIndex === 0,
+            isLast: segmentIndex === lastDistanceIndex,
+          };
+        })
+        .filter((segment): segment is NonNullable<typeof segment> => Boolean(segment)),
+      steps: steps.map((step, stepIndex) => {
+        const action = step.action?.toUpperCase();
+        const label = resolveStepLabel(step);
+
+        return {
+          key: `${label}-${stepIndex}`,
+          label,
+          lineText: resolveLineText(step.line),
+          secondaryText: step.secondaryText,
+          minutesText: step.minutes,
+          iconMinutes: parseMinutes(step.minutes || ""),
+          distanceMeters: step.distanceMeters,
+          color: String(step.colorHex || "#2563EB"),
+          type: (step.type as TransportType) || undefined,
+          isLast: stepIndex === steps.length - 1,
+          isArrival: action === "ARRIVE",
+          isWalk: action === "WALK",
+          prevLastColor: prevLastStep?.colorHex,
+        };
+      }),
+    };
+  }, [current]);
+
+  const goPrev = useCallback(() => {
+    setIndex(prev => (prev - 1 + Math.max(routes.length, 1)) % Math.max(routes.length, 1));
+  }, [routes.length]);
+
+  const goNext = useCallback(() => {
+    setIndex(prev => (prev + 1) % Math.max(routes.length, 1));
+  }, [routes.length]);
+
+  return {
+    isFetching,
+    hasRoutes: routes.length > 0,
+    routeCount: routes.length,
+    currentIndex: index,
+    timelineStyle,
+    goPrev,
+    goNext,
+    ...routeView,
+  };
+};

--- a/src/features/listings/model/filter/filterPanelModel.tsx
+++ b/src/features/listings/model/filter/filterPanelModel.tsx
@@ -38,6 +38,9 @@ import {
   WashingMachineInfraIcon,
   WheelchairInfraIcon,
 } from "@/src/assets/icons/infra";
+import { VerticalTransitIcon } from "@/src/assets/icons/route/vertical/verticalBusIcon";
+import { VerticalSubWayIcon } from "@/src/assets/icons/route/vertical/verticalSubWayIcon";
+import { VerticalWalkIcon } from "@/src/assets/icons/route/vertical/verticalWalkIcon";
 
 // 사용처: TAB_CONFIG 제네릭 타입에서 섹션 구성에 사용 (listingsModel.ts)
 export type City = { code: string; name: string };
@@ -46,7 +49,7 @@ export type SectionMap = Record<string, ReadonlyArray<City>>;
 // 사용처: TAB_CONFIG 제네릭 타입에서 섹션 라벨에 사용 (listingsModel.ts)
 export type SectionLabelMap = Record<string, string>;
 // 미사용: TransportType (내부에서 직접 참조하지 않음)
-export type TransportType = "BUS" | "TRAIN" | "WALK";
+export type TransportType = "BUS" | "TRAIN" | "WALK" | "AIR" | "SUBWAY";
 export type TransportIconProps = {
   color?: string;
   minutes: number;
@@ -272,4 +275,23 @@ export const TransitAction: TransitActionType = {
   START: "출발",
   TRANSFER: "환승",
   ARRIVAL: "도착",
+};
+
+export const ModeIcon = ({
+  type,
+  color,
+  minutes,
+}: {
+  type?: TransportType | null;
+  color: string;
+  minutes: number;
+}) => {
+  if (type === "BUS" || type === "AIR") {
+    return <VerticalTransitIcon color={color} minutes={minutes} showLine={false} />;
+  }
+  if (type === "WALK") return <VerticalWalkIcon color={color} minutes={minutes} />;
+  if (type === "SUBWAY" || type === "TRAIN") {
+    return <VerticalSubWayIcon color={color} minutes={minutes} showLine={false} />;
+  }
+  return <VerticalTransitIcon color={color} minutes={minutes} showLine={false} />;
 };

--- a/src/features/listings/server/callServer/getListingDetailOnServer.ts
+++ b/src/features/listings/server/callServer/getListingDetailOnServer.ts
@@ -77,7 +77,7 @@ export async function getListingDetailBasicOnServer(noticeId: string, body: Lsti
   const { pinPointId } = await getServerRequestContext();
   const resolvedPinPointId = body.pinPointId || pinPointId;
   if (!resolvedPinPointId) return null;
-
+  console.log(body, "body");
   return fetchFromApi<ListingDetailData>(`${NOTICE_ENDPOINT}/${encodeURIComponent(noticeId)}`, {
     method: "POST",
     headers: {
@@ -106,12 +106,9 @@ export async function getListingComplexSummaryOnServer(complexId: string, pinPoi
 export async function getListingComplexInfraOnServer(complexId: string) {
   if (!complexId) return null;
 
-  return fetchFromApi<Environmnt>(
-    `${COMPLEXES_ENDPOINT}/infra/${encodeURIComponent(complexId)}`,
-    {
-      method: "GET",
-    }
-  );
+  return fetchFromApi<Environmnt>(`${COMPLEXES_ENDPOINT}/infra/${encodeURIComponent(complexId)}`, {
+    method: "GET",
+  });
 }
 
 export async function getListingComplexResourceOnServer<T>(complexId: string, resource: string) {

--- a/src/features/listings/ui/listingsCardDetail/infra/components/routeDetail.tsx
+++ b/src/features/listings/ui/listingsCardDetail/infra/components/routeDetail.tsx
@@ -1,112 +1,30 @@
 "use client";
-import { CSSProperties, useCallback, useEffect, useMemo, useState } from "react";
-import { useListingRouteDetail } from "@/src/entities/listings/hooks/useListingDetailHooks";
-import { ListingRouteInfo, TransportType } from "@/src/entities/listings/model/type";
-import { SmallSpinner } from "@/src/shared/ui/spinner/small/smallSpinner";
+
 import { LeftButton } from "@/src/assets/icons/button";
 import { PinPointAddress } from "@/src/assets/icons/infra/pinAddress";
-
+import { useRouteDetail } from "@/src/features/listings/hooks/list/useRouteDetailHooks";
 import { cn } from "@/src/shared/lib/utils";
-import { VerticalTransitIcon } from "@/src/assets/icons/route/vertical/verticalBusIcon";
-import { VerticalSubWayIcon } from "@/src/assets/icons/route/vertical/verticalSubWayIcon";
-import { VerticalWalkIcon } from "@/src/assets/icons/route/vertical/verticalWalkIcon";
-import { parseMinutes } from "@/src/features/listings/hooks/list/components/listingsHooks";
-import { useOAuthStore } from "@/src/features/login/model";
-
-type RouteSegmentItem = ListingRouteInfo["routes"][number];
-type RouteStepItem = RouteSegmentItem["steps"][number];
-
-const ModeIcon = ({
-  type,
-  color,
-  minutes,
-}: {
-  type?: TransportType | null;
-  color: string;
-  minutes: number;
-}) => {
-  if (type === "BUS" || type === "AIR")
-    return <VerticalTransitIcon color={color} minutes={minutes} showLine={false} />;
-  if (type === "WALK") return <VerticalWalkIcon color={color} minutes={minutes} />;
-  if (type === "SUBWAY" || type === "TRAIN")
-    return <VerticalSubWayIcon color={color} minutes={minutes} showLine={false} />;
-  return <VerticalTransitIcon color={color} minutes={minutes} showLine={false} />;
-};
-
-const formatMinutesToText = (minutes?: number) => {
-  if (!minutes || Number.isNaN(minutes)) return "";
-  const hours = Math.floor(minutes / 60);
-  const mins = minutes % 60;
-  if (hours && mins) return `${hours}시간 ${mins}분`;
-  if (hours) return `${hours}시간`;
-  return `${mins}분`;
-};
-
-const formatFareText = (fare?: number | null) => {
-  if (typeof fare !== "number" || Number.isNaN(fare) || fare <= 0) return "0원";
-  return `${fare.toLocaleString("ko-KR")}원`;
-};
-
-const resolveStepLabel = (step?: RouteStepItem) => {
-  if (!step) return "";
-  if (step.primaryText) return step.primaryText;
-  if (typeof step.stopName === "string") return step.stopName;
-  if (typeof step.stopName === "number") return `${step.stopName}`;
-  return "";
-};
+import { SmallSpinner } from "@/src/shared/ui/spinner/small/smallSpinner";
+import { ModeIcon } from "@/src/features/listings/model";
 
 export const RouteDetail = ({ listingId }: { listingId: string }) => {
-  const pinPointId = useOAuthStore.getState().pinPointId;
-  const { data, isFetching } = useListingRouteDetail<ListingRouteInfo, { pinPointId: string }>({
-    id: listingId,
-    queryK: "useListingRouteDetail",
-    url: "transit",
-    params: { pinPointId: pinPointId },
-  });
-
-  const [index, setIndex] = useState(0);
-  const routes = data?.routes ?? [];
-
-  useEffect(() => {
-    if (index > 0 && index > routes.length - 1) {
-      setIndex(0);
-    }
-  }, [index, routes.length]);
-
-  const current = routes[index] ?? null;
-
-  const summary = (() => {
-    if (!current) return null;
-    const summaryData = current.summary;
-    return Array.isArray(summaryData) ? (summaryData[0] ?? null) : (summaryData ?? null);
-  })();
-
-  const totalMinutes = summary?.totalMinutes
-    ? summary.totalMinutes
-    : (current?.distance ?? []).reduce(
-        (sum, seg) => sum + (parseMinutes(seg.minutes || "") || 0),
-        0
-      );
-
-  const summaryText =
-    summary?.displayText || formatMinutesToText(summary?.totalMinutes ?? totalMinutes) || "-";
-
-  const fareText = formatFareText(summary?.totalFareWon);
-  const distances = current?.distance ?? [];
-  const steps = current?.steps ?? [];
-
-  const goPrev = useCallback(() => {
-    setIndex(p => (p - 1 + Math.max(routes.length, 1)) % Math.max(routes.length, 1));
-  }, [routes.length]);
-  const goNext = useCallback(() => {
-    setIndex(p => (p + 1) % Math.max(routes.length, 1));
-  }, [routes.length]);
-
-  const lastIndex = distances.length - 1;
-  const SHOULD_STRETCH = steps.length <= 7;
+  const {
+    isFetching,
+    hasRoutes,
+    routeCount,
+    currentIndex,
+    summaryText,
+    fareText,
+    distanceSegments,
+    steps,
+    shouldStretch,
+    timelineStyle,
+    goPrev,
+    goNext,
+  } = useRouteDetail(listingId);
 
   if (isFetching) return <SmallSpinner title="노선 정보를 불러오는 중.." />;
-  if (!routes.length) {
+  if (!hasRoutes) {
     return (
       <div className="p-6 text-center text-sm text-text-secondary">표시할 노선 정보가 없어요.</div>
     );
@@ -114,7 +32,6 @@ export const RouteDetail = ({ listingId }: { listingId: string }) => {
 
   return (
     <section className="flex h-full flex-col">
-      {/* 상단 요약 + 페이지네이션 */}
       <div className="relative border-b border-greyscale-grey-50 p-5">
         <div className="flex items-center justify-between">
           <div className="space-y-1">
@@ -124,14 +41,14 @@ export const RouteDetail = ({ listingId }: { listingId: string }) => {
             </p>
           </div>
 
-          {routes.length > 1 && (
+          {routeCount > 1 && (
             <div className="flex items-center gap-2 text-xs text-text-secondary">
               <button aria-label="이전 노선" onClick={goPrev} className="rounded-full p-1">
                 <LeftButton className="size-4 text-greyscale-grey-200" />
               </button>
-              <span className="font-semibold text-text-primary">{index + 1}</span>
+              <span className="font-semibold text-text-primary">{currentIndex + 1}</span>
               {" / "}
-              <span>{routes.length}</span>
+              <span>{routeCount}</span>
               <button aria-label="다음 노선" onClick={goNext} className="rounded-full p-1">
                 <LeftButton className="size-4 rotate-180 text-greyscale-grey-200" />
               </button>
@@ -139,69 +56,48 @@ export const RouteDetail = ({ listingId }: { listingId: string }) => {
           )}
         </div>
 
-        {/* 구간 바 */}
-        {!!distances.length && (
+        {!!distanceSegments.length && (
           <div className="mt-3">
             <div className="flex items-center">
-              {distances.map((seg, i) => {
-                const m = seg.minutes || 0;
-                if (m === 0) return null;
-                const widthPct = totalMinutes ? Math.max(5, (m / totalMinutes) * 100) : 0;
-
-                const color = seg.colorHex || "#4B5563";
-
-                return (
-                  <div key={i} style={{ width: `${widthPct}%` }}>
-                    <div
+              {distanceSegments.map(segment => (
+                <div key={segment.key} style={{ width: `${segment.widthPct}%` }}>
+                  <div
+                    className={cn(
+                      "flex h-4 items-center justify-center",
+                      segment.isFirst && "rounded-bl-lg rounded-tl-lg",
+                      segment.isLast && "rounded-br-lg rounded-tr-lg"
+                    )}
+                    style={{ backgroundColor: segment.color }}
+                  >
+                    <span
                       className={cn(
-                        "flex h-4 items-center justify-center",
-                        i === 0 && "rounded-bl-lg rounded-tl-lg",
-                        i === lastIndex && "rounded-br-lg rounded-tr-lg"
+                        "text-[10px] text-white",
+                        segment.isFirst && "ml-[2px]",
+                        segment.isLast && "mr-[2px]"
                       )}
-                      style={{ backgroundColor: String(color) }}
                     >
-                      <span
-                        className={cn(
-                          "text-[10px] text-white",
-                          i === 0 && "ml-[2px]",
-                          i === lastIndex && "mr-[2px]"
-                        )}
-                      >
-                        {seg.minutes}분
-                      </span>
-                    </div>
+                      {segment.minutes}분
+                    </span>
                   </div>
-                );
-              })}
+                </div>
+              ))}
             </div>
           </div>
         )}
       </div>
 
-      {/* 타임라인 */}
       <ul
         className={cn(
           "relative flex flex-1 flex-col overflow-y-auto p-5",
-          SHOULD_STRETCH && "justify-between"
+          shouldStretch && "justify-between"
         )}
-        style={
-          {
-            ["--icon-size" as any]: "clamp(25px, 5vw, 28px)",
-            ["--line-w" as any]: "clamp(2px, 0.6vw, 3px)",
-            ["--item-gap" as any]: "clamp(20px, 4.5vw, 28px)",
-            ["--col-gap" as any]: "clamp(8px, 2.5vw, 14px)",
-          } as CSSProperties
-        }
+        style={timelineStyle}
       >
-        {/* 핀포인트 주소 */}
         <li className="relative flex gap-[var(--col-gap)]">
-          {/* 왼쪽 */}
           <div className="relative flex h-full w-[var(--icon-size)] justify-center">
             <div className="z-[1]">
               <PinPointAddress />
             </div>
-
-            {/* 점선 */}
             <span
               className="absolute bottom-0 left-1/2 top-[var(--icon-size)] w-[var(--line-w)] -translate-x-1/2"
               style={{
@@ -211,98 +107,81 @@ export const RouteDetail = ({ listingId }: { listingId: string }) => {
             />
           </div>
 
-          {/* 오른쪽 */}
-          <div className={cn("flex h-[60px] flex-1 flex-col")}>
+          <div className="flex h-[60px] flex-1 flex-col">
             <p className="flex gap-1 text-sm font-medium text-text-primary">핀포인트 주소</p>
-            <p className="text-xs text-text-secondary">도보 이동 · 0분, 0m</p>
+            {/*<p className="text-xs text-text-secondary">도보 이동 · 0분, 0m</p>*/}
           </div>
         </li>
 
-        {/* 정류장 / 환승 / 도착 */}
-        {steps.map((s, i) => {
-          const color = s.colorHex || "#2563EB";
-          const isLast = i === steps.length - 1;
-          const prevLastStep = steps[steps.length - 2];
-          const prevLastColor = prevLastStep?.colorHex;
-          const isArrival = s.action?.toUpperCase() === "ARRIVE";
-          const isWALK = s.action?.toUpperCase() === "WALK";
-          const label = resolveStepLabel(s);
-
-          return (
-            <li
-              key={`${label}-${i}`}
-              className={cn(
-                "relative flex gap-[var(--col-gap)]",
-                SHOULD_STRETCH ? !isLast && "flex-1" : "min-h-[50px]"
+        {steps.map(step => (
+          <li
+            key={step.key}
+            className={cn(
+              "relative flex gap-[var(--col-gap)]",
+              shouldStretch ? !step.isLast && "flex-1" : "min-h-[50px]"
+            )}
+          >
+            <div className="relative z-[1] flex w-[var(--icon-size)] justify-center">
+              {!step.isLast && !step.isWalk && (
+                <span
+                  className="absolute bottom-0 left-1/2 top-[var(--icon-size)] w-[var(--line-w)] -translate-x-1/2"
+                  style={
+                    {
+                      "--line-extend": "10px",
+                      backgroundColor: step.color,
+                    } as React.CSSProperties
+                  }
+                />
               )}
-            >
-              {/* 왼쪽 아이콘 + 세로선 */}
-              <div className="relative z-[1] flex w-[var(--icon-size)] justify-center">
-                {/* 세로선 (왼쪽 컬럼 기준) */}
-                {!isLast && !isWALK && (
+
+              {step.isWalk && (
+                <span
+                  className="absolute bottom-0 left-1/2 top-[var(--icon-size)] w-[var(--line-w)] -translate-x-1/2"
+                  style={{
+                    backgroundImage:
+                      "repeating-linear-gradient(to bottom, #D1D5DB 0 6px, transparent 6px 8px)",
+                  }}
+                />
+              )}
+
+              {!step.isArrival ? (
+                <ModeIcon type={step.type} color={step.color} minutes={step.iconMinutes} />
+              ) : (
+                <div className="relative flex h-[var(--icon-size)] w-[var(--icon-size)] items-center justify-center">
                   <span
-                    className="absolute bottom-0 left-1/2 top-[var(--icon-size)] w-[var(--line-w)] -translate-x-1/2"
-                    style={
-                      {
-                        "--line-extend": "10px",
-                        backgroundColor: String(color),
-                      } as React.CSSProperties
-                    }
-                  />
-                )}
-                {isWALK && (
-                  <span
-                    className="absolute bottom-0 left-1/2 top-[var(--icon-size)] w-[var(--line-w)] -translate-x-1/2"
+                    className="absolute left-1/2 top-0 w-[var(--line-w)] -translate-x-1/2"
                     style={{
-                      backgroundImage:
-                        "repeating-linear-gradient(to bottom, #D1D5DB 0 6px, transparent 6px 8px)",
+                      height: "calc(var(--icon-size) / 2)",
+                      backgroundColor: String(step.prevLastColor),
                     }}
                   />
-                )}
-                {!isArrival ? (
-                  <ModeIcon
-                    type={(s.type as TransportType) || undefined}
-                    color={String(color)}
-                    minutes={parseMinutes(s.minutes || "")}
-                  />
-                ) : (
-                  <div className="relative flex h-[var(--icon-size)] w-[var(--icon-size)] items-center justify-center">
-                    <span
-                      className="absolute left-1/2 top-0 w-[var(--line-w)] -translate-x-1/2"
-                      style={{
-                        height: "calc(var(--icon-size) / 2)",
-                        backgroundColor: String(prevLastColor),
-                      }}
-                    />
-                    <span className="relative flex h-2.5 w-2.5 rounded-full bg-primary-blue-400 after:absolute after:inset-[-6px] after:-z-10 after:animate-glowBlink after:rounded-full after:bg-primary-blue-400 after:opacity-20 after:blur-sm after:content-['']" />
-                  </div>
-                )}
-              </div>
+                  <span className="relative flex h-2.5 w-2.5 rounded-full bg-primary-blue-400 after:absolute after:inset-[-6px] after:-z-10 after:animate-glowBlink after:rounded-full after:bg-primary-blue-400 after:opacity-20 after:blur-sm after:content-['']" />
+                </div>
+              )}
+            </div>
 
-              <div
-                className={cn(
-                  "flex flex-col",
-                  !isLast && SHOULD_STRETCH && "flex-1",
-                  isArrival && "justify-normal pt-1"
-                )}
-              >
-                <p className="flex text-sm font-medium text-text-primary">{label}</p>
+            <div
+              className={cn(
+                "flex flex-col",
+                !step.isLast && shouldStretch && "flex-1",
+                step.isArrival && "justify-normal pt-1"
+              )}
+            >
+              <p className="flex text-sm font-medium text-text-primary">{step.label}</p>
 
-                {s.line && (
-                  <p className="mt-0.5 text-xs text-text-secondary">
-                    {typeof s.line === "object" ? s.line?.line : s.line}
-                  </p>
-                )}
+              {step.lineText && (
+                <p className="mt-0.5 text-xs text-text-secondary">{step.lineText}</p>
+              )}
 
-                {s.minutes && (
-                  <p className="mt-0.5 text-xs text-text-secondary">
-                    {s.secondaryText} 약 {s.minutes} 분
-                  </p>
-                )}
-              </div>
-            </li>
-          );
-        })}
+              {step.minutesText && (
+                <p className="mt-0.5 text-xs text-text-secondary">
+                  {step.secondaryText} 약 {step.minutesText} 분{" "}
+                  {step.distanceMeters && `${step.distanceMeters} m`}
+                </p>
+              )}
+            </div>
+          </li>
+        ))}
       </ul>
     </section>
   );

--- a/src/features/listings/ui/listingsCardDetail/infra/listingsCardTtileInfra.tsx
+++ b/src/features/listings/ui/listingsCardDetail/infra/listingsCardTtileInfra.tsx
@@ -22,6 +22,7 @@ export const ListingsCardTileDetails = ({
   if (!infra || !route || !roomTypes) {
     return <SmallSpinner />;
   }
+
   return (
     <div className="rounded-b-lg border-t border-greyscale-grey-100 bg-bgColor-mute">
       {/* 기본 정보 */}


### PR DESCRIPTION
<!--- Pull Request title = 커밋 메시지와 동일/ 해당 이슈를 close 하지 않을 경우, footer #이슈 번호 제외  -->

## #️⃣ Issue Number

#537 

<br/>
<br/>

## 📝 요약(Summary) (선택)

- 노선 상세 화면의 복잡한 클라이언트 로직을 커스텀 훅으로 분리해 역할을 명확히
- 노선 데이터 조회, 현재 노선 index 상태, 이전/다음 이동 핸들러를 컴포넌트 밖으로 이동했습니다.
- 노선 스텝 타입에 거리 표시용 필드를 추가했습니다.

<br/>
<br/>
