### PR TITLE
2026-07-12 refactor: BFF 캐시정책 에 따라 공고조회 글로벌 검색 코드 리펙터링

### DIFF
--- a/app/api/listings/cache/route.ts
+++ b/app/api/listings/cache/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from "next/server";
+import { invalidateAllListingsRouteCaches } from "@/src/features/listings/server/bff/listingsRouteCache";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(_req: NextRequest) {
+  try {
+    await invalidateAllListingsRouteCaches();
+
+    return NextResponse.json({ success: true }, { status: 200 });
+  } catch {
+    return NextResponse.json(
+      { success: false, message: "Failed to invalidate listings cache." },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/listings/notice/route.ts
+++ b/app/api/listings/notice/route.ts
@@ -1,4 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
+import { normalizeListingsFilterCriteria } from "@/src/features/listings/model";
+import {
+  createListingNoticeRouteCacheKey,
+  getOrLoadListingsRouteCache,
+  resolveListingsRouteCacheScope,
+} from "@/src/features/listings/server/bff/listingsRouteCache";
 import { getNoticeFirstPageOnServer } from "@/src/features/listings/server";
 import type { ListingListFilterBody } from "@/src/entities/listings/model/type";
 
@@ -11,17 +17,24 @@ export async function POST(req: NextRequest) {
     const rawOffSet = Number(sp.get("offSet") ?? "10");
     const page = Number.isFinite(rawPage) && rawPage > 0 ? rawPage : 1;
     const offSet = Number.isFinite(rawOffSet) && rawOffSet > 0 ? rawOffSet : 10;
-    const body = (await req.json()) as ListingListFilterBody;
-    const data = await getNoticeFirstPageOnServer({ ...body, page, offSet });
+    const body = normalizeListingsFilterCriteria((await req.json()) as ListingListFilterBody);
+    const cacheScope = resolveListingsRouteCacheScope(req);
+    const cacheKey = createListingNoticeRouteCacheKey(body, page, offSet, body.status, cacheScope);
+    const { cacheStatus, data } = await getOrLoadListingsRouteCache(cacheKey, () =>
+      getNoticeFirstPageOnServer({ ...body, page, offSet })
+    );
 
     if (!data) {
       return NextResponse.json(
         { success: false, message: "Failed to fetch home notices first page." },
-        { status: 401 }
+        { status: 401, headers: { "x-pinhouse-cache": cacheStatus } }
       );
     }
 
-    return NextResponse.json({ success: true, data }, { status: 200 });
+    return NextResponse.json(
+      { success: true, data },
+      { status: 200, headers: { "x-pinhouse-cache": cacheStatus } }
+    );
   } catch {
     return NextResponse.json({ success: false, message: "Internal Server Error" }, { status: 500 });
   }

--- a/app/api/listings/search/route.ts
+++ b/app/api/listings/search/route.ts
@@ -1,26 +1,33 @@
 import { NextRequest, NextResponse } from "next/server";
+import { parseListingSearchCriteriaFromSearchParams } from "@/src/features/listings/model";
+import {
+  createListingSearchRouteCacheKey,
+  getOrLoadListingsRouteCache,
+  resolveListingsRouteCacheScope,
+} from "@/src/features/listings/server/bff/listingsRouteCache";
 import { getSearchPageOnServer } from "@/src/features/listings/server/callServer/getSearchPageOnServer";
 
 export const dynamic = "force-dynamic";
 
 export async function GET(req: NextRequest) {
   try {
-    const sp = req.nextUrl.searchParams;
-    const q = sp.get("q") ?? "";
-    const page = Number(sp.get("page") ?? "1");
-    const offSet = Number(sp.get("offSet") ?? "10");
-    const sortType = sp.get("sortType") ?? "LATEST";
-    const status = sp.get("status") ?? "ALL";
-
-    const data = await getSearchPageOnServer({ q, page, offSet, sortType, status });
+    const criteria = parseListingSearchCriteriaFromSearchParams(req.nextUrl.searchParams);
+    const cacheScope = resolveListingsRouteCacheScope(req);
+    const cacheKey = createListingSearchRouteCacheKey(criteria, cacheScope);
+    const { cacheStatus, data } = await getOrLoadListingsRouteCache(cacheKey, () =>
+      getSearchPageOnServer(criteria)
+    );
     if (!data) {
       return NextResponse.json(
         { success: false, message: "Failed to fetch listings search page." },
-        { status: 401 }
+        { status: 404, headers: { "x-pinhouse-cache": cacheStatus } }
       );
     }
 
-    return NextResponse.json({ success: true, data }, { status: 200 });
+    return NextResponse.json(
+      { success: true, data },
+      { status: 200, headers: { "x-pinhouse-cache": cacheStatus } }
+    );
   } catch {
     return NextResponse.json({ success: false, message: "Internal Server Error" }, { status: 500 });
   }

--- a/app/listings/page.tsx
+++ b/app/listings/page.tsx
@@ -1,5 +1,26 @@
 import { ListingsSectionPage } from "@/src/widgets/listingsSection";
+import {
+  DEFAULT_LISTINGS_STATUS,
+  parseListingsFilterCriteriaFromSearchParams,
+} from "@/src/features/listings/model";
 
-export default function Listings() {
-  return <ListingsSectionPage />;
+type SearchParams = Record<string, string | string[] | undefined>;
+
+export default async function Listings({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>;
+}) {
+  const params = await searchParams;
+  const urlSearchParams = new URLSearchParams();
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (typeof value === "string") {
+      urlSearchParams.set(key, value);
+    }
+  });
+
+  const initialFilter = parseListingsFilterCriteriaFromSearchParams(urlSearchParams);
+
+  return <ListingsSectionPage initialFilter={initialFilter} initialStatus={DEFAULT_LISTINGS_STATUS} />;
 }

--- a/src/entities/listings/api/listingsBffApi.ts
+++ b/src/entities/listings/api/listingsBffApi.ts
@@ -1,4 +1,9 @@
 import type { ListingListFilterBody, ListingListPage } from "@/src/entities/listings/model/type";
+import {
+  createListingSearchParams,
+  ListingSearchCriteria,
+  normalizeListingSearchCriteria,
+} from "@/src/features/listings/model";
 
 type ListingsNoticeBffResponse = {
   success: boolean;
@@ -18,12 +23,8 @@ type GetListingNoticePageFromBffArgs = ListingListFilterBody & {
   offSet?: number;
 };
 
-type GetListingSearchPageFromBffArgs = {
-  q: string;
-  sortType: string;
-  status: string;
-  page?: number;
-  offSet?: number;
+type GetListingSearchPageFromBffArgs = Partial<ListingSearchCriteria> & {
+  q?: string;
 };
 
 export async function getListingNoticePageFromBff({
@@ -72,18 +73,13 @@ export async function getListingNoticePageFromBff({
 
 export async function getListingSearchPageFromBff({
   q,
-  sortType,
-  status,
-  page = 1,
-  offSet = 10,
+  ...criteriaInput
 }: GetListingSearchPageFromBffArgs): Promise<ListingListPage> {
-  const query = new URLSearchParams({
+  const criteria = normalizeListingSearchCriteria({
     q,
-    page: String(page),
-    offSet: String(offSet),
-    sortType,
-    status,
+    ...criteriaInput,
   });
+  const query = createListingSearchParams(criteria);
 
   const res = await fetch(`/api/listings/search?${query.toString()}`, {
     method: "GET",

--- a/src/entities/listings/hooks/useListingHooks.ts
+++ b/src/entities/listings/hooks/useListingHooks.ts
@@ -5,12 +5,17 @@ import { PostBasicRequest, requestListingList } from "../api/listingsApi";
 import {
   LikeReturn,
   ListingListPage,
+  ListingsFilterState,
   PopularKeywordItem,
   ToggleLikeVariables,
 } from "../model/type";
 import { LIKE_ENDPOINT, NOTICE_ENDPOINT } from "@/src/shared/api";
 import { IResponse } from "@/src/shared/types";
 import {
+  normalizeListingsFilterCriteria,
+  DEFAULT_LISTING_SEARCH_PAGE,
+  DEFAULT_LISTING_SEARCH_OFFSET,
+  normalizeListingSearchCriteria,
   SearchOptions,
   useListingsFilterStore,
   useListingsSearchState,
@@ -21,19 +26,8 @@ import { listingListInfiniteQueryKey, listingSearchInfiniteQueryKey } from "@/sr
 
 export const useListingListInfiniteQuery = () => {
   const status = useListingState(state => state.status);
-  const regionType = useListingsFilterStore(s => s.regionType);
-  const rentalTypes = useListingsFilterStore(s => s.rentalTypes);
-  const supplyTypes = useListingsFilterStore(s => s.supplyTypes);
-  const houseTypes = useListingsFilterStore(s => s.houseTypes);
-  const sortType = useListingsFilterStore(s => s.sortType);
-
-  const filter = {
-    regionType,
-    rentalTypes,
-    supplyTypes,
-    houseTypes,
-    sortType,
-  };
+  const applied = useListingsFilterStore((state: ListingsFilterState) => state.applied);
+  const filter = normalizeListingsFilterCriteria(applied);
 
   return useInfiniteQuery<ListingListPage>({
     queryKey: listingListInfiniteQueryKey({ filter, status }),
@@ -41,12 +35,12 @@ export const useListingListInfiniteQuery = () => {
     initialPageParam: 1,
     queryFn: ({ pageParam = 1 }) =>
       getListingNoticePageFromBff({
-        regionType,
-        rentalTypes,
-        supplyTypes,
-        houseTypes,
+        regionType: filter.regionType,
+        rentalTypes: filter.rentalTypes,
+        supplyTypes: filter.supplyTypes,
+        houseTypes: filter.houseTypes,
         status,
-        sortType,
+        sortType: filter.sortType,
         page: Number(pageParam),
         offSet: 10,
       }),
@@ -90,6 +84,12 @@ export const useToogleLike = (resetQuery: string[]) => {
     },
 
     onSettled: () => {
+      fetch("/api/listings/cache", {
+        method: "POST",
+      }).catch(() => {
+        // Query invalidation remains the primary client-side recovery path.
+      });
+
       resetQuery.forEach(key => {
         queryClient.invalidateQueries({
           queryKey: [key],
@@ -112,20 +112,27 @@ export const useListingSearchInfiniteQuery = (queryOpt: SearchOptions) => {
   const { enabled = true, keepPreviousData = true, staleTime = 30000, keyword } = queryOpt;
   const sortType = useListingsSearchState(s => s.sortType);
   const status = useListingsSearchState(s => s.status);
+  const criteria = normalizeListingSearchCriteria({
+    keyword,
+    sortType,
+    status,
+    page: DEFAULT_LISTING_SEARCH_PAGE,
+    offSet: DEFAULT_LISTING_SEARCH_OFFSET,
+  });
 
   return useInfiniteQuery<ListingListPage>({
-    queryKey: listingSearchInfiniteQueryKey({ keyword, sortType, status }),
+    queryKey: listingSearchInfiniteQueryKey(criteria),
     enabled,
     staleTime,
     initialPageParam: 1,
     placeholderData: keepPreviousData ? oldData => oldData : undefined,
     queryFn: ({ pageParam = 1 }) =>
       getListingSearchPageFromBff({
-        q: keyword,
+        keyword: criteria.keyword,
         page: Number(pageParam),
-        offSet: 10,
-        sortType,
-        status,
+        offSet: criteria.offSet,
+        sortType: criteria.sortType,
+        status: criteria.status,
       }),
     getNextPageParam: lastPage => {
       return lastPage.hasNext ? lastPage.page + 1 : undefined;

--- a/src/entities/listings/model/type.ts
+++ b/src/entities/listings/model/type.ts
@@ -241,22 +241,31 @@ export interface FilterOption {
 
 // 사용처: 목록 필터 값/토글/리셋 (Zustand) — listingsStore.ts
 export interface ListingsFilterState {
+  draft: ListingListFilterBody;
+  applied: ListingListFilterBody;
+  syncDraftFromApplied: () => void;
+  applyDraft: () => void;
+  toggleDraftRegionType: (item: string) => void;
+  toggleDraftRentalType: (item: string) => void;
+  toggleDraftSupplyType: (item: string) => void;
+  toggleDraftHouseType: (item: string) => void;
+  setDraftStatus: (status: string) => void;
+  setSortType: (sort: string) => void;
+  resetDraftRegionType: () => void;
+  resetDraftRentalTypes: () => void;
+  resetDraftSupplyTypes: () => void;
+  resetDraftHouseTypes: () => void;
+  hasAppliedFilters: () => boolean;
+  hasDraftFilters: () => boolean;
+}
+
+export interface ListingsFilterSelectionState {
   regionType: string[];
   rentalTypes: string[];
   supplyTypes: string[];
   houseTypes: string[];
   status: string;
   sortType: string;
-  toggleRegionType: (item: string) => void;
-  toggleRentalType: (item: string) => void;
-  toggleSupplyType: (item: string) => void;
-  toggleHouseType: (item: string) => void;
-  setStatus: (status: string) => void;
-  setSortType: (sort: string) => void;
-  resetRegionType: () => void;
-  resetRentalTypes: () => void;
-  resetSupplyTypes: () => void;
-  resetHouseTypes: () => void;
 }
 
 /** 공고탐색상세조회 */

--- a/src/features/listings/hooks/list/ListingsContentHeader.ts
+++ b/src/features/listings/hooks/list/ListingsContentHeader.ts
@@ -1,21 +1,28 @@
 import {
+  createListingsFilterSearchParams,
+  DEFAULT_LISTING_SEARCH_SORT_TYPE,
   listingPoint,
   useListingsFilterStore,
   useListingsSearchState,
 } from "@/src/features/listings/model";
-import { useSearchParams } from "next/navigation";
+import type { ListingsFilterState, SearchState } from "@/src/entities/listings/model/type";
+import { useRouter, useSearchParams } from "next/navigation";
 
 const NOTICE_LATEST = "최신공고순";
 const NOTICE_DEADLINE = "마감임박순";
-const SEARCH_LATEST = "LATEST";
+const SEARCH_LATEST = DEFAULT_LISTING_SEARCH_SORT_TYPE;
 const SEARCH_DEADLINE = "DEADLINE";
 
 export const useListingsContentHeaderController = () => {
-  const sortType = useListingsFilterStore(state => state.sortType);
-  const setSortType = useListingsFilterStore(state => state.setSortType);
-  const setSearchSortType = useListingsSearchState(state => state.setSortType);
-  const searchSortType = useListingsSearchState(state => state.sortType);
+  const sortType = useListingsFilterStore(
+    (state: ListingsFilterState) => state.applied.sortType
+  );
+  const setSortType = useListingsFilterStore((state: ListingsFilterState) => state.setSortType);
+  const applied = useListingsFilterStore((state: ListingsFilterState) => state.applied);
+  const setSearchSortType = useListingsSearchState((state: SearchState) => state.setSortType);
+  const searchSortType = useListingsSearchState((state: SearchState) => state.sortType);
 
+  const router = useRouter();
   const searchParams = useSearchParams();
   const isSearchPage = searchParams.has("query");
 
@@ -31,7 +38,17 @@ export const useListingsContentHeaderController = () => {
       return;
     }
 
-    setSortType(sortType === NOTICE_LATEST ? NOTICE_DEADLINE : NOTICE_LATEST);
+    const nextSortType = sortType === NOTICE_LATEST ? NOTICE_DEADLINE : NOTICE_LATEST;
+    setSortType(nextSortType);
+    const nextParams = createListingsFilterSearchParams(
+      {
+        ...applied,
+        sortType: nextSortType,
+      },
+      new URLSearchParams(searchParams.toString())
+    );
+    const query = nextParams.toString();
+    router.replace(query ? `/listings?${query}` : "/listings", { scroll: false });
   };
 
   return {

--- a/src/features/listings/hooks/search/useListingsSearchRoute.ts
+++ b/src/features/listings/hooks/search/useListingsSearchRoute.ts
@@ -1,22 +1,35 @@
 import { useRouter, useSearchParams } from "next/navigation";
 import { useSearchState } from "@/src/shared/hooks/store";
-import { useListingsSearchState } from "@/src/features/listings/model";
+import {
+  createListingSearchParams,
+  parseListingSearchCriteriaFromSearchParams,
+  useListingsSearchState,
+} from "@/src/features/listings/model";
 
 export function useListingsSearchRoute() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const keyword = (searchParams.get("query") ?? "").trim();
+  const criteria = parseListingSearchCriteriaFromSearchParams(searchParams);
+  const keyword = criteria.keyword;
   const { setSearchQuery } = useSearchState();
   const searchState = useListingsSearchState();
 
   const submit = (next: string) => {
     if (!next.trim()) return;
-    router.push(`/listings/search?query=${next}`);
+    const query = createListingSearchParams(
+      {
+        ...criteria,
+        keyword: next,
+        page: 1,
+      },
+      "query"
+    );
+    router.push(`/listings/search?${query.toString()}`);
     setSearchQuery(next);
   };
 
   const clear = () => {
-    router.push("/listings/search?query=");
+    router.push("/listings/search");
     searchState.reset();
   };
 

--- a/src/features/listings/model/__test__/listingsFilterStore.test.ts
+++ b/src/features/listings/model/__test__/listingsFilterStore.test.ts
@@ -1,0 +1,127 @@
+import {
+  createListingsFilterSearchParams,
+  createDefaultListingsFilterCriteria,
+  normalizeListingsFilterCriteria,
+  parseListingsFilterCriteriaFromSearchParams,
+} from "@/src/features/listings/model/listFilterCriteria";
+import { ListingsFilterState } from "@/src/entities/listings/model/type";
+import { useListingsFilterStore } from "@/src/features/listings/model/store/listingsStore";
+
+describe("listings filter criteria", () => {
+  it("normalizes array selections into stable sorted values", () => {
+    expect(
+      normalizeListingsFilterCriteria({
+        regionType: ["서울", "경기", "서울"],
+        rentalTypes: ["청년", "신혼부부", "청년"],
+        supplyTypes: ["행복주택", "국민임대", "행복주택"],
+        houseTypes: ["오피스텔", "아파트", "오피스텔"],
+      })
+    ).toEqual({
+      regionType: ["경기", "서울"],
+      rentalTypes: ["신혼부부", "청년"],
+      supplyTypes: ["국민임대", "행복주택"],
+      houseTypes: ["아파트", "오피스텔"],
+      status: "",
+      sortType: "최신공고순",
+    });
+  });
+
+  it("parses listings filter criteria from URL search params", () => {
+    const searchParams = new URLSearchParams({
+      region: "서울,경기",
+      target: "청년,신혼부부",
+      rental: "행복주택",
+      housing: "아파트,오피스텔",
+      sortType: "deadline",
+    });
+
+    expect(parseListingsFilterCriteriaFromSearchParams(searchParams)).toEqual({
+      regionType: ["경기", "서울"],
+      rentalTypes: ["신혼부부", "청년"],
+      supplyTypes: ["행복주택"],
+      houseTypes: ["아파트", "오피스텔"],
+      status: "",
+      sortType: "마감임박순",
+    });
+  });
+
+  it("serializes listings filter criteria into stable URL search params", () => {
+    const searchParams = createListingsFilterSearchParams({
+      regionType: ["서울", "경기"],
+      rentalTypes: ["청년", "신혼부부"],
+      supplyTypes: ["행복주택"],
+      houseTypes: [],
+      status: "",
+      sortType: "마감임박순",
+    });
+
+    expect(searchParams.toString()).toBe(
+      "region=%EA%B2%BD%EA%B8%B0%2C%EC%84%9C%EC%9A%B8&target=%EC%8B%A0%ED%98%BC%EB%B6%80%EB%B6%80%2C%EC%B2%AD%EB%85%84&rental=%ED%96%89%EB%B3%B5%EC%A3%BC%ED%83%9D&sortType=deadline"
+    );
+  });
+});
+
+describe("useListingsFilterStore", () => {
+  const resetStore = () => {
+    const initial = createDefaultListingsFilterCriteria();
+    useListingsFilterStore.setState({
+      draft: initial,
+      applied: initial,
+    });
+  };
+
+  beforeEach(() => {
+    resetStore();
+  });
+
+  it("keeps draft changes isolated until apply", () => {
+    useListingsFilterStore.getState().toggleDraftRegionType("서울");
+
+    expect(useListingsFilterStore.getState().draft.regionType).toEqual(["서울"]);
+    expect(useListingsFilterStore.getState().applied.regionType).toEqual([]);
+  });
+
+  it("applies normalized draft values into applied state", () => {
+    const store = useListingsFilterStore.getState();
+
+    store.toggleDraftRegionType("서울");
+    store.toggleDraftRegionType("경기");
+    store.toggleDraftRentalType("청년");
+    store.toggleDraftRentalType("신혼부부");
+    store.setSortType("마감임박순");
+    useListingsFilterStore.getState().applyDraft();
+
+    expect(useListingsFilterStore.getState().applied).toEqual({
+      regionType: ["경기", "서울"],
+      rentalTypes: ["신혼부부", "청년"],
+      supplyTypes: [],
+      houseTypes: [],
+      status: "",
+      sortType: "마감임박순",
+    });
+    expect(useListingsFilterStore.getState().draft).toEqual(
+      useListingsFilterStore.getState().applied
+    );
+  });
+
+  it("restores draft from applied when the sheet is reopened", () => {
+    useListingsFilterStore.setState((state: ListingsFilterState) => ({
+      ...state,
+      applied: {
+        regionType: ["서울"],
+        rentalTypes: [],
+        supplyTypes: [],
+        houseTypes: [],
+        status: "",
+        sortType: "최신공고순",
+      },
+    }));
+
+    useListingsFilterStore.getState().toggleDraftRegionType("경기");
+    useListingsFilterStore.getState().syncDraftFromApplied();
+
+    expect(useListingsFilterStore.getState().draft).toEqual(
+      useListingsFilterStore.getState().applied
+    );
+  });
+});

--- a/src/features/listings/model/__test__/searchCriteria.test.ts
+++ b/src/features/listings/model/__test__/searchCriteria.test.ts
@@ -1,0 +1,84 @@
+import {
+  createListingSearchParams,
+  DEFAULT_LISTING_SEARCH_OFFSET,
+  DEFAULT_LISTING_SEARCH_PAGE,
+  DEFAULT_LISTING_SEARCH_SORT_TYPE,
+  DEFAULT_LISTING_SEARCH_STATUS,
+  normalizeListingSearchCriteria,
+  parseListingSearchCriteriaFromSearchParams,
+} from "@/src/features/listings/model/searchCriteria";
+import { listingSearchInfiniteQueryKey } from "@/src/shared/config";
+
+describe("listing search criteria", () => {
+  it("normalizes keyword, sort, status, and paging defaults", () => {
+    expect(
+      normalizeListingSearchCriteria({
+        q: "  행복주택  ",
+        sortType: "latest",
+        status: "all",
+        page: "0",
+        offSet: "-1",
+      })
+    ).toEqual({
+      keyword: "행복주택",
+      sortType: DEFAULT_LISTING_SEARCH_SORT_TYPE,
+      status: DEFAULT_LISTING_SEARCH_STATUS,
+      page: DEFAULT_LISTING_SEARCH_PAGE,
+      offSet: DEFAULT_LISTING_SEARCH_OFFSET,
+    });
+  });
+
+  it("parses search params with query alias and keeps valid sort type", () => {
+    const searchParams = new URLSearchParams({
+      query: "  seoul ",
+      sortType: "DEADLINE",
+      status: "recruiting",
+      page: "3",
+      offSet: "20",
+    });
+
+    expect(parseListingSearchCriteriaFromSearchParams(searchParams)).toEqual({
+      keyword: "seoul",
+      sortType: "DEADLINE",
+      status: "RECRUITING",
+      page: 3,
+      offSet: 20,
+    });
+  });
+
+  it("creates stable query keys from normalized criteria", () => {
+    const a = listingSearchInfiniteQueryKey(
+      normalizeListingSearchCriteria({
+        keyword: "  seoul ",
+        sortType: "latest",
+        status: "all",
+      })
+    );
+    const b = listingSearchInfiniteQueryKey(
+      normalizeListingSearchCriteria({
+        q: "seoul",
+        sortType: "LATEST",
+        status: "ALL",
+        page: 1,
+        offSet: 10,
+      })
+    );
+
+    expect(a).toEqual(b);
+  });
+
+  it("serializes params without leaking an empty keyword", () => {
+    const searchParams = createListingSearchParams(
+      normalizeListingSearchCriteria({
+        keyword: "",
+        sortType: "LATEST",
+        status: "ALL",
+        page: 2,
+        offSet: 15,
+      }),
+      "query"
+    );
+
+    expect(searchParams.toString()).toBe("page=2&offSet=15&sortType=LATEST&status=ALL");
+  });
+});

--- a/src/features/listings/model/filter/filterPanelModel.tsx
+++ b/src/features/listings/model/filter/filterPanelModel.tsx
@@ -13,6 +13,7 @@ import {
   ListingItem,
   ListingNormalized,
   ListingSearchItem,
+  ListingsFilterSelectionState,
   ListingsFilterState,
   RouteType,
 } from "@/src/entities/listings/model/type";
@@ -94,17 +95,17 @@ export const AllFitler_OPTIONS: AllFilterOption = {
 };
 
 export type ListingFilterMap = {
-  region: (s: ListingsFilterState) => ListingsFilterState["regionType"];
-  target: (s: ListingsFilterState) => ListingsFilterState["rentalTypes"];
-  rental: (s: ListingsFilterState) => ListingsFilterState["supplyTypes"];
-  housing: (s: ListingsFilterState) => ListingsFilterState["houseTypes"];
+  region: (s: ListingsFilterState) => ListingsFilterSelectionState["regionType"];
+  target: (s: ListingsFilterState) => ListingsFilterSelectionState["rentalTypes"];
+  rental: (s: ListingsFilterState) => ListingsFilterSelectionState["supplyTypes"];
+  housing: (s: ListingsFilterState) => ListingsFilterSelectionState["houseTypes"];
 };
 // 사용처: 각 필터 탭의 선택값 접근 (listingsFilterPanel.tsx)
 export const filterMap: ListingFilterMap = {
-  region: s => s.regionType,
-  target: s => s.rentalTypes,
-  rental: s => s.supplyTypes,
-  housing: s => s.houseTypes,
+  region: s => s.applied.regionType,
+  target: s => s.applied.rentalTypes,
+  rental: s => s.applied.supplyTypes,
+  housing: s => s.applied.houseTypes,
 };
 
 // 사용처: 최근 검색어 컴포넌트에서 검색 실행 핸들러 타입 (listingsSearchHistory.tsx)

--- a/src/features/listings/model/index.ts
+++ b/src/features/listings/model/index.ts
@@ -1,5 +1,7 @@
 // listings 모델 모듈 집합 re-export
 export * from "./filter/listingsModel";
 export * from "./filter/filterPanelModel";
+export * from "./listFilterCriteria";
+export * from "./searchCriteria";
 export * from "./store/listingsStore";
 export * from "./store/listingDetailStore";

--- a/src/features/listings/model/listFilterCriteria.ts
+++ b/src/features/listings/model/listFilterCriteria.ts
@@ -1,0 +1,89 @@
+import { ListingListFilterBody } from "@/src/entities/listings/model/type";
+
+export type ListingsFilterCriteria = ListingListFilterBody;
+
+export const DEFAULT_LISTINGS_FILTER_SORT_TYPE = "최신공고순";
+export const DEFAULT_LISTINGS_FILTER_STATUS = "";
+export const DEFAULT_LISTINGS_STATUS = "전체";
+export const DEADLINE_LISTINGS_SORT_QUERY_VALUE = "deadline";
+
+export const createDefaultListingsFilterCriteria = (): ListingsFilterCriteria => ({
+  regionType: [],
+  rentalTypes: [],
+  supplyTypes: [],
+  houseTypes: [],
+  status: DEFAULT_LISTINGS_FILTER_STATUS,
+  sortType: DEFAULT_LISTINGS_FILTER_SORT_TYPE,
+});
+
+function uniqueSorted(values: string[]) {
+  return [...new Set(values)].sort((a, b) => a.localeCompare(b));
+}
+
+export function normalizeListingsFilterCriteria(
+  criteria: Partial<ListingsFilterCriteria>
+): ListingsFilterCriteria {
+  const defaults = createDefaultListingsFilterCriteria();
+
+  return {
+    regionType: uniqueSorted(criteria.regionType ?? defaults.regionType),
+    rentalTypes: uniqueSorted(criteria.rentalTypes ?? defaults.rentalTypes),
+    supplyTypes: uniqueSorted(criteria.supplyTypes ?? defaults.supplyTypes),
+    houseTypes: uniqueSorted(criteria.houseTypes ?? defaults.houseTypes),
+    status: criteria.status ?? defaults.status,
+    sortType: criteria.sortType ?? defaults.sortType,
+  };
+}
+
+type SearchParamsReader = {
+  get: (key: string) => string | null;
+};
+
+export function parseListingsFilterCriteriaFromSearchParams(searchParams: SearchParamsReader) {
+  const requestedSortType = searchParams.get("sortType");
+  const parseList = (key: string) =>
+    (searchParams.get(key) ?? "")
+      .split(",")
+      .map(value => value.trim())
+      .filter(Boolean);
+
+  return normalizeListingsFilterCriteria({
+    regionType: parseList("region"),
+    rentalTypes: parseList("target"),
+    supplyTypes: parseList("rental"),
+    houseTypes: parseList("housing"),
+    sortType: requestedSortType === "deadline" ? "마감임박순" : DEFAULT_LISTINGS_FILTER_SORT_TYPE,
+  });
+}
+
+export function createListingsFilterSearchParams(
+  criteria: ListingsFilterCriteria,
+  existingSearchParams?: URLSearchParams
+) {
+  const normalized = normalizeListingsFilterCriteria(criteria);
+  const next = new URLSearchParams(existingSearchParams?.toString() ?? "");
+
+  next.delete("tab");
+
+  const setList = (key: string, values: string[]) => {
+    if (values.length === 0) {
+      next.delete(key);
+      return;
+    }
+
+    next.set(key, values.join(","));
+  };
+
+  setList("region", normalized.regionType);
+  setList("target", normalized.rentalTypes);
+  setList("rental", normalized.supplyTypes);
+  setList("housing", normalized.houseTypes);
+
+  if (normalized.sortType === DEFAULT_LISTINGS_FILTER_SORT_TYPE) {
+    next.delete("sortType");
+  } else {
+    next.set("sortType", DEADLINE_LISTINGS_SORT_QUERY_VALUE);
+  }
+
+  return next;
+}

--- a/src/features/listings/model/searchCriteria.ts
+++ b/src/features/listings/model/searchCriteria.ts
@@ -1,0 +1,90 @@
+export const LISTING_SEARCH_SORT_TYPES = ["LATEST", "DEADLINE"] as const;
+
+export type ListingSearchSortType = (typeof LISTING_SEARCH_SORT_TYPES)[number];
+
+export const DEFAULT_LISTING_SEARCH_SORT_TYPE: ListingSearchSortType = "LATEST";
+export const DEFAULT_LISTING_SEARCH_STATUS = "ALL";
+export const DEFAULT_LISTING_SEARCH_PAGE = 1;
+export const DEFAULT_LISTING_SEARCH_OFFSET = 10;
+
+export type ListingSearchCriteria = {
+  keyword: string;
+  sortType: ListingSearchSortType;
+  status: string;
+  page: number;
+  offSet: number;
+};
+
+type ListingSearchCriteriaInput = {
+  keyword?: string | null;
+  q?: string | null;
+  query?: string | null;
+  sortType?: string | null;
+  status?: string | null;
+  page?: number | string | null;
+  offSet?: number | string | null;
+};
+
+const LISTING_SEARCH_SORT_TYPE_SET = new Set<ListingSearchSortType>(LISTING_SEARCH_SORT_TYPES);
+
+function normalizePositiveInt(value: number | string | null | undefined, fallback: number) {
+  const next = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(next) && next > 0 ? Math.floor(next) : fallback;
+}
+
+export function normalizeListingSearchKeyword(
+  keyword: string | null | undefined,
+  fallbackKeyword?: string | null | undefined
+) {
+  return (keyword ?? fallbackKeyword ?? "").trim();
+}
+
+export function normalizeListingSearchCriteria(
+  input: ListingSearchCriteriaInput = {}
+): ListingSearchCriteria {
+  const keyword = normalizeListingSearchKeyword(input.keyword, input.q ?? input.query);
+  const rawSortType = input.sortType?.trim().toUpperCase() as ListingSearchSortType | undefined;
+  const sortType = rawSortType && LISTING_SEARCH_SORT_TYPE_SET.has(rawSortType)
+    ? rawSortType
+    : DEFAULT_LISTING_SEARCH_SORT_TYPE;
+  const status = input.status?.trim().toUpperCase() || DEFAULT_LISTING_SEARCH_STATUS;
+
+  return {
+    keyword,
+    sortType,
+    status,
+    page: normalizePositiveInt(input.page, DEFAULT_LISTING_SEARCH_PAGE),
+    offSet: normalizePositiveInt(input.offSet, DEFAULT_LISTING_SEARCH_OFFSET),
+  };
+}
+
+type SearchParamsReader = {
+  get: (key: string) => string | null;
+};
+
+export function parseListingSearchCriteriaFromSearchParams(searchParams: SearchParamsReader) {
+  return normalizeListingSearchCriteria({
+    query: searchParams.get("query"),
+    q: searchParams.get("q"),
+    sortType: searchParams.get("sortType"),
+    status: searchParams.get("status"),
+    page: searchParams.get("page"),
+    offSet: searchParams.get("offSet"),
+  });
+}
+
+export function createListingSearchParams(criteria: ListingSearchCriteria, keywordParam: "q" | "query" = "q") {
+  const normalized = normalizeListingSearchCriteria(criteria);
+  const searchParams = new URLSearchParams({
+    page: String(normalized.page),
+    offSet: String(normalized.offSet),
+    sortType: normalized.sortType,
+    status: normalized.status,
+  });
+
+  if (normalized.keyword) {
+    searchParams.set(keywordParam, normalized.keyword);
+  }
+
+  return searchParams;
+}

--- a/src/features/listings/model/store/listingsStore.ts
+++ b/src/features/listings/model/store/listingsStore.ts
@@ -7,16 +7,35 @@
 //   * useListingDetailStore: 상세 보기에서 방 타입 선택 상태
 import { create } from "zustand";
 import {
+  DEFAULT_LISTING_SEARCH_SORT_TYPE,
+  DEFAULT_LISTING_SEARCH_STATUS,
+} from "@/src/features/listings/model/searchCriteria";
+import {
+  DEFAULT_LISTINGS_STATUS,
+  createDefaultListingsFilterCriteria,
+  normalizeListingsFilterCriteria,
+} from "@/src/features/listings/model/listFilterCriteria";
+import {
   FilterSheetState,
   ListingDetailFilterState,
+  ListingListFilterBody,
   ListingsFilterState,
   ListingState,
   SearchState,
 } from "@/src/entities/listings/model/type";
 
+function hasSelectedListingsFilter(criteria: ListingListFilterBody): boolean {
+  return [
+    criteria.regionType,
+    criteria.rentalTypes,
+    criteria.supplyTypes,
+    criteria.houseTypes,
+  ].some(list => list.length > 0);
+}
+
 // 사용처: 공고 리스트 상단 상태 드롭다운/쿼리 필터 (useListingHooks.ts, listingsContentsHeader.tsx)
 export const useListingState = create<ListingState>(set => ({
-  status: "전체",
+  status: DEFAULT_LISTINGS_STATUS,
   setStatus: value => set({ status: value }),
   reset: () => set({ status: "" }),
 }));
@@ -35,82 +54,145 @@ export const useDetailFilterSheetStore = create<FilterSheetState>(set => ({
 }));
 
 // 사용처: 필터 바/시트에서 선택한 값 저장 및 토글 (listingsFullSheet.tsx, listingsFilterPanel.tsx, useListingHooks.ts)
-export const useListingsFilterStore = create<ListingsFilterState>(set => ({
-  regionType: [],
-  rentalTypes: [],
-  supplyTypes: [],
-  houseTypes: [],
-  status: "",
-  sortType: "최신공고순",
+export const useListingsFilterStore = create<ListingsFilterState>((set, get) => ({
+  draft: createDefaultListingsFilterCriteria(),
+  applied: createDefaultListingsFilterCriteria(),
 
-  toggleRegionType: region =>
+  syncDraftFromApplied: () =>
+    set(state => ({
+      draft: {
+        ...state.applied,
+        regionType: [...state.applied.regionType],
+        rentalTypes: [...state.applied.rentalTypes],
+        supplyTypes: [...state.applied.supplyTypes],
+        houseTypes: [...state.applied.houseTypes],
+      },
+    })),
+
+  applyDraft: () =>
     set(state => {
-      const exists = state.regionType.includes(region);
+      const next = normalizeListingsFilterCriteria(state.draft);
       return {
-        regionType: exists
-          ? state.regionType.filter(i => i !== region)
-          : [...state.regionType, region],
+        applied: next,
+        draft: next,
       };
     }),
 
-  toggleRentalType: rental =>
+  toggleDraftRegionType: region =>
     set(state => {
-      const exists = state.rentalTypes.includes(rental);
+      const exists = state.draft.regionType.includes(region);
       return {
-        rentalTypes: exists
-          ? state.rentalTypes.filter(i => i !== rental)
-          : [...state.rentalTypes, rental],
+        draft: {
+          ...state.draft,
+          regionType: exists
+            ? state.draft.regionType.filter(i => i !== region)
+            : [...state.draft.regionType, region],
+        },
       };
     }),
 
-  toggleSupplyType: supply =>
+  toggleDraftRentalType: rental =>
     set(state => {
-      const exists = state.supplyTypes.includes(supply);
+      const exists = state.draft.rentalTypes.includes(rental);
       return {
-        supplyTypes: exists
-          ? state.supplyTypes.filter(i => i !== supply)
-          : [...state.supplyTypes, supply],
+        draft: {
+          ...state.draft,
+          rentalTypes: exists
+            ? state.draft.rentalTypes.filter(i => i !== rental)
+            : [...state.draft.rentalTypes, rental],
+        },
       };
     }),
 
-  toggleHouseType: house =>
+  toggleDraftSupplyType: supply =>
     set(state => {
-      const exists = state.houseTypes.includes(house);
+      const exists = state.draft.supplyTypes.includes(supply);
       return {
-        houseTypes: exists
-          ? state.houseTypes.filter(i => i !== house)
-          : [...state.houseTypes, house],
+        draft: {
+          ...state.draft,
+          supplyTypes: exists
+            ? state.draft.supplyTypes.filter(i => i !== supply)
+            : [...state.draft.supplyTypes, supply],
+        },
       };
     }),
 
-  setStatus: status => set({ status }),
-  setSortType: sort => set({ sortType: sort }),
+  toggleDraftHouseType: house =>
+    set(state => {
+      const exists = state.draft.houseTypes.includes(house);
+      return {
+        draft: {
+          ...state.draft,
+          houseTypes: exists
+            ? state.draft.houseTypes.filter(i => i !== house)
+            : [...state.draft.houseTypes, house],
+        },
+      };
+    }),
 
-  resetRegionType: () =>
-    set({
-      regionType: [],
-    }),
-  resetRentalTypes: () =>
-    set({
-      rentalTypes: [],
-    }),
-  resetSupplyTypes: () =>
-    set({
-      supplyTypes: [],
-    }),
-  resetHouseTypes: () =>
-    set({
-      houseTypes: [],
-    }),
+  setDraftStatus: status =>
+    set(state => ({
+      draft: {
+        ...state.draft,
+        status,
+      },
+    })),
+  setSortType: sort =>
+    set(state => ({
+      draft: {
+        ...state.draft,
+        sortType: sort,
+      },
+      applied: {
+        ...state.applied,
+        sortType: sort,
+      },
+    })),
+
+  resetDraftRegionType: () =>
+    set(state => ({
+      draft: {
+        ...state.draft,
+        regionType: [],
+      },
+    })),
+  resetDraftRentalTypes: () =>
+    set(state => ({
+      draft: {
+        ...state.draft,
+        rentalTypes: [],
+      },
+    })),
+  resetDraftSupplyTypes: () =>
+    set(state => ({
+      draft: {
+        ...state.draft,
+        supplyTypes: [],
+      },
+    })),
+  resetDraftHouseTypes: () =>
+    set(state => ({
+      draft: {
+        ...state.draft,
+        houseTypes: [],
+      },
+    })),
+
+  hasAppliedFilters: () => hasSelectedListingsFilter(get().applied),
+  hasDraftFilters: () => hasSelectedListingsFilter(get().draft),
 }));
 
 // 사용처: 검색 페이지 상태/정렬 (useListingHooks.ts, shared dropdown 등)
 export const useListingsSearchState = create<SearchState>(set => ({
-  sortType: "LATEST",
-  status: "ALL",
+  sortType: DEFAULT_LISTING_SEARCH_SORT_TYPE,
+  status: DEFAULT_LISTING_SEARCH_STATUS,
   setStatus: value => set({ status: value }),
   setSortType: value => set({ sortType: value }),
-  reset: () => set({ status: "", sortType: "" }),
+  reset: () =>
+    set({
+      status: DEFAULT_LISTING_SEARCH_STATUS,
+      sortType: DEFAULT_LISTING_SEARCH_SORT_TYPE,
+    }),
 }));
 
 // 사용처: 상세 페이지 내 방 타입 선택 상태

--- a/src/features/listings/server/bff/__test__/listingsRouteCache.test.ts
+++ b/src/features/listings/server/bff/__test__/listingsRouteCache.test.ts
@@ -1,0 +1,151 @@
+import {
+  createListingNoticeRouteCacheKey,
+  createListingSearchRouteCacheKey,
+  getOrLoadListingsRouteCache,
+  invalidateAllListingsRouteCaches,
+  resolveListingsRouteCacheScope,
+} from "@/src/features/listings/server/bff/listingsRouteCache";
+import {
+  setListingsCacheAdapter,
+  type ListingsCacheAdapter,
+  type ListingsCacheEntry,
+} from "@/src/features/listings/server/bff/listingsCacheAdapter";
+import { normalizeListingSearchCriteria } from "@/src/features/listings/model/searchCriteria";
+import { normalizeListingsFilterCriteria } from "@/src/features/listings/model/listFilterCriteria";
+
+class TestListingsCacheAdapter implements ListingsCacheAdapter {
+  private readonly store = new Map<string, ListingsCacheEntry<unknown>>();
+
+  async get<T>(key: string) {
+    const entry = this.store.get(key);
+    return (entry as ListingsCacheEntry<T> | undefined) ?? null;
+  }
+
+  async set<T>(key: string, entry: ListingsCacheEntry<T>) {
+    this.store.set(key, entry);
+  }
+
+  async deleteByPrefix(prefix: string) {
+    for (const key of this.store.keys()) {
+      if (key.startsWith(prefix)) {
+        this.store.delete(key);
+      }
+    }
+  }
+}
+
+describe("listings route cache", () => {
+  beforeEach(async () => {
+    setListingsCacheAdapter(new TestListingsCacheAdapter());
+    await invalidateAllListingsRouteCaches();
+  });
+
+  it("creates stable search cache keys for equivalent criteria", () => {
+    const a = createListingSearchRouteCacheKey(
+      normalizeListingSearchCriteria({
+        q: " 행복주택 ",
+        sortType: "latest",
+        status: "all",
+      }),
+      "public"
+    );
+    const b = createListingSearchRouteCacheKey(
+      normalizeListingSearchCriteria({
+        keyword: "행복주택",
+        sortType: "LATEST",
+        status: "ALL",
+        page: 1,
+        offSet: 10,
+      }),
+      "public"
+    );
+
+    expect(a).toBe(b);
+  });
+
+  it("creates stable notice cache keys for equivalent filter order", () => {
+    const a = createListingNoticeRouteCacheKey(
+      normalizeListingsFilterCriteria({
+        regionType: ["서울", "경기", "서울"],
+        rentalTypes: ["청년", "신혼부부"],
+        supplyTypes: ["행복주택"],
+        houseTypes: ["오피스텔", "아파트"],
+        sortType: "최신공고순",
+        status: "",
+      }),
+      1,
+      10,
+      "",
+      "public"
+    );
+    const b = createListingNoticeRouteCacheKey(
+      normalizeListingsFilterCriteria({
+        regionType: ["경기", "서울"],
+        rentalTypes: ["신혼부부", "청년"],
+        supplyTypes: ["행복주택"],
+        houseTypes: ["아파트", "오피스텔"],
+        sortType: "최신공고순",
+        status: "",
+      }),
+      1,
+      10,
+      "",
+      "public"
+    );
+
+    expect(a).toBe(b);
+  });
+
+  it("scopes cookie-backed requests away from public cache", () => {
+    const publicRequest = {
+      cookies: {
+        get: () => undefined,
+      },
+    } as never;
+    const scopedRequest = {
+      cookies: {
+        get: (key: string) =>
+          key === "access_token"
+            ? { value: "token-a" }
+            : key === "pinpoint_id"
+              ? { value: "pin-1" }
+              : undefined,
+      },
+    } as never;
+
+    expect(resolveListingsRouteCacheScope(publicRequest)).toBe("public");
+    expect(resolveListingsRouteCacheScope(scopedRequest)).not.toBe("public");
+    expect(resolveListingsRouteCacheScope(scopedRequest)).toContain("session:");
+  });
+
+  it("invalidates cached listings route entries", async () => {
+    const key = createListingSearchRouteCacheKey(
+      normalizeListingSearchCriteria({
+        keyword: "행복주택",
+        sortType: "LATEST",
+        status: "ALL",
+      }),
+      "public"
+    );
+
+    const first = await getOrLoadListingsRouteCache(key, async () => ({
+      id: "first",
+    }));
+    const second = await getOrLoadListingsRouteCache(key, async () => ({
+      id: "second",
+    }));
+
+    expect(first.cacheStatus).toBe("MISS");
+    expect(second.cacheStatus).toBe("HIT");
+    expect(second.data).toEqual({ id: "first" });
+
+    await invalidateAllListingsRouteCaches();
+
+    const third = await getOrLoadListingsRouteCache(key, async () => ({
+      id: "third",
+    }));
+
+    expect(third.cacheStatus).toBe("MISS");
+    expect(third.data).toEqual({ id: "third" });
+  });
+});

--- a/src/features/listings/server/bff/getSearchNoticeInitialFromBff.ts
+++ b/src/features/listings/server/bff/getSearchNoticeInitialFromBff.ts
@@ -1,11 +1,6 @@
 import { ListingListPage } from "@/src/entities/listings/model/type";
+import { createListingSearchParams, ListingSearchCriteria } from "@/src/features/listings/model";
 import { getBffRequestContext } from "@/src/shared/api/server/fowardHeaders";
-
-type GetSearchFirstPageProps = {
-  q: string;
-  sortType: string;
-  status: string;
-};
 
 type SearchBffResponse = {
   success: boolean;
@@ -13,21 +8,25 @@ type SearchBffResponse = {
 };
 
 export async function getSearchNoticeInitialFromBff({
-  q,
+  keyword,
   sortType,
   status,
-}: GetSearchFirstPageProps) {
-  const keyword = q.trim();
+  page,
+  offSet,
+}: ListingSearchCriteria) {
   if (!keyword) return null;
 
   const { baseUrl, forwardedHeaders } = await getBffRequestContext();
-  const query = new URLSearchParams({
-    q: keyword,
-    page: "1",
-    offSet: "10",
-    sortType,
-    status,
-  });
+  const query = createListingSearchParams(
+    {
+      keyword,
+      page,
+      offSet,
+      sortType,
+      status,
+    },
+    "q"
+  );
 
   const res = await fetch(`${baseUrl}/api/listings/search?${query.toString()}`, {
     method: "GET",

--- a/src/features/listings/server/bff/listingsCacheAdapter.ts
+++ b/src/features/listings/server/bff/listingsCacheAdapter.ts
@@ -1,0 +1,41 @@
+export type ListingsCacheEntry<T> = {
+  expiresAt: number;
+  value: T;
+};
+
+export interface ListingsCacheAdapter {
+  get<T>(key: string): Promise<ListingsCacheEntry<T> | null>;
+  set<T>(key: string, entry: ListingsCacheEntry<T>): Promise<void>;
+  deleteByPrefix(prefix: string): Promise<void>;
+}
+
+class InMemoryListingsCacheAdapter implements ListingsCacheAdapter {
+  private readonly store = new Map<string, ListingsCacheEntry<unknown>>();
+
+  async get<T>(key: string) {
+    const entry = this.store.get(key);
+    return (entry as ListingsCacheEntry<T> | undefined) ?? null;
+  }
+
+  async set<T>(key: string, entry: ListingsCacheEntry<T>) {
+    this.store.set(key, entry);
+  }
+
+  async deleteByPrefix(prefix: string) {
+    for (const key of this.store.keys()) {
+      if (key.startsWith(prefix)) {
+        this.store.delete(key);
+      }
+    }
+  }
+}
+
+let listingsCacheAdapter: ListingsCacheAdapter = new InMemoryListingsCacheAdapter();
+
+export function getListingsCacheAdapter() {
+  return listingsCacheAdapter;
+}
+
+export function setListingsCacheAdapter(adapter: ListingsCacheAdapter) {
+  listingsCacheAdapter = adapter;
+}

--- a/src/features/listings/server/bff/listingsRouteCache.ts
+++ b/src/features/listings/server/bff/listingsRouteCache.ts
@@ -1,0 +1,128 @@
+import { createHash } from "node:crypto";
+import type { NextRequest } from "next/server";
+import type { ListingSearchCriteria } from "@/src/features/listings/model/searchCriteria";
+import type { ListingsFilterCriteria } from "@/src/features/listings/model/listFilterCriteria";
+import { getListingsCacheAdapter } from "@/src/features/listings/server/bff/listingsCacheAdapter";
+import {
+  normalizeListingSearchCriteria,
+} from "@/src/features/listings/model/searchCriteria";
+import { normalizeListingsFilterCriteria } from "@/src/features/listings/model/listFilterCriteria";
+
+const LISTINGS_BFF_CACHE_VERSION = "v1";
+const LISTINGS_ROUTE_CACHE_TTL_MS = 5 * 60 * 1000;
+
+const inFlightStore = new Map<string, Promise<unknown>>();
+
+type ListingsCacheStatus = "HIT" | "MISS" | "BYPASS";
+
+function stableHash(value: unknown) {
+  return createHash("sha1").update(JSON.stringify(value)).digest("hex");
+}
+
+async function cleanupExpiredCacheEntry(key: string, now: number) {
+  const cached = await getListingsCacheAdapter().get(key);
+  if (!cached) return null;
+  if (cached.expiresAt > now) return cached;
+  await getListingsCacheAdapter().deleteByPrefix(key);
+  return null;
+}
+
+export function resolveListingsRouteCacheScope(request: NextRequest) {
+  const accessToken = request.cookies.get("access_token")?.value ?? "";
+  const pinpointId = request.cookies.get("pinpoint_id")?.value ?? "";
+
+  if (!accessToken && !pinpointId) {
+    return "public";
+  }
+
+  return `session:${stableHash({ accessToken, pinpointId })}`;
+}
+
+export function createListingSearchRouteCacheKey(
+  criteria: ListingSearchCriteria,
+  scope: string
+) {
+  const normalized = normalizeListingSearchCriteria(criteria);
+  return `${LISTINGS_BFF_CACHE_VERSION}:listing-search:${scope}:${stableHash(normalized)}`;
+}
+
+export function createListingNoticeRouteCacheKey(
+  filter: ListingsFilterCriteria,
+  page: number,
+  offSet: number,
+  status: string,
+  scope: string
+) {
+  const normalizedFilter = normalizeListingsFilterCriteria(filter);
+  return `${LISTINGS_BFF_CACHE_VERSION}:listing-notice:${scope}:${stableHash({
+    filter: normalizedFilter,
+    page,
+    offSet,
+    status,
+  })}`;
+}
+
+export async function getOrLoadListingsRouteCache<T>(
+  key: string | null,
+  loader: () => Promise<T | null>
+): Promise<{ cacheStatus: ListingsCacheStatus; data: T | null }> {
+  if (!key) {
+    return {
+      cacheStatus: "BYPASS",
+      data: await loader(),
+    };
+  }
+
+  const now = Date.now();
+  const cached = await cleanupExpiredCacheEntry(key, now);
+  if (cached) {
+    return {
+      cacheStatus: "HIT",
+      data: cached.value as T,
+    };
+  }
+
+  const existingTask = inFlightStore.get(key) as Promise<T | null> | undefined;
+  if (existingTask) {
+    const data = await existingTask;
+    return {
+      cacheStatus: "HIT",
+      data,
+    };
+  }
+
+  const task = loader()
+    .then(data => {
+      if (data) {
+        return getListingsCacheAdapter().set(key, {
+          value: data,
+          expiresAt: Date.now() + LISTINGS_ROUTE_CACHE_TTL_MS,
+        }).then(() => data);
+      }
+      return data;
+    })
+    .finally(() => {
+      inFlightStore.delete(key);
+    });
+
+  inFlightStore.set(key, task);
+
+  return {
+    cacheStatus: "MISS",
+    data: await task,
+  };
+}
+
+export async function invalidateListingsRouteCacheByPrefix(prefix: string) {
+  await getListingsCacheAdapter().deleteByPrefix(prefix);
+  for (const key of inFlightStore.keys()) {
+    if (key.startsWith(prefix)) {
+      inFlightStore.delete(key);
+    }
+  }
+}
+
+export async function invalidateAllListingsRouteCaches() {
+  await invalidateListingsRouteCacheByPrefix(`${LISTINGS_BFF_CACHE_VERSION}:listing-search:`);
+  await invalidateListingsRouteCacheByPrefix(`${LISTINGS_BFF_CACHE_VERSION}:listing-notice:`);
+}

--- a/src/features/listings/server/callServer/getSearchPageOnServer.ts
+++ b/src/features/listings/server/callServer/getSearchPageOnServer.ts
@@ -2,36 +2,31 @@ import { cookies } from "next/headers";
 import { LISTING_SEARCH_ENDPOINT, POPULAR_SEARCH_ENDPOINT } from "@/src/shared/api";
 import { IResponse } from "@/src/shared/types";
 import { ListingListPage, PopularKeywordItem } from "@/src/entities/listings/model/type";
+import {
+  createListingSearchParams,
+  normalizeListingSearchCriteria,
+  type ListingSearchCriteria,
+} from "@/src/features/listings/model";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
 
-type GetSearchPageOnServerProps = {
-  q: string;
-  page?: number;
-  offSet?: number;
-  sortType: string;
-  status: string;
+type GetSearchPageOnServerProps = Partial<ListingSearchCriteria> & {
+  q?: string;
 };
 
 export async function getSearchPageOnServer({
   q,
-  page = 1,
-  offSet = 10,
-  sortType,
-  status,
+  ...criteriaInput
 }: GetSearchPageOnServerProps) {
-  const keyword = q.trim();
-  if (!keyword || !API_BASE_URL) return null;
+  const criteria = normalizeListingSearchCriteria({
+    q,
+    ...criteriaInput,
+  });
+  if (!criteria.keyword || !API_BASE_URL) return null;
 
   const cookieStore = await cookies();
   const accessToken = cookieStore.get("access_token")?.value;
-  const query = new URLSearchParams({
-    q: keyword,
-    page: String(page),
-    offSet: String(offSet),
-    sortType,
-    status,
-  });
+  const query = createListingSearchParams(criteria);
 
   const res = await fetch(`${API_BASE_URL}${LISTING_SEARCH_ENDPOINT}?${query.toString()}`, {
     method: "GET",

--- a/src/features/listings/ui/listingsButton/listingsTagButton.tsx
+++ b/src/features/listings/ui/listingsButton/listingsTagButton.tsx
@@ -2,7 +2,7 @@
 import { DownButton } from "@/src/assets/icons/button";
 import { TagButton } from "@/src/shared/ui/button/tagButton";
 import { useFilterSheetStore } from "../../model";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 
 type BaseLabel = {
   key: string;
@@ -20,9 +20,12 @@ export const ListingTagButton = ({
 }) => {
   const openSheet = useFilterSheetStore(state => state.openSheet);
   const router = useRouter();
+  const searchParams = useSearchParams();
 
   const handleClick = async () => {
-    await router.push(`/listings?${param}=${label.key}`, { scroll: false });
+    const params = new URLSearchParams(searchParams.toString());
+    params.set(param, label.key);
+    await router.push(`/listings?${params.toString()}`, { scroll: false });
 
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {

--- a/src/features/listings/ui/listingsFilter/hooks.ts
+++ b/src/features/listings/ui/listingsFilter/hooks.ts
@@ -1,21 +1,20 @@
 import { useFilterSheetStore, useListingsFilterStore } from "@/src/features/listings/model";
+import { ListingsFilterState } from "@/src/entities/listings/model/type";
 import { useRouter, useSearchParams } from "next/navigation";
 
 export const ListingHooks = () => {
   const openSheet = useFilterSheetStore(state => state.openSheet);
+  const syncDraftFromApplied = useListingsFilterStore((state: ListingsFilterState) => state.syncDraftFromApplied);
   const router = useRouter();
   const searchParams = useSearchParams();
-  const params = new URLSearchParams(searchParams.toString());
   const onOpenSheet = () => {
+    syncDraftFromApplied();
     openSheet();
-    router.push(`listings?${params}`);
+    const params = new URLSearchParams(searchParams.toString());
+    router.push(`/listings?${params.toString()}`, { scroll: false });
   };
 
-  const hasSelectedFilters = useListingsFilterStore(state =>
-    [state.regionType, state.rentalTypes, state.supplyTypes, state.houseTypes].some(
-      list => list.length > 0
-    )
-  );
+  const hasSelectedFilters = useListingsFilterStore((state: ListingsFilterState) => state.hasAppliedFilters());
 
   return {
     openSheet,

--- a/src/features/listings/ui/listingsFilter/listingsFilterPanel.tsx
+++ b/src/features/listings/ui/listingsFilter/listingsFilterPanel.tsx
@@ -4,6 +4,7 @@ import { FILTER_OPTIONS, filterMap, getAllFilterIcon } from "../../model";
 import { useListingsFilterStore } from "../../model/store/listingsStore";
 import { ListingTagButton } from "../listingsButton/listingsTagButton";
 import { ListingHooks } from "@/src/features/listings/ui/listingsFilter/hooks";
+import type { ListingsFilterState } from "@/src/entities/listings/model/type";
 
 export const ListingFilterPanel = () => {
   const { onOpenSheet, hasSelectedFilters } = ListingHooks();
@@ -18,7 +19,9 @@ export const ListingFilterPanel = () => {
         <div className="no-scrollbar flex flex-1 overflow-x-auto">
           <div className="flex min-w-max items-center gap-2">
             {FILTER_OPTIONS.map(item => {
-              const selectedValues = useListingsFilterStore(state => filterMap[item.key](state));
+              const selectedValues = useListingsFilterStore((state: ListingsFilterState) =>
+                filterMap[item.key](state)
+              );
               const count = selectedValues.length;
               return (
                 <div key={item.key} className="flex-shrink-0">

--- a/src/features/listings/ui/listingsFullSheet/components/listingSheet.tsx
+++ b/src/features/listings/ui/listingsFullSheet/components/listingSheet.tsx
@@ -1,6 +1,7 @@
 import { useSearchParams } from "next/navigation";
 import { FilterTabKey, TAB_CONFIG } from "../../../model";
 import { useListingsFilterStore } from "../../../model/store/listingsStore";
+import { ListingsFilterState } from "@/src/entities/listings/model/type";
 import { Tag } from "./tag";
 
 export const ListingSheet = () => {
@@ -8,25 +9,22 @@ export const ListingSheet = () => {
   const currentTab = (searchParams.get("tab") as FilterTabKey) || "region";
   const tabConfig = currentTab ? TAB_CONFIG[currentTab] : null;
 
-  const regionType = useListingsFilterStore(s => s.regionType);
-  const rentalTypes = useListingsFilterStore(s => s.rentalTypes);
-  const supplyTypes = useListingsFilterStore(s => s.supplyTypes);
-  const houseTypes = useListingsFilterStore(s => s.houseTypes);
+  const draft = useListingsFilterStore((state: ListingsFilterState) => state.draft);
 
-  const toggleRegion = useListingsFilterStore(s => s.toggleRegionType);
-  const toggleRental = useListingsFilterStore(s => s.toggleRentalType);
-  const toggleSupply = useListingsFilterStore(s => s.toggleSupplyType);
-  const toggleHouse = useListingsFilterStore(s => s.toggleHouseType);
+  const toggleRegion = useListingsFilterStore((state: ListingsFilterState) => state.toggleDraftRegionType);
+  const toggleRental = useListingsFilterStore((state: ListingsFilterState) => state.toggleDraftRentalType);
+  const toggleSupply = useListingsFilterStore((state: ListingsFilterState) => state.toggleDraftSupplyType);
+  const toggleHouse = useListingsFilterStore((state: ListingsFilterState) => state.toggleDraftHouseType);
   if (!tabConfig) {
     return null;
   }
   const { sections, labels } = TAB_CONFIG[currentTab];
 
   const isSelected = (name: string) => {
-    if (currentTab === "region") return regionType.includes(name);
-    if (currentTab === "target") return rentalTypes.includes(name);
-    if (currentTab === "rental") return supplyTypes.includes(name);
-    if (currentTab === "housing") return houseTypes.includes(name);
+    if (currentTab === "region") return draft.regionType.includes(name);
+    if (currentTab === "target") return draft.rentalTypes.includes(name);
+    if (currentTab === "rental") return draft.supplyTypes.includes(name);
+    if (currentTab === "housing") return draft.houseTypes.includes(name);
     return false;
   };
 

--- a/src/features/listings/ui/listingsFullSheet/components/useCheckBox.tsx
+++ b/src/features/listings/ui/listingsFullSheet/components/useCheckBox.tsx
@@ -1,25 +1,23 @@
 import { useSearchParams } from "next/navigation";
 import { FilterTabKey, TAB_CONFIG } from "../../../model";
 import { useListingsFilterStore } from "../../../model/store/listingsStore";
+import { ListingsFilterState } from "@/src/entities/listings/model/type";
 import { Checkbox } from "@/src/shared/lib/headlessUi/checkBox/checkbox";
 
 export const UseCheckBox = () => {
   const searchParams = useSearchParams();
   const currentTab = (searchParams.get("tab") as FilterTabKey) || "region";
   const tabConfig = currentTab ? TAB_CONFIG[currentTab] : null;
-  const regionType = useListingsFilterStore(s => s.regionType);
-  const rentalTypes = useListingsFilterStore(s => s.rentalTypes);
-  const supplyTypes = useListingsFilterStore(s => s.supplyTypes);
-  const houseTypes = useListingsFilterStore(s => s.houseTypes);
+  const draft = useListingsFilterStore((state: ListingsFilterState) => state.draft);
 
-  const toggleRegionType = useListingsFilterStore(s => s.toggleRegionType);
-  const toggleRentalType = useListingsFilterStore(s => s.toggleRentalType);
-  const toggleSupplyType = useListingsFilterStore(s => s.toggleSupplyType);
-  const toggleHouseType = useListingsFilterStore(s => s.toggleHouseType);
-  const resetRegionType = useListingsFilterStore(s => s.resetRegionType);
-  const resetRentalTypes = useListingsFilterStore(s => s.resetRentalTypes);
-  const resetSupplyTypes = useListingsFilterStore(s => s.resetSupplyTypes);
-  const resetHouseTypes = useListingsFilterStore(s => s.resetHouseTypes);
+  const toggleRegionType = useListingsFilterStore((state: ListingsFilterState) => state.toggleDraftRegionType);
+  const toggleRentalType = useListingsFilterStore((state: ListingsFilterState) => state.toggleDraftRentalType);
+  const toggleSupplyType = useListingsFilterStore((state: ListingsFilterState) => state.toggleDraftSupplyType);
+  const toggleHouseType = useListingsFilterStore((state: ListingsFilterState) => state.toggleDraftHouseType);
+  const resetRegionType = useListingsFilterStore((state: ListingsFilterState) => state.resetDraftRegionType);
+  const resetRentalTypes = useListingsFilterStore((state: ListingsFilterState) => state.resetDraftRentalTypes);
+  const resetSupplyTypes = useListingsFilterStore((state: ListingsFilterState) => state.resetDraftSupplyTypes);
+  const resetHouseTypes = useListingsFilterStore((state: ListingsFilterState) => state.resetDraftHouseTypes);
 
   if (!tabConfig) {
     return null;
@@ -30,10 +28,10 @@ export const UseCheckBox = () => {
     .map(i => i.name);
   // 현재 탭에 따라 현재 선택된 값 가져오기
   const selectedList = {
-    region: regionType,
-    target: rentalTypes,
-    rental: supplyTypes,
-    housing: houseTypes,
+    region: draft.regionType,
+    target: draft.rentalTypes,
+    rental: draft.supplyTypes,
+    housing: draft.houseTypes,
   }[currentTab];
   const isAllSelected = selectedList.length === totalItems.length;
   const handleAllSelect = (e: boolean) => {

--- a/src/features/listings/ui/listingsFullSheet/hooks/hooks.ts
+++ b/src/features/listings/ui/listingsFullSheet/hooks/hooks.ts
@@ -1,4 +1,10 @@
-import { useFilterSheetStore, useHasRouter } from "@/src/features/listings/model";
+import {
+  createListingsFilterSearchParams,
+  useFilterSheetStore,
+  useHasRouter,
+  useListingsFilterStore,
+} from "@/src/features/listings/model";
+import { ListingsFilterState } from "@/src/entities/listings/model/type";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useListingListInfiniteQuery } from "@/src/entities/listings/hooks/useListingHooks";
@@ -53,6 +59,9 @@ const useListingsTabSync = (open: boolean, handleScroll: () => void) => {
 export const ListingFilterPartialSheetHooks = () => {
   const open = useFilterSheetStore(s => s.open);
   const closeSheet = useFilterSheetStore(s => s.closeSheet);
+  const syncDraftFromApplied = useListingsFilterStore((state: ListingsFilterState) => state.syncDraftFromApplied);
+  const applyDraft = useListingsFilterStore((state: ListingsFilterState) => state.applyDraft);
+  const draft = useListingsFilterStore((state: ListingsFilterState) => state.draft);
   const router = useRouter();
   const searchParams = useSearchParams();
   const displayTotal = useListingTotal();
@@ -71,13 +80,30 @@ export const ListingFilterPartialSheetHooks = () => {
     }
   };
 
+  const replaceListingsQueryFromDraft = () => {
+    const params = createListingsFilterSearchParams(draft, new URLSearchParams(searchParams.toString()));
+    const query = params.toString();
+    router.replace(query ? `/listings?${query}` : "/listings", { scroll: false });
+  };
+
   const handleCloseSheet = () => {
     try {
       // UI를 먼저 닫고, 이어서 URL을 정리하는 흐름으로 고정한다.
       closeSheet();
+      syncDraftFromApplied();
       resetListingsQuery();
     } catch (error) {
       console.error("[ListingFilterPartialSheet] Failed to close sheet", error);
+    }
+  };
+
+  const handleApplySheet = () => {
+    try {
+      applyDraft();
+      closeSheet();
+      replaceListingsQueryFromDraft();
+    } catch (error) {
+      console.error("[ListingFilterPartialSheet] Failed to apply sheet", error);
     }
   };
 
@@ -88,5 +114,6 @@ export const ListingFilterPartialSheetHooks = () => {
     displayTotal,
     handleScroll,
     handleCloseSheet,
+    handleApplySheet,
   };
 };

--- a/src/features/listings/ui/listingsFullSheet/listingsFullSheet.tsx
+++ b/src/features/listings/ui/listingsFullSheet/listingsFullSheet.tsx
@@ -9,7 +9,7 @@ import { UseCheckBox } from "./components/useCheckBox";
 import { ListingSheet } from "./components/listingSheet";
 
 export const ListingFilterPartialSheet = () => {
-  const { open, scrollRef, isAtBottom, displayTotal, handleScroll, handleCloseSheet } =
+  const { open, scrollRef, isAtBottom, displayTotal, handleScroll, handleCloseSheet, handleApplySheet } =
     ListingFilterPartialSheetHooks();
 
   return (
@@ -23,7 +23,7 @@ export const ListingFilterPartialSheet = () => {
               <ListingSheet />
             </div>
           </FilterSheetContent>
-          <FilterSheetFooter total={displayTotal} onApply={handleCloseSheet} />
+          <FilterSheetFooter total={displayTotal} onApply={handleApplySheet} />
         </FilterSheetContainer>
       )}
     </AnimatePresence>

--- a/src/shared/config/queryKeys.ts
+++ b/src/shared/config/queryKeys.ts
@@ -3,6 +3,11 @@
  * 모든 queryKey는 여기서 정의하고 export합니다.
  */
 
+import {
+  ListingSearchCriteria,
+  normalizeListingSearchCriteria,
+} from "@/src/features/listings/model/searchCriteria";
+
 // QuickSearch 관련 QueryKeys
 export const quickSearchKeys = {
   all: ["quickSearch"] as const,
@@ -32,6 +37,13 @@ export const listingKeys = {
     [...listingKeys.lists(), filters] as const,
   infinite: (filters?: { sortType?: string; status?: string }) =>
     [...listingKeys.all, "infinite", filters] as const,
+} as const;
+
+export const listingSearchKeys = {
+  all: ["listingSearch"] as const,
+  infiniteLists: () => [...listingSearchKeys.all, "infinite"] as const,
+  infinite: (criteria: ListingSearchCriteria) =>
+    [...listingSearchKeys.infiniteLists(), normalizeListingSearchCriteria(criteria)] as const,
 } as const;
 
 // Eligibility(자격진단) 관련 QueryKeys
@@ -70,12 +82,7 @@ export const listingListInfiniteQueryKey = ({
 }) => ["listingListInfinite", filter, status] as const;
 
 //공고 조회 무한스크롤 QueryKeys
-export const listingSearchInfiniteQueryKey = ({
-  keyword,
-  sortType,
-  status,
-}: {
-  keyword: string;
-  sortType: string;
-  status: string;
-}) => ["listingSearchInfinite", keyword, sortType, status] as const;
+export const listingSearchInfiniteQueryKey = (criteria: ListingSearchCriteria) =>
+  listingSearchKeys.infinite(
+    normalizeListingSearchCriteria(criteria)
+  );

--- a/src/widgets/listingsSection/listingsSectionPage.tsx
+++ b/src/widgets/listingsSection/listingsSectionPage.tsx
@@ -1,16 +1,30 @@
 import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
 import { ListingsSection } from "./ui/listingsSection";
+import { ListingsFilterStoreBootstrap } from "./ui/listingsFilterStoreBootstrap";
 import { prefetchNoticeQueries } from "@/src/widgets/listingsSection/server/notice/prefetchNoticeQueries";
 import { getNoticeInitialData } from "@/src/widgets/listingsSection/server/notice/getNoticeInitialData";
+import { ListingsFilterCriteria } from "@/src/features/listings/model";
 
-export async function ListingsSectionPage() {
+type ListingsSectionPageProps = {
+  initialFilter: ListingsFilterCriteria;
+  initialStatus: string;
+};
+
+export async function ListingsSectionPage({
+  initialFilter,
+  initialStatus,
+}: ListingsSectionPageProps) {
   const queryClient = new QueryClient();
-  const { initial } = await getNoticeInitialData();
-  await prefetchNoticeQueries({ queryClient, initial });
+  const { initial } = await getNoticeInitialData({
+    filter: initialFilter,
+    status: initialStatus,
+  });
+  await prefetchNoticeQueries({ queryClient, initial, filter: initialFilter, status: initialStatus });
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
       <main className="flex h-full flex-col">
+        <ListingsFilterStoreBootstrap initialFilter={initialFilter} initialStatus={initialStatus} />
         <ListingsSection />
       </main>
     </HydrationBoundary>

--- a/src/widgets/listingsSection/model/useSyncSortTypeFromQuery.ts
+++ b/src/widgets/listingsSection/model/useSyncSortTypeFromQuery.ts
@@ -2,6 +2,7 @@
 import { useSearchParams } from "next/navigation";
 import { useEffect } from "react";
 import { useListingsFilterStore } from "@/src/features/listings/model";
+import { ListingsFilterState } from "@/src/entities/listings/model/type";
 import {
   DEADLINE_QUERY_VALUE,
   DEADLINE_SORT_TYPE,
@@ -9,8 +10,8 @@ import {
 
 export function useSyncSortTypeFromQuery() {
   const searchParams = useSearchParams();
-  const sortType = useListingsFilterStore(state => state.sortType);
-  const setSortType = useListingsFilterStore(state => state.setSortType);
+  const sortType = useListingsFilterStore((state: ListingsFilterState) => state.applied.sortType);
+  const setSortType = useListingsFilterStore((state: ListingsFilterState) => state.setSortType);
 
   useEffect(() => {
     const requestedSortType = searchParams.get("sortType");

--- a/src/widgets/listingsSection/server/notice/getNoticeInitialData.ts
+++ b/src/widgets/listingsSection/server/notice/getNoticeInitialData.ts
@@ -1,18 +1,20 @@
-import { useListingState, useListingsFilterStore } from "@/src/features/listings/model";
+import { ListingsFilterCriteria } from "@/src/features/listings/model";
 import { fetchNoticeInitialFromBff } from "@/src/features/listings/server";
 
-export async function getNoticeInitialData() {
-  const { status } = useListingState.getState();
-  const { regionType, rentalTypes, supplyTypes, houseTypes, sortType } =
-    useListingsFilterStore.getState();
+type GetNoticeInitialDataArgs = {
+  filter: ListingsFilterCriteria;
+  status: string;
+};
+
+export async function getNoticeInitialData({ filter, status }: GetNoticeInitialDataArgs) {
   const [initial] = await Promise.all([
     fetchNoticeInitialFromBff({
-      regionType,
-      rentalTypes,
-      supplyTypes,
-      houseTypes,
+      regionType: filter.regionType,
+      rentalTypes: filter.rentalTypes,
+      supplyTypes: filter.supplyTypes,
+      houseTypes: filter.houseTypes,
       status,
-      sortType,
+      sortType: filter.sortType,
     }),
   ]);
   return { initial };

--- a/src/widgets/listingsSection/server/notice/prefetchNoticeQueries.ts
+++ b/src/widgets/listingsSection/server/notice/prefetchNoticeQueries.ts
@@ -1,6 +1,6 @@
 import type { QueryClient } from "@tanstack/react-query";
 import type { ListingListPage } from "@/src/entities/listings/model/type";
-import { useListingsFilterStore, useListingState } from "@/src/features/listings/model";
+import { ListingsFilterCriteria } from "@/src/features/listings/model";
 import { ListingsNoticeBffResponse } from "@/src/features/listings/server/bff/getNoticeInitialFromBff";
 import { listingListInfiniteQueryKey } from "@/src/shared/config";
 
@@ -8,16 +8,17 @@ type NoticeInitialData = ListingsNoticeBffResponse["data"];
 type PrefetchNoticeArgs = {
   queryClient: QueryClient;
   initial: NoticeInitialData | null;
+  filter: ListingsFilterCriteria;
+  status: string;
 };
 
-export async function prefetchNoticeQueries({ queryClient, initial }: PrefetchNoticeArgs) {
+export async function prefetchNoticeQueries({
+  queryClient,
+  initial,
+  filter,
+  status,
+}: PrefetchNoticeArgs) {
   if (!initial) return;
-
-  const { regionType, rentalTypes, supplyTypes, houseTypes, sortType } =
-    useListingsFilterStore.getState();
-  const { status } = useListingState.getState();
-
-  const filter = { regionType, rentalTypes, supplyTypes, houseTypes, sortType };
 
   await queryClient.prefetchInfiniteQuery({
     queryKey: listingListInfiniteQueryKey({ filter, status }),

--- a/src/widgets/listingsSection/server/search/getNoticeInitialType.ts
+++ b/src/widgets/listingsSection/server/search/getNoticeInitialType.ts
@@ -3,25 +3,24 @@ import {
   getPopularSearchFromBff,
   getSearchNoticeInitialFromBff,
 } from "@/src/features/listings/server";
-
-export const DEFAULT_SEARCH_SORT = "LATEST" as const;
-export const DEFAULT_SEARCH_STATUS = "ALL" as const;
+import {
+  DEFAULT_LISTING_SEARCH_OFFSET,
+  DEFAULT_LISTING_SEARCH_PAGE,
+  DEFAULT_LISTING_SEARCH_SORT_TYPE,
+  DEFAULT_LISTING_SEARCH_STATUS,
+  ListingSearchCriteria,
+  normalizeListingSearchCriteria,
+} from "@/src/features/listings/model";
+import { listingSearchInfiniteQueryKey } from "@/src/shared/config";
 
 export type SearchInitialParams = {
   query?: string;
 };
 
-export type ListingSearchInfiniteKey = readonly [
-  "listingSearchInfinite",
-  string, // keyword
-  typeof DEFAULT_SEARCH_SORT,
-  typeof DEFAULT_SEARCH_STATUS,
-];
+export type ListingSearchInfiniteKey = ReturnType<typeof listingSearchInfiniteQueryKey>;
 
 export type NoticeSearchInitialData = {
-  keyword: string;
-  sortType: typeof DEFAULT_SEARCH_SORT;
-  status: typeof DEFAULT_SEARCH_STATUS;
+  criteria: ListingSearchCriteria;
   queryKey: ListingSearchInfiniteKey;
   popular: PopularKeywordItem[] | null;
   initialPage: ListingListPage | null;
@@ -30,22 +29,24 @@ export type NoticeSearchInitialData = {
 export async function getNoticeSearchInitialData({
   query = "",
 }: SearchInitialParams): Promise<NoticeSearchInitialData> {
-  const keyword = query.trim();
-  const sortType = DEFAULT_SEARCH_SORT;
-  const status = DEFAULT_SEARCH_STATUS;
+  const criteria = normalizeListingSearchCriteria({
+    query,
+    sortType: DEFAULT_LISTING_SEARCH_SORT_TYPE,
+    status: DEFAULT_LISTING_SEARCH_STATUS,
+    page: DEFAULT_LISTING_SEARCH_PAGE,
+    offSet: DEFAULT_LISTING_SEARCH_OFFSET,
+  });
 
   const [popular, initialPage] = await Promise.all([
     getPopularSearchFromBff(5),
-    keyword
-      ? getSearchNoticeInitialFromBff({ q: keyword, sortType, status })
+    criteria.keyword
+      ? getSearchNoticeInitialFromBff(criteria)
       : Promise.resolve(null),
   ]);
 
   return {
-    keyword,
-    sortType,
-    status,
-    queryKey: ["listingSearchInfinite", keyword, sortType, status] as const,
+    criteria,
+    queryKey: listingSearchInfiniteQueryKey(criteria),
     popular,
     initialPage,
   };

--- a/src/widgets/listingsSection/ui/listingsFilterStoreBootstrap.tsx
+++ b/src/widgets/listingsSection/ui/listingsFilterStoreBootstrap.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect } from "react";
+import { ListingsFilterCriteria, useListingState, useListingsFilterStore } from "@/src/features/listings/model";
+import { ListingsFilterState } from "@/src/entities/listings/model/type";
+
+type ListingsFilterStoreBootstrapProps = {
+  initialFilter: ListingsFilterCriteria;
+  initialStatus: string;
+};
+
+export function ListingsFilterStoreBootstrap({
+  initialFilter,
+  initialStatus,
+}: ListingsFilterStoreBootstrapProps) {
+  const setListingStatus = useListingState(state => state.setStatus);
+  const listingStatus = useListingState(state => state.status);
+
+  useEffect(() => {
+    useListingsFilterStore.setState((state: ListingsFilterState) => ({
+      ...state,
+      draft: initialFilter,
+      applied: initialFilter,
+    }));
+
+    if (listingStatus !== initialStatus) {
+      setListingStatus(initialStatus);
+    }
+  }, [initialFilter, initialStatus, listingStatus, setListingStatus]);
+
+  return null;
+}


### PR DESCRIPTION
<!--- Pull Request title = 커밋 메시지와 동일/ 해당 이슈를 close 하지 않을 경우, footer #이슈 번호 제외  -->

## #️⃣ Issue Number

#541 

<br/>
<br/>

## 📝 요약(Summary) (선택)

검색/필터/정렬 조건의 의미 계약을 URL, Zustand, Query Key, BFF 요청 파라미터 전 구간에서 일관되게 정렬
UI 편집 상태와 실제 조회 상태를 분리해 불필요한 재조회와 상태 오염 가능성 축소
SSR이 클라이언트 전역 스토어에 의존하지 않도록 서버 프리패치 경계 재정의
BFF 레이어에서 요청 정규화, 인증 스코프 분리, 캐시 키 표준화, TTL 기반 응답 캐시 적용
좋아요 mutation 이후 클라이언트 캐시 무효화와 서버 캐시 무효화를 함께 수행하도록 정리
캐시 구현을 저장소 인터페이스 뒤로 숨겨 운영 환경에 따라 인메모리 또는 Redis 계열로 전환 가능한 구조 마련

<br/>
<br/>

