### PR TITLE
feat: 홈 검색 API 호출 구조를 BFF 패턴으로 전환

### DIFF
--- a/app/api/home/search/category/route.ts
+++ b/app/api/home/search/category/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getHomeSearchCategoryOnServer } from "@/src/features/home/server/callServer/getHomeSearchOnServer";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  try {
+    const sp = req.nextUrl.searchParams;
+    const type = sp.get("type") ?? "";
+    const q = sp.get("q") ?? "";
+    const rawPage = Number(sp.get("page") ?? "1");
+    const page = Number.isFinite(rawPage) && rawPage > 0 ? rawPage : 1;
+    // 카테고리 더보기 요청도 route handler에서 server 함수로 위임한다.
+    const data = await getHomeSearchCategoryOnServer({ type, q, page });
+
+    if (!data) {
+      return NextResponse.json(
+        { success: false, message: "Failed to fetch home search category." },
+        { status: 401 }
+      );
+    }
+
+    return NextResponse.json({ success: true, data }, { status: 200 });
+  } catch {
+    return NextResponse.json({ success: false, message: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/app/api/home/search/overview/route.ts
+++ b/app/api/home/search/overview/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getHomeSearchOverviewOnServer } from "@/src/features/home/server/callServer/getHomeSearchOnServer";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  try {
+    const q = req.nextUrl.searchParams.get("q") ?? "";
+    // 7. BFF route handler가 외부 API 호출 전용 server 함수로 위임한다.
+    const data = await getHomeSearchOverviewOnServer(q);
+
+    if (!data) {
+      return NextResponse.json(
+        { success: false, message: "Failed to fetch home search overview." },
+        { status: 401 }
+      );
+    }
+
+    return NextResponse.json({ success: true, data }, { status: 200 });
+  } catch {
+    return NextResponse.json({ success: false, message: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/app/home/search/result/page.tsx
+++ b/app/home/search/result/page.tsx
@@ -1,5 +1,7 @@
 import { ResultLifecycle } from "./resultLifecycle";
 import { Metadata } from "next";
+import { HydrationBoundary } from "@tanstack/react-query";
+import { getHomeSearchResultInitialData } from "@/src/widgets/homeSection/server/getHomeSearchResultInitialData";
 
 export const metadata: Metadata = {
   robots: {
@@ -11,12 +13,18 @@ export const metadata: Metadata = {
 export default async function HomeSearchResults({
   searchParams,
 }: {
-  searchParams: { q?: string; query?: string };
+  searchParams: Promise<{ q?: string; query?: string }>;
 }) {
-  const params = searchParams;
+  const params = await searchParams;
 
   const q =
     typeof params.q === "string" ? params.q : typeof params.query === "string" ? params.query : "";
+  // 4. URL의 q로 검색 결과 overview를 서버에서 먼저 가져와 React Query 캐시에 hydrate한다.
+  const { dehydratedState } = await getHomeSearchResultInitialData(q);
 
-  return <ResultLifecycle q={q} />;
+  return (
+    <HydrationBoundary state={dehydratedState}>
+      <ResultLifecycle q={q} />
+    </HydrationBoundary>
+  );
 }

--- a/src/entities/home/api/homeBffApi.ts
+++ b/src/entities/home/api/homeBffApi.ts
@@ -1,4 +1,10 @@
-import type { NoticeContent, NoticeCount, SliceResponse } from "@/src/entities/home/model/type";
+import type {
+  GlobalListType,
+  GlobalSearchItem,
+  NoticeContent,
+  NoticeCount,
+  SliceResponse,
+} from "@/src/entities/home/model/type";
 import type { ListingItem } from "@/src/entities/listings/model/type";
 
 type HomeNoticeBffResponse = {
@@ -20,6 +26,16 @@ type HomeCountBffResponse = {
 type HomeRecommendedBffResponse = {
   success: boolean;
   data?: SliceResponse<ListingItem>;
+};
+
+type HomeSearchOverviewBffResponse = {
+  success: boolean;
+  data?: GlobalListType;
+};
+
+type HomeSearchCategoryBffResponse = {
+  success: boolean;
+  data?: SliceResponse<GlobalSearchItem>;
 };
 
 export async function getHomeNoticePageFromBff(
@@ -87,6 +103,54 @@ export async function getHomeRecommendedPageFromBff(
 
   const body = (await res.json()) as HomeRecommendedBffResponse;
   if (!body.success || !body.data) throw new Error("Invalid home recommended response.");
+
+  return body.data;
+}
+
+export async function getHomeSearchOverviewFromBff(q: string): Promise<GlobalListType> {
+  const query = new URLSearchParams({ q });
+
+  // 클라이언트 캐시가 비었거나 stale이면 동일한 BFF endpoint를 호출한다.
+  const res = await fetch(`/api/home/search/overview?${query.toString()}`, {
+    method: "GET",
+    cache: "no-store",
+    credentials: "include",
+  });
+
+  if (!res.ok) throw new Error("Failed to fetch home search overview.");
+
+  const body = (await res.json()) as HomeSearchOverviewBffResponse;
+  if (!body.success || !body.data) throw new Error("Invalid home search overview response.");
+
+  return body.data;
+}
+
+export async function getHomeSearchCategoryFromBff({
+  type,
+  q,
+  page = 1,
+}: {
+  type: string;
+  q: string;
+  page?: number;
+}): Promise<SliceResponse<GlobalSearchItem>> {
+  const query = new URLSearchParams({
+    type,
+    q,
+    page: String(page),
+  });
+
+  // 카테고리 더보기는 페이지 단위로 BFF endpoint를 호출한다.
+  const res = await fetch(`/api/home/search/category?${query.toString()}`, {
+    method: "GET",
+    cache: "no-store",
+    credentials: "include",
+  });
+
+  if (!res.ok) throw new Error("Failed to fetch home search category.");
+
+  const body = (await res.json()) as HomeSearchCategoryBffResponse;
+  if (!body.success || !body.data) throw new Error("Invalid home search category response.");
 
   return body.data;
 }

--- a/src/entities/home/hooks/homeHooks.ts
+++ b/src/entities/home/hooks/homeHooks.ts
@@ -1,13 +1,19 @@
-import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
-import { getNoticeByPinPoint } from "../interface/homeInterface";
-import { NoticeContent, SearchCategory, SliceResponse } from "../model/type";
+import { useInfiniteQuery, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  GlobalListType,
+  NoticeContent,
+  PopularResponse,
+  SearchCategory,
+  SliceResponse,
+} from "../model/type";
 import { useOAuthStore } from "@/src/features/login/model";
 import {
   getHomeNoticeCountFromBff,
   getHomeNoticePageFromBff,
   getHomeRecommendedPageFromBff,
+  getHomeSearchCategoryFromBff,
+  getHomeSearchOverviewFromBff,
 } from "@/src/entities/home/api/homeBffApi";
-import { HOME_RECOMMENDED_ENDPOINT, HOME_SEARCH_POPULAR_ENDPOINT } from "@/src/shared/api";
 import { useHomeMaxTime } from "@/src/features/home/model/homeStore";
 import { useDebounce } from "@/src/shared/hooks/useDebounce/useDebounce";
 import { ApiCategory, CATEGORY_MAP } from "@/src/features/home/model/model";
@@ -46,14 +52,21 @@ export const useNoticeCount = () => {
   });
 };
 
-export const useGlobal = <T>({ params, q }: { params: string; q: string }) => {
-  const url = `${HOME_SEARCH_POPULAR_ENDPOINT}/${params}`;
-  const param = params === "popular" ? { limit: 10 } : { q: q };
+export const useHomePopularSearchCache = () => {
+  const queryClient = useQueryClient();
+  return {
+    data: queryClient.getQueryData<PopularResponse[]>(["global-search", "popular", ""]) ?? [],
+  };
+};
+
+export const useGlobal = <T = GlobalListType>({ params, q }: { params: string; q: string }) => {
+  const keyword = q.trim();
+
   return useQuery({
     queryKey: ["global-search", params, q],
     retry: false,
-    queryFn: () => getNoticeByPinPoint<T>({ url, params: param }),
-    enabled: params === "popular" || q?.length > 0,
+    queryFn: async () => getHomeSearchOverviewFromBff(keyword) as Promise<T>,
+    enabled: params === "overview" && keyword.length > 0,
     staleTime: 30_000,
     gcTime: 5 * 60_000,
   });
@@ -68,23 +81,20 @@ export const useGlobalPageNation = <TItem>({
   category: SearchCategory | null;
   enabled: boolean;
 }) => {
-  const url = `${HOME_SEARCH_POPULAR_ENDPOINT}/category`;
   const apiCategory: ApiCategory | null = category ? CATEGORY_MAP[category] : null;
+  const keyword = q.trim();
 
   return useInfiniteQuery<SliceResponse<TItem>, Error>({
     queryKey: ["globalInfinity", apiCategory, q],
-    enabled: enabled,
+    enabled: enabled && !!apiCategory && keyword.length > 0,
     initialPageParam: 2,
     retry: false,
     queryFn: ({ pageParam }) =>
-      getNoticeByPinPoint<SliceResponse<TItem>>({
-        url,
-        params: {
-          type: apiCategory,
-          q,
-          page: Number(pageParam),
-        },
-      }),
+      getHomeSearchCategoryFromBff({
+        type: apiCategory ?? "",
+        q: keyword,
+        page: Number(pageParam),
+      }) as Promise<SliceResponse<TItem>>,
     getNextPageParam: (lastPage, allPages) => (lastPage.hasNext ? allPages.length + 2 : undefined),
   });
 };

--- a/src/features/home/server/bff/getHomeSearchFromBff.ts
+++ b/src/features/home/server/bff/getHomeSearchFromBff.ts
@@ -1,0 +1,64 @@
+import "server-only";
+
+import type {
+  GlobalListType,
+  GlobalSearchItem,
+  SliceResponse,
+} from "@/src/entities/home/model/type";
+import { getBffRequestContext } from "@/src/shared/api/server/fowardHeaders";
+
+type HomeSearchBffResponse<T> = {
+  success: boolean;
+  data?: T;
+};
+
+async function fetchHomeSearchFromBff<T>(path: string, query: URLSearchParams) {
+  const { baseUrl, forwardedHeaders } = await getBffRequestContext();
+
+  const res = await fetch(`${baseUrl}${path}?${query.toString()}`, {
+    method: "GET",
+    cache: "no-store",
+    headers: forwardedHeaders,
+  });
+
+  if (!res.ok) return null;
+
+  const body = (await res.json()) as HomeSearchBffResponse<T>;
+  if (!body.success || !body.data) return null;
+
+  return body.data;
+}
+
+export async function getHomeSearchOverviewFromBff(q: string) {
+  const keyword = q.trim();
+  if (!keyword) return null;
+
+  // 6. SSR용 BFF 호출 endpoint: GET /api/home/search/overview?q={keyword}
+  return fetchHomeSearchFromBff<GlobalListType>(
+    "/api/home/search/overview",
+    new URLSearchParams({ q: keyword })
+  );
+}
+
+export async function getHomeSearchCategoryFromBff({
+  type,
+  q,
+  page = 1,
+}: {
+  type: string;
+  q: string;
+  page?: number;
+}) {
+  const keyword = q.trim();
+  if (!keyword || !type) return null;
+
+  // 추가 조회 endpoint: GET /api/home/search/category?type={type}&q={keyword}&page={page}
+  return fetchHomeSearchFromBff<SliceResponse<GlobalSearchItem>>(
+    "/api/home/search/category",
+    new URLSearchParams({
+      type,
+      q: keyword,
+      page: String(page),
+    })
+  );
+}

--- a/src/features/home/server/callServer/getHomeSearchOnServer.ts
+++ b/src/features/home/server/callServer/getHomeSearchOnServer.ts
@@ -1,0 +1,77 @@
+import "server-only";
+
+import { cookies } from "next/headers";
+import { HOME_SEARCH_POPULAR_ENDPOINT } from "@/src/shared/api";
+import type {
+  GlobalListType,
+  GlobalSearchItem,
+  SliceResponse,
+} from "@/src/entities/home/model/type";
+import type { IResponse } from "@/src/shared/types";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
+
+async function getHomeSearchHeaders() {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get("access_token")?.value;
+
+  return {
+    cookie: cookieStore.toString(),
+    ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+  };
+}
+
+async function fetchHomeSearchFromApi<T>(path: string, params: URLSearchParams) {
+  if (!API_BASE_URL) return null;
+
+  const res = await fetch(`${API_BASE_URL}${path}?${params.toString()}`, {
+    method: "GET",
+    cache: "no-store",
+    headers: await getHomeSearchHeaders(),
+  });
+
+  if (!res.ok) return null;
+
+  const body = (await res.json()) as IResponse<T>;
+  if (!body?.success || !body.data) return null;
+
+  return body.data;
+}
+
+export async function getHomeSearchOverviewOnServer(q: string) {
+  const keyword = q.trim();
+  if (!keyword) return null;
+
+  const params = new URLSearchParams({ q: keyword });
+
+  // 8. 최종 외부 API endpoint: GET {API_BASE_URL}/home/search/overview?q={keyword}
+  return fetchHomeSearchFromApi<GlobalListType>(
+    `${HOME_SEARCH_POPULAR_ENDPOINT}/overview`,
+    params
+  );
+}
+
+export async function getHomeSearchCategoryOnServer({
+  type,
+  q,
+  page = 1,
+}: {
+  type: string;
+  q: string;
+  page?: number;
+}) {
+  const keyword = q.trim();
+  if (!keyword || !type) return null;
+
+  const params = new URLSearchParams({
+    type,
+    q: keyword,
+    page: String(page),
+  });
+
+  // 최종 외부 API endpoint: GET {API_BASE_URL}/home/search/category?type={type}&q={keyword}&page={page}
+  return fetchHomeSearchFromApi<SliceResponse<GlobalSearchItem>>(
+    `${HOME_SEARCH_POPULAR_ENDPOINT}/category`,
+    params
+  );
+}

--- a/src/features/home/ui/search/homeSearchPopular.tsx
+++ b/src/features/home/ui/search/homeSearchPopular.tsx
@@ -1,12 +1,11 @@
 "use client";
 import { cn } from "@/lib/utils";
-import { useGlobal } from "@/src/entities/home/hooks/homeHooks";
-import { PopularResponse } from "@/src/entities/home/model/type";
+import { useHomePopularSearchCache } from "@/src/entities/home/hooks/homeHooks";
 import { TagButton } from "@/src/shared/ui/button/tagButton";
 import { useHomeKeywordRouter } from "@/src/features/home/ui/homeUseHooks/useHomeRouterHooks";
 
 export const HomeSearchPopular = () => {
-  const { data } = useGlobal<PopularResponse[]>({ params: "popular", q: "" });
+  const { data } = useHomePopularSearchCache();
   const { handleSearchTag } = useHomeKeywordRouter();
 
   return (

--- a/src/shared/ui/header/header/searchHeader/useSearchHeader.ts
+++ b/src/shared/ui/header/header/searchHeader/useSearchHeader.ts
@@ -47,7 +47,10 @@ export const useSearchHeader = ({
   const submitSearch = useCallback(
     (value: string) => {
       if (!value.trim()) return;
-      onSearch(value); // 최근검색어 저장은 즉시
+      // 1. 검색어를 최근 검색어 저장소에 먼저 반영한다.
+      onSearch(value);
+      // 2. BFF를 직접 호출하지 않고 결과 페이지로 이동한다.
+      // 3. /home/search/result 페이지가 q를 읽고 SSR 단계에서 BFF를 호출한다.
       router.push(`${resultPath}?${queryKey}=${encodeURIComponent(value)}`);
     },
     [onSearch, queryKey, resultPath, router]

--- a/src/widgets/homeSection/server/getHomeSearchResultInitialData.ts
+++ b/src/widgets/homeSection/server/getHomeSearchResultInitialData.ts
@@ -1,0 +1,24 @@
+import { dehydrate, QueryClient } from "@tanstack/react-query";
+import { getHomeSearchOverviewFromBff } from "@/src/features/home/server/bff/getHomeSearchFromBff";
+
+export async function getHomeSearchResultInitialData(q: string) {
+  const queryClient = new QueryClient();
+  const keyword = q.trim();
+
+  if (keyword) {
+    // 5. 서버 컴포넌트에서 내부 BFF route(/api/home/search/overview)를 호출한다.
+    const initial = await getHomeSearchOverviewFromBff(keyword);
+
+    if (initial) {
+      await queryClient.prefetchQuery({
+        queryKey: ["global-search", "overview", keyword],
+        queryFn: async () => initial,
+        staleTime: 30_000,
+      });
+    }
+  }
+
+  return {
+    dehydratedState: dehydrate(queryClient),
+  };
+}


### PR DESCRIPTION
<!--- Pull Request title = 커밋 메시지와 동일/ 해당 이슈를 close 하지 않을 경우, footer #이슈 번호 제외  -->

## #️⃣ Issue Number

#539 

<br/>
<br/>

## 📝 요약(Summary) (선택)

- /home/search의 overview, category 검색 API를 BFF 패턴으로 전환
- 검색 결과 페이지에 SSR prefetch와 React Query hydration 적용
- 인기검색어는 초기 hydration 데이터만 사용하는 구조로 분리
- 검색 입력부터 최종 endpoint 호출까지의 흐름을 주석으로 정리

<br/>
<br/>
